### PR TITLE
Freight Fate 1.2.0: BASS audio backend, truck upgrades, and a freight market

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 1.2.0 — 2026-06-09
+
+### Added
+- **BASS audio backend** via [sound_lib](https://pypi.org/project/sound_lib/)
+  (pinned `==0.8.8`; PyPI's version ordering for this package is broken and an
+  unpinned install resolves to a stale 2022 build). The truck engine is now a
+  single loop whose playback frequency tracks RPM in real time, smoothed with
+  BASS attribute slides — no more four-band crossfade seams. pygame.mixer
+  remains as an automatic fallback when sound_lib/BASS cannot initialize
+  (`FREIGHT_FATE_AUDIO_BACKEND=pygame` forces it), and headless environments
+  use BASS's "no sound" device so CI runs the full audio pipeline silently.
+- **Garage upgrades** (Garage → Upgrades), money-gated and saved on the
+  profile: engine tune (+10% torque per tier, two tiers), aerodynamic kit
+  (−12% drag), long-range tank (+50 gallons), and reinforced brakes (fade
+  onset pushed 150 degrees hotter). Upgrades feed straight into the driving
+  physics.
+- **A second truck**: the heavy hauler (Garage → Trucks) — a quarter more
+  torque and a 200-gallon tank, but blunter aerodynamics and a thirstier
+  engine. Buy it once, then switch between owned trucks at any garage.
+- **Freight market**: every cargo class carries a pay multiplier (0.8–1.3)
+  that drifts each in-game day on a seeded random walk persisted in the
+  profile. Job descriptions call out hot, strong, soft, and cold markets,
+  and the job board opens with a spoken market watch headline.
+
+### Changed
+- Truck status and garage refueling respect the active truck's actual tank
+  size instead of assuming 150 gallons.
+- Save format version is now 2 (older saves load fine; new fields get
+  defaults).
+
+### Notes
+- BASS is proprietary software, free for non-commercial use. If Freight Fate
+  is ever sold commercially, a paid license from
+  [un4seen developments](https://www.un4seen.com/bass.html#license) is
+  required. See the README's license section.
+
 ## 1.1.0 — 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ visual display mirrors all speech for sighted players and helpers.
 - **Real driving** — a tuned Class 8 truck simulation: 450 horsepower,
   ten gears (manual with clutch, or automatic), engine braking, grades,
   stalls, brake fade, and honest fuel economy.
+- **Trucks and upgrades** — earn your way into a heavy hauler with more
+  torque and a bigger tank (and worse aerodynamics), and outfit any truck
+  with an engine tune, aerodynamic kit, long-range tank, or reinforced
+  brakes. Every purchase changes the physics.
+- **A living market** — each cargo class has a pay rate that drifts day by
+  day. The job board tells you when electronics are hot or bulk freight has
+  gone cold; chase the strong markets.
 - **A living road** — dynamic regional weather that changes grip and safe
   speeds, construction and traffic zones, road hazards that demand quick
   braking, rest stops for refueling, and roadside rescue when you run dry.
@@ -29,7 +36,10 @@ visual display mirrors all speech for sighted players and helpers.
 - **Route planning** — multiple route options per job with distance, highways,
   terrain, and weather forecasts.
 - **Original audio** — every sound effect and all three music tracks are
-  procedurally synthesized and dedicated to the public domain (CC0).
+  procedurally synthesized and dedicated to the public domain (CC0). Audio
+  plays through BASS (via [sound_lib](https://pypi.org/project/sound_lib/)),
+  with the engine note pitch-tracking RPM in real time; pygame.mixer takes
+  over automatically if BASS cannot initialize.
 - **Screen reader native** — menus with first-letter navigation, contextual
   F1 help everywhere, on-demand information keys while driving, and three
   speech verbosity levels.
@@ -99,3 +109,11 @@ randomness — see [CREDITS.md](src/freight_fate/assets/sounds/CREDITS.md).
 
 Code is [MIT](LICENSE). All bundled audio is
 [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+**BASS license caveat:** audio playback uses the
+[BASS](https://www.un4seen.com/) library (through the `sound_lib` Python
+package), which is proprietary and **free for non-commercial use only**. If
+Freight Fate is ever sold commercially (Steam, itch.io paid downloads, and
+so on), a paid license must be purchased from
+[un4seen developments](https://www.un4seen.com/bass.html#license) first.
+The game falls back to pygame.mixer automatically when BASS is unavailable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,14 @@
 # Freight Fate Roadmap
 
+## Shipped in 1.2.0
+
+- [x] Truck upgrades (engine tune, aerodynamic kit, long-range tank,
+      reinforced brakes) and a second purchasable truck (heavy hauler)
+- [x] Market fluctuations in cargo rates: per-class multipliers drifting
+      daily on a seeded random walk, spoken on the job board
+- [x] BASS audio backend (sound_lib) with real-time RPM-tracking engine
+      pitch; pygame.mixer kept as an automatic fallback
+
 ## Shipped in 1.1.0
 
 - [x] Optional real-world weather per city via the Open-Meteo API
@@ -58,7 +67,6 @@ Deliver -> Earn and level up -> Repeat
 
 ### Gameplay depth
 - [ ] Cargo loading/securing minigame
-- [ ] Truck upgrades (engine, tank, aerodynamics) and new trucks
 - [ ] Hours-of-service fatigue and mandatory rest planning
 - [ ] Special event jobs (oversize loads, urgent medical freight)
 - [ ] Trailer types with handling differences
@@ -71,7 +79,6 @@ Deliver -> Earn and level up -> Repeat
 ### Business
 - [ ] Company ownership: hire AI drivers, buy trucks
 - [ ] Loans and insurance
-- [ ] Market fluctuations in cargo rates
 
 ### Platforms and community
 - [ ] Binary releases (PyInstaller) per platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freight-fate"
-version = "1.1.0"
+version = "1.2.0"
 description = "An accessible, audio-first cross-country trucking simulation game"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -21,6 +21,10 @@ dependencies = [
     "pygame>=2.6",
     "prismatoid>=0.16",
     "numpy>=1.26",
+    # Pinned exactly: PyPI's version ordering for this package is broken
+    # (0.83 from 2022 sorts above 0.8.8 from 2026), so any range resolves
+    # to the stale build that ships no Linux library.
+    "sound-lib==0.8.8",
 ]
 
 [project.scripts]

--- a/src/freight_fate/__init__.py
+++ b/src/freight_fate/__init__.py
@@ -1,3 +1,3 @@
 """Freight Fate: an accessible, audio-first trucking simulation."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/src/freight_fate/audio.py
+++ b/src/freight_fate/audio.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import sys
 from pathlib import Path
 
 import pygame
@@ -285,8 +286,15 @@ class _BassBackend:
 
     def _stream(self, path: Path, looping: bool):
         """A fresh stream for one playback; autofreed once it stops."""
+        kwargs: dict = {"file": str(path), "autofree": True}
+        if sys.platform.startswith("linux"):
+            # BASS_UNICODE (UTF-16 paths) is Windows-only; sound_lib handles
+            # macOS itself but passes the flag on Linux, where BASS then
+            # rejects the file. Hand over a filesystem-encoded path instead.
+            kwargs["file"] = str(path).encode(sys.getfilesystemencoding())
+            kwargs["unicode"] = False
         try:
-            stream = self._FileStream(file=str(path), autofree=True)
+            stream = self._FileStream(**kwargs)
         except self._BassError:
             log.warning("Could not open stream: %s", path, exc_info=True)
             return None

--- a/src/freight_fate/audio.py
+++ b/src/freight_fate/audio.py
@@ -1,8 +1,18 @@
-"""Runtime audio engine: sound effects, loops, engine crossfade, and music.
+"""Runtime audio engine: sound effects, loops, engine audio, and music.
 
-Built on ``pygame.mixer``. The engine degrades gracefully: if the mixer
-cannot initialize (no audio device, CI) every method becomes a no-op, so
-game logic never needs to check for audio availability.
+Two interchangeable backends sit behind the :class:`AudioEngine` facade:
+
+* **BASS** (via ``sound_lib``) — the preferred backend. The truck engine is a
+  single loop whose playback frequency tracks RPM in real time, smoothed with
+  BASS attribute slides. With no audio device (headless CI) it initializes
+  BASS's "no sound" device, so the full code path still runs silently.
+* **pygame.mixer** — automatic fallback when sound_lib/BASS cannot
+  initialize. Uses the classic four-band engine loop crossfade.
+
+Set ``FREIGHT_FATE_AUDIO_BACKEND=pygame`` to skip BASS entirely.
+
+Both backends degrade gracefully: if nothing can initialize, every method
+becomes a no-op, so game logic never needs to check for audio availability.
 
 Sound keys are paths relative to the bundled sound library, without
 extension: ``play("ui/menu_select")`` plays
@@ -11,7 +21,9 @@ extension: ``play("ui/menu_select")`` plays
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
 from pathlib import Path
 
 import pygame
@@ -20,8 +32,9 @@ log = logging.getLogger(__name__)
 
 ASSETS = Path(__file__).parent / "assets" / "sounds"
 
-# Reserved mixer channels (everything above these is for one-shot effects).
-CH_ENGINE = (0, 1, 2, 3)  # idle, low, mid, high crossfade ring
+# Reserved loop slots. The pygame backend maps them onto mixer channels;
+# the BASS backend uses them as keys for its stream table.
+CH_ENGINE = (0, 1, 2, 3)  # idle, low, mid, high crossfade ring (pygame only)
 CH_ROAD = 4
 CH_WEATHER = 5
 CH_WEATHER_B = 6
@@ -29,12 +42,36 @@ CH_AMBIENT = 7
 RESERVED = 8
 NUM_CHANNELS = 32
 
-# RPM centers for the engine loop crossfade.
+# RPM centers for the pygame engine loop crossfade.
 ENGINE_BANDS = (("engine/idle", 620), ("engine/low", 1000),
                 ("engine/mid", 1500), ("engine/high", 2100))
 
+# BASS engine model: one idle loop, pitched up with RPM.
+ENGINE_LOOP_KEY = "engine/idle"
+ENGINE_RPM_IDLE = 600.0
+ENGINE_RPM_MAX = 2200.0
+ENGINE_FREQ_MAX_MULT = 2.2
+ENGINE_SLIDE_MS = 120
 
-class AudioEngine:
+BASS_NO_SOUND_DEVICE = 0
+
+
+def engine_freq_mult(rpm: float) -> float:
+    """Playback-frequency multiplier for the BASS engine loop at ``rpm``.
+
+    Linear from 1.0 at idle (600 RPM) to ~2.2x at redline (2200 RPM),
+    clamped at both ends.
+    """
+    t = (rpm - ENGINE_RPM_IDLE) / (ENGINE_RPM_MAX - ENGINE_RPM_IDLE)
+    return max(1.0, min(ENGINE_FREQ_MAX_MULT,
+                        1.0 + t * (ENGINE_FREQ_MAX_MULT - 1.0)))
+
+
+class _PygameBackend:
+    """The original pygame.mixer implementation (engine band crossfade)."""
+
+    name = "pygame"
+
     def __init__(self) -> None:
         self.enabled = False
         self.master_volume = 1.0
@@ -148,47 +185,9 @@ class AudioEngine:
     def engine_running(self) -> bool:
         return self._engine_running
 
-    # -- road / weather / ambience --------------------------------------------
-
-    def set_road_noise(self, speed_mps: float) -> None:
-        """Tire-on-asphalt loop whose volume tracks speed."""
-        if not self.enabled:
-            return
-        gain = min(0.9, speed_mps / 30.0)
-        if gain < 0.02:
-            self.stop_loop(CH_ROAD, fade_ms=500)
-        else:
-            self.start_loop(CH_ROAD, "vehicle/road", volume=gain, fade_ms=400)
-
-    def set_weather(self, key: str | None, intensity: float = 1.0) -> None:
-        """Play a weather ambience loop, e.g. ``weather/rain_light``."""
-        if key is None:
-            self.stop_loop(CH_WEATHER, fade_ms=1200)
-        else:
-            self.start_loop(CH_WEATHER, key, volume=min(1.0, intensity), fade_ms=1200)
-
-    def set_wind(self, intensity: float) -> None:
-        if intensity < 0.05:
-            self.stop_loop(CH_WEATHER_B, fade_ms=1500)
-        else:
-            self.start_loop(CH_WEATHER_B, "weather/wind", volume=min(0.8, intensity), fade_ms=1500)
-
-    def set_ambient(self, key: str | None, volume: float = 0.7) -> None:
-        if key is None:
-            self.stop_loop(CH_AMBIENT, fade_ms=800)
-        else:
-            self.start_loop(CH_AMBIENT, key, volume=volume, fade_ms=800)
-
-    def stop_world(self) -> None:
-        """Stop engine, road, weather, and ambience (leaving UI sfx alone)."""
-        self.engine_stop(shutdown_sound=False)
-        for ch in (CH_ROAD, CH_WEATHER, CH_WEATHER_B, CH_AMBIENT):
-            self.stop_loop(ch, fade_ms=400)
-
     # -- music ----------------------------------------------------------------
 
     def play_music(self, track: str, fade_ms: int = 1500) -> None:
-        """Stream a music track, e.g. ``play_music("menu_theme")``."""
         if not self.enabled or self._music_track == track:
             return
         path = ASSETS / "music" / (track + ".ogg")
@@ -232,3 +231,406 @@ class AudioEngine:
         if self.enabled:
             pygame.mixer.stop()
             pygame.mixer.music.stop()
+
+
+class _BassBackend:
+    """sound_lib (BASS) implementation: streams, slides, and a pitched engine.
+
+    Raises on construction if sound_lib cannot be imported or BASS cannot
+    initialize at all; the facade then falls back to pygame.mixer. With the
+    dummy SDL audio driver (tests, CI) or when no device exists, BASS's
+    "no sound" device keeps the whole pipeline running silently.
+    """
+
+    name = "bass"
+
+    def __init__(self) -> None:
+        from sound_lib.external.pybass import (
+            BASS_ATTRIB_FREQ,
+            BASS_ATTRIB_VOL,
+            BASS_ChannelSlideAttribute,
+        )
+        from sound_lib.main import BassError, bass_call
+        from sound_lib.output import Output
+        from sound_lib.stream import FileStream
+
+        self._FileStream = FileStream
+        self._BassError = BassError
+        self._bass_call = bass_call
+        self._slide = BASS_ChannelSlideAttribute
+        self._ATTRIB_FREQ = BASS_ATTRIB_FREQ
+        self._ATTRIB_VOL = BASS_ATTRIB_VOL
+
+        self.master_volume = 1.0
+        self.sfx_volume = 0.8
+        self.music_volume = 0.55
+        self._loops: dict[int, tuple[str, float, object]] = {}  # slot -> (key, gain, stream)
+        self._music_track: str | None = None
+        self._music_stream = None
+        self._engine_running = False
+        self._engine_stream = None
+        self._engine_base_freq = 0.0
+
+        if os.environ.get("SDL_AUDIODRIVER", "").lower() == "dummy":
+            self._output = Output(device=BASS_NO_SOUND_DEVICE)
+        else:
+            try:
+                self._output = Output()
+            except BassError:
+                log.warning("No audio device; using the BASS no-sound device")
+                self._output = Output(device=BASS_NO_SOUND_DEVICE)
+        self.enabled = True
+
+    # -- assets -------------------------------------------------------------
+
+    def _stream(self, path: Path, looping: bool):
+        """A fresh stream for one playback; autofreed once it stops."""
+        try:
+            stream = self._FileStream(file=str(path), autofree=True)
+        except self._BassError:
+            log.warning("Could not open stream: %s", path, exc_info=True)
+            return None
+        if looping:
+            stream.set_looping(True)
+        return stream
+
+    def _sfx_stream(self, key: str, looping: bool = False):
+        path = ASSETS / (key + ".wav")
+        if not path.exists():
+            log.warning("Missing sound: %s", path)
+            return None
+        return self._stream(path, looping)
+
+    def _fade_out(self, stream, fade_ms: int) -> None:
+        """Slide volume to -1: BASS stops (and autofrees) the channel at 0."""
+        try:
+            self._bass_call(self._slide, stream.handle, self._ATTRIB_VOL,
+                            -1.0, max(0, int(fade_ms)))
+        except self._BassError:
+            log.debug("Fade-out failed; stream already gone", exc_info=True)
+
+    # -- one-shots ----------------------------------------------------------
+
+    def play(self, key: str, volume: float = 1.0) -> None:
+        stream = self._sfx_stream(key)
+        if stream is None:
+            return
+        try:
+            stream.set_volume(max(0.0, min(1.0, volume * self.sfx_volume * self.master_volume)))
+            stream.play()
+        except self._BassError:
+            log.warning("Could not play %s", key, exc_info=True)
+
+    # -- loops on reserved slots ------------------------------------------------
+
+    def start_loop(self, channel: int, key: str, volume: float = 1.0, fade_ms: int = 300) -> None:
+        current = self._loops.get(channel)
+        if current and current[0] == key:
+            self.set_loop_volume(channel, volume)
+            return
+        if current:
+            self.stop_loop(channel, fade_ms=min(fade_ms, 300))
+        stream = self._sfx_stream(key, looping=True)
+        if stream is None:
+            return
+        self._loops[channel] = (key, volume, stream)
+        try:
+            stream.set_volume(0.0)
+            stream.play()
+        except self._BassError:
+            del self._loops[channel]
+            return
+        self._apply_loop_volume(channel, fade_ms)
+
+    def set_loop_volume(self, channel: int, volume: float) -> None:
+        if channel in self._loops:
+            key, _, stream = self._loops[channel]
+            self._loops[channel] = (key, volume, stream)
+            self._apply_loop_volume(channel)
+
+    def stop_loop(self, channel: int, fade_ms: int = 300) -> None:
+        entry = self._loops.pop(channel, None)
+        if entry is not None:
+            self._fade_out(entry[2], fade_ms)
+
+    def _apply_loop_volume(self, channel: int, fade_ms: int = 0) -> None:
+        if channel not in self._loops:
+            return
+        _, gain, stream = self._loops[channel]
+        vol = max(0.0, min(1.0, gain * self.sfx_volume * self.master_volume))
+        try:
+            if fade_ms > 0:
+                self._bass_call(self._slide, stream.handle, self._ATTRIB_VOL,
+                                vol, int(fade_ms))
+            else:
+                stream.set_volume(vol)
+        except self._BassError:
+            del self._loops[channel]
+
+    # -- truck engine: one loop, frequency tracks RPM ------------------------------
+
+    def engine_start(self) -> None:
+        if self._engine_running:
+            return
+        self._engine_running = True
+        self.play("engine/start")
+        stream = self._sfx_stream(ENGINE_LOOP_KEY, looping=True)
+        if stream is not None:
+            try:
+                self._engine_base_freq = stream.get_frequency()
+                stream.set_volume(0.0)
+                stream.play()
+            except self._BassError:
+                stream = None
+        self._engine_stream = stream
+        self.set_engine_rpm(ENGINE_RPM_IDLE, throttle=0.0)
+
+    def engine_stop(self, shutdown_sound: bool = True) -> None:
+        if not self._engine_running:
+            return
+        self._engine_running = False
+        if self._engine_stream is not None:
+            self._fade_out(self._engine_stream, 250)
+            self._engine_stream = None
+        if shutdown_sound:
+            self.play("engine/shutdown")
+
+    def set_engine_rpm(self, rpm: float, throttle: float = 0.0) -> None:
+        """Slide the engine loop's playback frequency to track RPM."""
+        if not (self._engine_running and self._engine_stream is not None):
+            return
+        target = self._engine_base_freq * engine_freq_mult(rpm)
+        gain = 0.5 + 0.35 * throttle
+        vol = max(0.0, min(1.0, gain * self.sfx_volume * self.master_volume))
+        try:
+            self._bass_call(self._slide, self._engine_stream.handle,
+                            self._ATTRIB_FREQ, target, ENGINE_SLIDE_MS)
+            self._engine_stream.set_volume(vol)
+        except self._BassError:
+            self._engine_stream = None
+
+    @property
+    def engine_running(self) -> bool:
+        return self._engine_running
+
+    # -- music ----------------------------------------------------------------
+
+    def play_music(self, track: str, fade_ms: int = 1500) -> None:
+        if self._music_track == track:
+            return
+        path = ASSETS / "music" / (track + ".ogg")
+        if not path.exists():
+            path = ASSETS / "music" / (track + ".wav")
+        if not path.exists():
+            log.warning("Missing music track: %s", track)
+            return
+        if self._music_stream is not None:
+            self._fade_out(self._music_stream, 800)
+            self._music_stream = None
+            self._music_track = None
+        stream = self._stream(path, looping=True)
+        if stream is None:
+            return
+        try:
+            stream.set_volume(0.0)
+            stream.play()
+            self._bass_call(self._slide, stream.handle, self._ATTRIB_VOL,
+                            max(0.0, min(1.0, self.music_volume * self.master_volume)),
+                            max(0, int(fade_ms)))
+        except self._BassError:
+            log.warning("Could not play music %s", track, exc_info=True)
+            return
+        self._music_stream = stream
+        self._music_track = track
+
+    def stop_music(self, fade_ms: int = 1000) -> None:
+        if self._music_stream is None:
+            return
+        self._fade_out(self._music_stream, fade_ms)
+        self._music_stream = None
+        self._music_track = None
+
+    # -- volume control ---------------------------------------------------------
+
+    def set_volumes(self, master: float | None = None, sfx: float | None = None,
+                    music: float | None = None) -> None:
+        if master is not None:
+            self.master_volume = max(0.0, min(1.0, master))
+        if sfx is not None:
+            self.sfx_volume = max(0.0, min(1.0, sfx))
+        if music is not None:
+            self.music_volume = max(0.0, min(1.0, music))
+        for ch in list(self._loops):
+            self._apply_loop_volume(ch)
+        if self._engine_stream is not None:
+            try:
+                self._engine_stream.set_volume(
+                    max(0.0, min(1.0, 0.5 * self.sfx_volume * self.master_volume)))
+            except self._BassError:
+                self._engine_stream = None
+        if self._music_stream is not None:
+            try:
+                self._music_stream.set_volume(
+                    max(0.0, min(1.0, self.music_volume * self.master_volume)))
+            except self._BassError:
+                self._music_stream = None
+
+    def shutdown(self) -> None:
+        for ch in list(self._loops):
+            self.stop_loop(ch, fade_ms=0)
+        self.engine_stop(shutdown_sound=False)
+        self.stop_music(fade_ms=0)
+        with contextlib.suppress(self._BassError):
+            self._output.free()
+        self.enabled = False
+
+
+class _NullBackend:
+    """Last resort: every primitive is a no-op."""
+
+    name = "none"
+    enabled = False
+    engine_running = False
+    master_volume = 1.0
+    sfx_volume = 0.8
+    music_volume = 0.55
+
+    def play(self, key: str, volume: float = 1.0) -> None: ...
+    def start_loop(self, channel: int, key: str, volume: float = 1.0,
+                   fade_ms: int = 300) -> None: ...
+    def set_loop_volume(self, channel: int, volume: float) -> None: ...
+    def stop_loop(self, channel: int, fade_ms: int = 300) -> None: ...
+    def engine_start(self) -> None: ...
+    def engine_stop(self, shutdown_sound: bool = True) -> None: ...
+    def set_engine_rpm(self, rpm: float, throttle: float = 0.0) -> None: ...
+    def play_music(self, track: str, fade_ms: int = 1500) -> None: ...
+    def stop_music(self, fade_ms: int = 1000) -> None: ...
+    def set_volumes(self, master: float | None = None, sfx: float | None = None,
+                    music: float | None = None) -> None: ...
+    def shutdown(self) -> None: ...
+
+
+class AudioEngine:
+    """Facade over the active backend; the rest of the game talks only to this."""
+
+    def __init__(self) -> None:
+        self._impl = self._pick_backend()
+        log.info("Audio backend: %s", self._impl.name)
+
+    @staticmethod
+    def _pick_backend():
+        pref = os.environ.get("FREIGHT_FATE_AUDIO_BACKEND", "").strip().lower()
+        if pref in ("", "bass"):
+            try:
+                return _BassBackend()
+            except Exception:
+                log.warning("sound_lib/BASS unavailable; falling back to pygame.mixer",
+                            exc_info=True)
+        backend = _PygameBackend()
+        if backend.enabled:
+            return backend
+        return _NullBackend()
+
+    @property
+    def enabled(self) -> bool:
+        return self._impl.enabled
+
+    @property
+    def backend_name(self) -> str:
+        return self._impl.name
+
+    @property
+    def master_volume(self) -> float:
+        return self._impl.master_volume
+
+    @property
+    def sfx_volume(self) -> float:
+        return self._impl.sfx_volume
+
+    @property
+    def music_volume(self) -> float:
+        return self._impl.music_volume
+
+    # -- one-shots and loops ------------------------------------------------------
+
+    def play(self, key: str, volume: float = 1.0) -> None:
+        self._impl.play(key, volume)
+
+    def start_loop(self, channel: int, key: str, volume: float = 1.0, fade_ms: int = 300) -> None:
+        self._impl.start_loop(channel, key, volume, fade_ms)
+
+    def set_loop_volume(self, channel: int, volume: float) -> None:
+        self._impl.set_loop_volume(channel, volume)
+
+    def stop_loop(self, channel: int, fade_ms: int = 300) -> None:
+        self._impl.stop_loop(channel, fade_ms)
+
+    # -- truck engine ----------------------------------------------------------------
+
+    def engine_start(self) -> None:
+        self._impl.engine_start()
+
+    def engine_stop(self, shutdown_sound: bool = True) -> None:
+        self._impl.engine_stop(shutdown_sound)
+
+    def set_engine_rpm(self, rpm: float, throttle: float = 0.0) -> None:
+        self._impl.set_engine_rpm(rpm, throttle)
+
+    @property
+    def engine_running(self) -> bool:
+        return self._impl.engine_running
+
+    # -- road / weather / ambience --------------------------------------------
+
+    def set_road_noise(self, speed_mps: float) -> None:
+        """Tire-on-asphalt loop whose volume tracks speed."""
+        if not self.enabled:
+            return
+        gain = min(0.9, speed_mps / 30.0)
+        if gain < 0.02:
+            self.stop_loop(CH_ROAD, fade_ms=500)
+        else:
+            self.start_loop(CH_ROAD, "vehicle/road", volume=gain, fade_ms=400)
+
+    def set_weather(self, key: str | None, intensity: float = 1.0) -> None:
+        """Play a weather ambience loop, e.g. ``weather/rain_light``."""
+        if key is None:
+            self.stop_loop(CH_WEATHER, fade_ms=1200)
+        else:
+            self.start_loop(CH_WEATHER, key, volume=min(1.0, intensity), fade_ms=1200)
+
+    def set_wind(self, intensity: float) -> None:
+        if intensity < 0.05:
+            self.stop_loop(CH_WEATHER_B, fade_ms=1500)
+        else:
+            self.start_loop(CH_WEATHER_B, "weather/wind", volume=min(0.8, intensity), fade_ms=1500)
+
+    def set_ambient(self, key: str | None, volume: float = 0.7) -> None:
+        if key is None:
+            self.stop_loop(CH_AMBIENT, fade_ms=800)
+        else:
+            self.start_loop(CH_AMBIENT, key, volume=volume, fade_ms=800)
+
+    def stop_world(self) -> None:
+        """Stop engine, road, weather, and ambience (leaving UI sfx alone)."""
+        self.engine_stop(shutdown_sound=False)
+        for ch in (CH_ROAD, CH_WEATHER, CH_WEATHER_B, CH_AMBIENT):
+            self.stop_loop(ch, fade_ms=400)
+
+    # -- music ----------------------------------------------------------------
+
+    def play_music(self, track: str, fade_ms: int = 1500) -> None:
+        """Stream a music track, e.g. ``play_music("menu_theme")``."""
+        self._impl.play_music(track, fade_ms)
+
+    def stop_music(self, fade_ms: int = 1000) -> None:
+        self._impl.stop_music(fade_ms)
+
+    # -- volume control ---------------------------------------------------------
+
+    def set_volumes(self, master: float | None = None, sfx: float | None = None,
+                    music: float | None = None) -> None:
+        self._impl.set_volumes(master, sfx, music)
+
+    def shutdown(self) -> None:
+        self._impl.shutdown()

--- a/src/freight_fate/models/__init__.py
+++ b/src/freight_fate/models/__init__.py
@@ -1,6 +1,9 @@
 from .career import Career
 from .economy import Economy
 from .jobs import CARGO_CATALOG, Job, JobBoard
+from .market import Market
 from .profile import Profile
+from .trucks import TRUCK_CATALOG, UPGRADE_CATALOG, build_truck_specs
 
-__all__ = ["CARGO_CATALOG", "Career", "Economy", "Job", "JobBoard", "Profile"]
+__all__ = ["CARGO_CATALOG", "TRUCK_CATALOG", "UPGRADE_CATALOG", "Career",
+           "Economy", "Job", "JobBoard", "Market", "Profile", "build_truck_specs"]

--- a/src/freight_fate/models/jobs.py
+++ b/src/freight_fate/models/jobs.py
@@ -11,6 +11,7 @@ import random
 from dataclasses import dataclass
 
 from ..data.world import World
+from .market import Market, market_condition
 
 
 @dataclass(frozen=True)
@@ -53,16 +54,19 @@ class Job:
     distance_mi: float       # shortest-route miles, used for pay and deadline
     pay: float
     deadline_game_h: float
+    market_mult: float = 1.0   # market multiplier already applied to pay
 
     def describe(self, index: int | None = None, total: int | None = None) -> str:
         prefix = f"Job {index} of {total}: " if index is not None else ""
+        condition = market_condition(self.market_mult)
+        market = f" Market is {condition}." if condition != "steady" else ""
         endorsement = ""
         if self.cargo.endorsement:
             endorsement = f" Requires {ENDORSEMENT_LABELS[self.cargo.endorsement]}."
         return (f"{prefix}{self.weight_tons:.0f} tons of {self.cargo.label} "
                 f"to {self.destination}. {self.distance_mi:.0f} miles. "
                 f"Pays {self.pay:,.0f} dollars. "
-                f"Deadline {self.deadline_game_h:.0f} hours.{endorsement}")
+                f"Deadline {self.deadline_game_h:.0f} hours.{market}{endorsement}")
 
     def payout(self, hours_taken: float, damage_pct: float, on_time_bonus: float = 0.15) -> float:
         """Final payment given delivery time and cargo condition."""
@@ -88,7 +92,7 @@ class JobBoard:
         self._rng = random.Random(seed)
 
     def offers(self, city: str, endorsements: set[str], count: int = 5,
-               level: int = 1) -> list[Job]:
+               level: int = 1, market: Market | None = None) -> list[Job]:
         jobs: list[Job] = []
         city_obj = self.world.cities[city]
         others = [c for c in self.world.city_names() if c != city]
@@ -108,16 +112,18 @@ class JobBoard:
             route = self.world.shortest_route(city, destination)
             if route is None or route.miles > max_miles:
                 continue
-            jobs.append(self._make_job(cargo, city, location.name, destination, route.miles))
+            jobs.append(self._make_job(cargo, city, location.name, destination,
+                                       route.miles, market))
         jobs.sort(key=lambda j: j.distance_mi)
         return jobs
 
     def _make_job(self, cargo: CargoType, origin: str, origin_location: str,
-                  destination: str, miles: float) -> Job:
+                  destination: str, miles: float, market: Market | None) -> Job:
         weight = self._rng.uniform(*cargo.weight_tons)
         rate = cargo.rate_per_mile * self._rng.uniform(0.9, 1.15)
-        pay = round(miles * rate * (1.0 + weight / 120.0), 2)
+        mult = market.multiplier(cargo.key) if market is not None else 1.0
+        pay = round(miles * rate * (1.0 + weight / 120.0) * mult, 2)
         # deadline: 50 mph average plus generous slack
         deadline = miles / 50.0 * self._rng.uniform(1.35, 1.7)
         return Job(cargo, weight, origin, origin_location, destination,
-                   round(miles, 1), pay, round(deadline, 1))
+                   round(miles, 1), pay, round(deadline, 1), market_mult=mult)

--- a/src/freight_fate/models/market.py
+++ b/src/freight_fate/models/market.py
@@ -1,0 +1,87 @@
+"""Freight market: per-cargo-class pay multipliers that drift day by day.
+
+Each cargo class carries a multiplier between 0.8 and 1.3 applied to job
+pay. Multipliers move once per in-game day with a seeded random walk, so a
+profile's market history is deterministic: replaying the same seed over the
+same days always lands on the same numbers. The whole state is persisted on
+the player profile.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+MARKET_MIN = 0.8
+MARKET_MAX = 1.3
+DAILY_DRIFT = 0.06
+
+# Cargo classes tracked by the market (mirrors jobs.CARGO_CATALOG; kept as a
+# literal so this module needs no imports from the job layer).
+MARKET_CARGO_KEYS = ("general", "retail", "container", "bulk", "machinery",
+                     "food", "refrigerated", "electronics")
+
+
+def market_condition(multiplier: float) -> str:
+    """Spoken one-word market condition for a multiplier."""
+    if multiplier >= 1.18:
+        return "hot"
+    if multiplier >= 1.07:
+        return "strong"
+    if multiplier <= 0.88:
+        return "cold"
+    if multiplier <= 0.97:
+        return "soft"
+    return "steady"
+
+
+def _clamp(value: float) -> float:
+    return max(MARKET_MIN, min(MARKET_MAX, value))
+
+
+@dataclass
+class Market:
+    seed: int = field(default_factory=lambda: random.randrange(2**31))
+    day: int = 0
+    multipliers: dict[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.multipliers:
+            rng = random.Random(self.seed)
+            self.multipliers = {key: round(rng.uniform(0.9, 1.15), 3)
+                                for key in MARKET_CARGO_KEYS}
+
+    def multiplier(self, cargo_key: str) -> float:
+        return self.multipliers.get(cargo_key, 1.0)
+
+    def condition(self, cargo_key: str) -> str:
+        return market_condition(self.multiplier(cargo_key))
+
+    def advance_to(self, day: int) -> bool:
+        """Walk the market forward to the given in-game day.
+
+        Each elapsed day every class drifts by a step drawn from a generator
+        seeded with (profile seed, day), so catching up several days at once
+        gives the same result as advancing one day at a time.
+        """
+        changed = False
+        while self.day < day:
+            self.day += 1
+            rng = random.Random(self.seed * 1_000_003 + self.day)
+            for key in sorted(self.multipliers):
+                step = rng.uniform(-DAILY_DRIFT, DAILY_DRIFT)
+                self.multipliers[key] = round(_clamp(self.multipliers[key] + step), 3)
+            changed = True
+        return changed
+
+    def summary(self) -> str:
+        """Spoken job-board headline naming the standout cargo classes."""
+        items = sorted(self.multipliers.items())
+        hot = sorted((kv for kv in items if kv[1] >= 1.07),
+                     key=lambda kv: kv[1], reverse=True)
+        cold = sorted((kv for kv in items if kv[1] <= 0.97), key=lambda kv: kv[1])
+        if not hot and not cold:
+            return "Freight market is steady across the board."
+        parts = [f"{key.replace('_', ' ')} {market_condition(mult)}"
+                 for key, mult in hot[:2] + cold[:2]]
+        return "Market watch: " + ", ".join(parts) + "."

--- a/src/freight_fate/models/profile.py
+++ b/src/freight_fate/models/profile.py
@@ -15,8 +15,9 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from .career import Career
+from .market import Market
 
-SAVE_VERSION = 1
+SAVE_VERSION = 2
 STARTING_MONEY = 5_000.0
 DEFAULT_CITY = "Chicago"
 
@@ -49,7 +50,11 @@ class Profile:
     truck_fuel_gal: float = 150.0
     game_hours: float = 6.0          # in-game clock, hours since career start
     tutorial_done: bool = False
+    truck: str = "rig"               # key into trucks.TRUCK_CATALOG
+    owned_trucks: list[str] = field(default_factory=lambda: ["rig"])
+    upgrades: dict[str, int] = field(default_factory=dict)  # upgrade key -> tier
     career: Career = field(default_factory=Career)
+    market: Market = field(default_factory=Market)
 
     # -- serialization -------------------------------------------------------
 
@@ -63,9 +68,21 @@ class Profile:
         d = dict(d)
         d.pop("version", None)
         career = Career(**d.pop("career", {}))
-        known = {f for f in cls.__dataclass_fields__ if f != "career"}
+        market = Market(**d.pop("market", {}))
+        known = {f for f in cls.__dataclass_fields__ if f not in ("career", "market")}
         kwargs = {k: v for k, v in d.items() if k in known}
-        return cls(career=career, **kwargs)
+        return cls(career=career, market=market, **kwargs)
+
+    # -- truck ------------------------------------------------------------------
+
+    def truck_specs(self):
+        """The active truck's specs with this profile's upgrades applied."""
+        from .trucks import build_truck_specs
+
+        return build_truck_specs(self.truck, self.upgrades)
+
+    def market_day(self) -> int:
+        return int(self.game_hours // 24)
 
     # -- persistence -----------------------------------------------------------
 

--- a/src/freight_fate/models/trucks.py
+++ b/src/freight_fate/models/trucks.py
@@ -1,0 +1,93 @@
+"""Truck catalog and garage upgrades.
+
+Upgrades and the chosen truck live on the player profile; they come together
+in :func:`build_truck_specs`, which produces the :class:`TruckSpecs` the
+driving simulation runs on.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from ..sim.vehicle import TruckSpecs
+
+# Upgrade effect constants.
+ENGINE_TUNE_TORQUE_PER_TIER = 0.10   # +10% torque per tier
+AERO_DRAG_MULT = 0.88                # -12% drag
+TANK_EXTRA_GAL = 50.0
+BRAKE_FADE_BONUS_C = 150.0           # fade onset pushed this much hotter
+
+
+@dataclass(frozen=True)
+class TruckModel:
+    key: str
+    label: str
+    price: float
+    description: str
+    specs: TruckSpecs
+
+
+TRUCK_CATALOG: dict[str, TruckModel] = {
+    "rig": TruckModel(
+        "rig", "standard rig", 0.0,
+        "The dependable tractor you started with. Balanced all around.",
+        TruckSpecs()),
+    "heavy_hauler": TruckModel(
+        "heavy_hauler", "heavy hauler", 52_000.0,
+        "A brute: a quarter more torque and a two hundred gallon tank, but "
+        "blunt aerodynamics and a thirstier engine.",
+        TruckSpecs(max_torque_nm=2_460.0, fuel_tank_gal=200.0,
+                   drag_coefficient=0.75, fuel_burn_factor=1.2,
+                   mass_kg=37_500.0)),
+}
+
+
+@dataclass(frozen=True)
+class Upgrade:
+    key: str
+    label: str
+    description: str
+    prices: tuple[float, ...]      # one entry per tier
+
+    @property
+    def max_tier(self) -> int:
+        return len(self.prices)
+
+
+UPGRADE_CATALOG: dict[str, Upgrade] = {
+    "engine_tune": Upgrade(
+        "engine_tune", "Engine tune",
+        "Ten percent more torque per tier. Two tiers available.",
+        (12_000.0, 26_000.0)),
+    "aero_kit": Upgrade(
+        "aero_kit", "Aerodynamic kit",
+        "Roof fairing and side skirts cut drag twelve percent, "
+        "saving fuel at highway speed.",
+        (9_000.0,)),
+    "long_range_tank": Upgrade(
+        "long_range_tank", "Long-range tank",
+        "Adds fifty gallons of fuel capacity.",
+        (7_500.0,)),
+    "reinforced_brakes": Upgrade(
+        "reinforced_brakes", "Reinforced brakes",
+        "High-temperature linings resist brake fade on long descents.",
+        (6_500.0,)),
+}
+
+
+def build_truck_specs(truck_key: str, upgrades: dict[str, int]) -> TruckSpecs:
+    """Specs for the given truck model with the profile's upgrades applied."""
+    model = TRUCK_CATALOG.get(truck_key, TRUCK_CATALOG["rig"])
+    specs = model.specs
+    changes: dict[str, float] = {}
+    tier = upgrades.get("engine_tune", 0)
+    if tier:
+        changes["max_torque_nm"] = specs.max_torque_nm * (
+            1.0 + ENGINE_TUNE_TORQUE_PER_TIER * min(tier, 2))
+    if upgrades.get("aero_kit"):
+        changes["drag_coefficient"] = specs.drag_coefficient * AERO_DRAG_MULT
+    if upgrades.get("long_range_tank"):
+        changes["fuel_tank_gal"] = specs.fuel_tank_gal + TANK_EXTRA_GAL
+    if upgrades.get("reinforced_brakes"):
+        changes["brake_fade_temp_c"] = specs.brake_fade_temp_c + BRAKE_FADE_BONUS_C
+    return replace(specs, **changes) if changes else specs

--- a/src/freight_fate/sim/vehicle.py
+++ b/src/freight_fate/sim/vehicle.py
@@ -30,7 +30,9 @@ class TruckSpecs:
     peak_torque_rpm: float = 1_300.0
     driveline_efficiency: float = 0.85
     max_brake_decel_g: float = 0.35
+    brake_fade_temp_c: float = 400.0   # brakes fade above this temperature
     fuel_tank_gal: float = 150.0
+    fuel_burn_factor: float = 1.0      # model-specific thirst multiplier
     engine_brake_force_n: float = 25_000.0
 
 
@@ -138,7 +140,9 @@ class TruckState:
         if self.velocity_mps <= 0.0:
             return 0.0
         s = self.specs
-        fade = 1.0 if self.brake_temp_c < 400 else max(0.35, 1.0 - (self.brake_temp_c - 400) / 400)
+        fade_temp = s.brake_fade_temp_c
+        fade = (1.0 if self.brake_temp_c < fade_temp
+                else max(0.35, 1.0 - (self.brake_temp_c - fade_temp) / 400))
         service = s.mass_kg * G * s.max_brake_decel_g * self.brake * fade * self.grip
         jake = s.engine_brake_force_n if (self.engine_brake and self.engine_on
                                           and not self.transmission.in_neutral) else 0.0
@@ -195,7 +199,7 @@ class TruckState:
             return
         # ~0.8 gal/h at idle; load burn calibrated for ~6.5-7 mpg at 60 mph cruise
         power_kw = abs(self.drive_force()) * self.velocity_mps / 1000.0
-        burn = 0.00022 + power_kw * 1.5e-5
+        burn = (0.00022 + power_kw * 1.5e-5) * self.specs.fuel_burn_factor
         self.fuel_gal = max(0.0, self.fuel_gal - burn * dt * self.fuel_burn_mult)
         if self.fuel_gal <= 0.0:
             self.stop_engine()

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -1,9 +1,10 @@
-"""City hub: job board, garage, career stats, and route selection."""
+"""City hub: job board, garage, upgrades, trucks, and route selection."""
 
 from __future__ import annotations
 
 from ..data.world import Route
 from ..models.jobs import Job, JobBoard
+from ..models.trucks import TRUCK_CATALOG, UPGRADE_CATALOG, TruckModel, Upgrade
 from .base import MenuItem, MenuState
 
 
@@ -55,8 +56,9 @@ class CityMenuState(MenuState):
 
     def _job_board(self) -> None:
         p = self.ctx.profile
+        p.market.advance_to(p.market_day())
         jobs = self._board.offers(p.current_city, p.career.endorsements,
-                                  level=p.career.level)
+                                  level=p.career.level, market=p.market)
         self._jobs_cache = jobs
         self.ctx.push_state(JobBoardState(self.ctx, jobs))
 
@@ -74,11 +76,15 @@ class CityMenuState(MenuState):
 
     def _truck_status(self) -> None:
         p = self.ctx.profile
-        fuel_pct = p.truck_fuel_gal / 150.0 * 100
+        specs = p.truck_specs()
+        truck = TRUCK_CATALOG.get(p.truck, TRUCK_CATALOG["rig"])
+        fuel_pct = p.truck_fuel_gal / specs.fuel_tank_gal * 100
         damage = p.truck_damage_pct
         condition = ("excellent" if damage < 5 else "good" if damage < 20
                      else "worn" if damage < 50 else "poor")
-        self.ctx.say(f"Fuel {fuel_pct:.0f} percent, {p.truck_fuel_gal:.0f} gallons. "
+        self.ctx.say(f"Driving the {truck.label}. "
+                     f"Fuel {fuel_pct:.0f} percent, {p.truck_fuel_gal:.0f} gallons "
+                     f"of {specs.fuel_tank_gal:.0f}. "
                      f"Truck condition {condition}, {damage:.0f} percent damage.")
 
     def _save(self) -> None:
@@ -112,15 +118,23 @@ class GarageState(MenuState):
                      help="Fill the tank at this region's diesel price."),
             MenuItem(self._repair_label, self._repair,
                      help="Restore the truck to full condition."),
+            MenuItem("Upgrades", self._upgrades,
+                     help="Buy performance upgrades for your truck: more torque, "
+                          "less drag, a bigger tank, stronger brakes."),
+            MenuItem("Trucks", self._trucks,
+                     help="Buy a new truck, or switch between trucks you own."),
             MenuItem("Back", self.go_back),
         ]
 
     def _region(self) -> str:
         return self.ctx.world.cities[self.ctx.profile.current_city].region
 
+    def _tank_gal(self) -> float:
+        return self.ctx.profile.truck_specs().fuel_tank_gal
+
     def _fuel_label(self) -> str:
         p = self.ctx.profile
-        need = 150.0 - p.truck_fuel_gal
+        need = self._tank_gal() - p.truck_fuel_gal
         if need < 1:
             return "Fuel: tank is full"
         cost = self.ctx.economy.fuel_cost(self._region(), need)
@@ -135,7 +149,8 @@ class GarageState(MenuState):
 
     def _refuel(self) -> None:
         p = self.ctx.profile
-        need = 150.0 - p.truck_fuel_gal
+        tank = self._tank_gal()
+        need = tank - p.truck_fuel_gal
         if need < 1:
             self.ctx.say("The tank is already full.")
             return
@@ -145,7 +160,7 @@ class GarageState(MenuState):
             self.ctx.say(f"Not enough money. You need {cost:,.0f} dollars.")
             return
         p.money -= cost
-        p.truck_fuel_gal = 150.0
+        p.truck_fuel_gal = tank
         self.ctx.audio.play("vehicle/fuel_pump")
         self.ctx.say(f"Tank filled. {cost:,.0f} dollars. "
                      f"You have {p.money:,.0f} dollars left.")
@@ -168,6 +183,120 @@ class GarageState(MenuState):
                      f"You have {p.money:,.0f} dollars left.")
         self.refresh()
 
+    def _upgrades(self) -> None:
+        self.ctx.push_state(UpgradeShopState(self.ctx))
+
+    def _trucks(self) -> None:
+        self.ctx.push_state(TruckShopState(self.ctx))
+
+
+class UpgradeShopState(MenuState):
+    title = "Upgrades"
+    intro_help = ("Each entry speaks the upgrade, its price, and what you already "
+                  "own. Enter buys the next tier. Press F1 on an upgrade to hear "
+                  "what it does. Escape returns to the garage.")
+
+    def announce_entry(self) -> None:
+        p = self.ctx.profile
+        self.ctx.say(f"Upgrades. You have {p.money:,.0f} dollars. {self.current_text()}")
+
+    def build_items(self) -> list[MenuItem]:
+        items = [MenuItem(lambda u=u: self._label(u), lambda u=u: self._buy(u),
+                          help=u.description)
+                 for u in UPGRADE_CATALOG.values()]
+        items.append(MenuItem("Back", self.go_back))
+        return items
+
+    def _label(self, upgrade: Upgrade) -> str:
+        owned = self.ctx.profile.upgrades.get(upgrade.key, 0)
+        if owned >= upgrade.max_tier:
+            tiers = f", tier {owned} of {upgrade.max_tier}" if upgrade.max_tier > 1 else ""
+            return f"{upgrade.label}: owned{tiers}"
+        price = upgrade.prices[owned]
+        if upgrade.max_tier > 1:
+            owned_part = f", tier {owned} owned" if owned else ""
+            return (f"{upgrade.label}, tier {owned + 1} of {upgrade.max_tier}: "
+                    f"{price:,.0f} dollars{owned_part}")
+        return f"{upgrade.label}: {price:,.0f} dollars"
+
+    def _buy(self, upgrade: Upgrade) -> None:
+        p = self.ctx.profile
+        owned = p.upgrades.get(upgrade.key, 0)
+        if owned >= upgrade.max_tier:
+            self.ctx.say(f"{upgrade.label} is already fully installed.")
+            return
+        price = upgrade.prices[owned]
+        if p.money < price:
+            self.ctx.audio.play("ui/error")
+            self.ctx.say(f"Not enough money. {upgrade.label} costs {price:,.0f} dollars "
+                         f"and you have {p.money:,.0f}.")
+            return
+        p.money -= price
+        p.upgrades[upgrade.key] = owned + 1
+        self.ctx.save_profile()
+        self.ctx.audio.play("ui/cash")
+        tier_part = (f" tier {owned + 1}" if upgrade.max_tier > 1 else "")
+        self.ctx.say(f"{upgrade.label}{tier_part} installed for {price:,.0f} dollars. "
+                     f"You have {p.money:,.0f} dollars left.")
+        self.refresh()
+
+
+class TruckShopState(MenuState):
+    title = "Trucks"
+    intro_help = ("Each entry speaks the truck, its price, and whether you own it. "
+                  "Enter buys a truck you do not own, or switches to one you do. "
+                  "Press F1 on a truck to hear its character. Escape returns to "
+                  "the garage.")
+
+    def announce_entry(self) -> None:
+        p = self.ctx.profile
+        self.ctx.say(f"Trucks. You have {p.money:,.0f} dollars. {self.current_text()}")
+
+    def build_items(self) -> list[MenuItem]:
+        items = [MenuItem(lambda m=m: self._label(m), lambda m=m: self._pick(m),
+                          help=m.description)
+                 for m in TRUCK_CATALOG.values()]
+        items.append(MenuItem("Back", self.go_back))
+        return items
+
+    def _label(self, model: TruckModel) -> str:
+        p = self.ctx.profile
+        name = model.label.capitalize()
+        if model.key == p.truck:
+            return f"{name}: currently driving"
+        if model.key in p.owned_trucks:
+            return f"{name}: owned, switch to it"
+        return f"{name}: buy for {model.price:,.0f} dollars"
+
+    def _pick(self, model: TruckModel) -> None:
+        p = self.ctx.profile
+        if model.key == p.truck:
+            self.ctx.say(f"You are already driving the {model.label}.")
+            return
+        if model.key not in p.owned_trucks:
+            if p.money < model.price:
+                self.ctx.audio.play("ui/error")
+                self.ctx.say(f"Not enough money. The {model.label} costs "
+                             f"{model.price:,.0f} dollars and you have {p.money:,.0f}.")
+                return
+            p.money -= model.price
+            p.owned_trucks.append(model.key)
+            self.ctx.audio.play("ui/cash")
+            self._switch_to(model)
+            self.ctx.say(f"You bought the {model.label} for {model.price:,.0f} dollars "
+                         f"and it is now your truck. You have {p.money:,.0f} dollars left.")
+            return
+        self.ctx.audio.play("vehicle/truck_door")
+        self._switch_to(model)
+        self.ctx.say(f"You are now driving the {model.label}.")
+
+    def _switch_to(self, model: TruckModel) -> None:
+        p = self.ctx.profile
+        p.truck = model.key
+        p.truck_fuel_gal = min(p.truck_fuel_gal, p.truck_specs().fuel_tank_gal)
+        self.ctx.save_profile()
+        self.refresh()
+
 
 class JobBoardState(MenuState):
     title = "Job board"
@@ -184,6 +313,7 @@ class JobBoardState(MenuState):
             self.ctx.say("Job board. No jobs available right now. Press Escape to go back.")
         else:
             self.ctx.say(f"Job board. {n} job{'s' if n != 1 else ''} available. "
+                         f"{self.ctx.profile.market.summary()} "
                          + self.current_text())
 
     def build_items(self) -> list[MenuItem]:

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -30,9 +30,9 @@ class DrivingState(State):
         self.job = job
         self.route = route
         profile = ctx.profile
-        self.truck = TruckState()
+        self.truck = TruckState(specs=profile.truck_specs())
         self.truck.transmission.automatic = ctx.settings.automatic_transmission
-        self.truck.fuel_gal = profile.truck_fuel_gal
+        self.truck.fuel_gal = min(profile.truck_fuel_gal, self.truck.specs.fuel_tank_gal)
         self.truck.damage_pct = profile.truck_damage_pct
         self.start_damage = profile.truck_damage_pct
         region = ctx.world.cities[job.origin].region
@@ -530,6 +530,7 @@ class ArrivalState(MenuState):
         p.truck_damage_pct = d.truck.damage_pct
         announcements = p.career.record_delivery(job.distance_mi, pay, on_time, trip_damage)
         p.game_hours += hours
+        p.market.advance_to(p.market_day())
         self.ctx.save_profile()
 
         self.summary_parts.insert(0, (

--- a/src/freight_fate/states/main_menu.py
+++ b/src/freight_fate/states/main_menu.py
@@ -193,6 +193,16 @@ HELP_PAGES = [
         "Fragile cargo, like electronics and fresh food, punishes rough driving.",
         "Repair your truck in the city garage. Damage reduces engine power.",
         "Higher levels unlock longer hauls and special cargo endorsements.",
+        "Cargo markets drift day by day. The job board calls out hot and cold",
+        "markets; hot cargo pays well above the usual rate.",
+    ]),
+    ("The garage", [
+        "Every city garage refuels and repairs your truck.",
+        "The Upgrades menu sells permanent improvements: an engine tune,",
+        "an aerodynamic kit, a long-range tank, and reinforced brakes.",
+        "The Trucks menu sells the heavy hauler: more torque and a bigger",
+        "tank, but worse aerodynamics and a thirstier engine.",
+        "Switch between trucks you own at any garage, free of charge.",
     ]),
 ]
 

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -1,0 +1,102 @@
+"""Audio backend selection, the BASS engine model, and the pygame fallback."""
+
+import pytest
+
+from freight_fate import audio
+from freight_fate.audio import (
+    ENGINE_FREQ_MAX_MULT,
+    ENGINE_RPM_IDLE,
+    ENGINE_RPM_MAX,
+    AudioEngine,
+    engine_freq_mult,
+)
+
+
+def exercise(a: AudioEngine) -> None:
+    """Every facade call must be safe regardless of backend."""
+    a.play("ui/menu_select")
+    a.play("nonexistent/sound")
+    a.engine_start()
+    a.set_engine_rpm(1500, 0.5)
+    a.set_engine_rpm(2200, 1.0)
+    a.set_road_noise(20.0)
+    a.set_road_noise(0.0)
+    a.set_weather("weather/rain_light", 0.8)
+    a.set_weather(None)
+    a.set_wind(0.5)
+    a.set_ambient("ambient/truck_stop", 0.4)
+    a.play_music("menu_theme")
+    a.play_music("open_road")
+    a.play_music("not_a_track")
+    a.set_volumes(master=0.5, sfx=0.5, music=0.5)
+    a.stop_world()
+    a.stop_music()
+    a.shutdown()
+
+
+def test_bass_backend_selected_by_default(monkeypatch):
+    monkeypatch.delenv("FREIGHT_FATE_AUDIO_BACKEND", raising=False)
+    a = AudioEngine()
+    assert a.backend_name == "bass"
+    assert a.enabled
+    exercise(a)
+
+
+def test_env_var_forces_pygame_backend(monkeypatch):
+    monkeypatch.setenv("FREIGHT_FATE_AUDIO_BACKEND", "pygame")
+    a = AudioEngine()
+    assert a.backend_name in ("pygame", "none")
+    exercise(a)
+
+
+def test_fallback_to_pygame_when_bass_init_fails(monkeypatch):
+    monkeypatch.delenv("FREIGHT_FATE_AUDIO_BACKEND", raising=False)
+
+    def broken_bass():
+        raise RuntimeError("BASS failed to initialize")
+
+    monkeypatch.setattr(audio, "_BassBackend", broken_bass)
+    a = AudioEngine()
+    assert a.backend_name in ("pygame", "none")
+    exercise(a)
+
+
+def test_engine_freq_mult_mapping():
+    assert engine_freq_mult(ENGINE_RPM_IDLE) == 1.0
+    assert abs(engine_freq_mult(ENGINE_RPM_MAX) - ENGINE_FREQ_MAX_MULT) < 1e-9
+    assert engine_freq_mult(0) == 1.0                  # clamped below idle
+    assert engine_freq_mult(99_999) == ENGINE_FREQ_MAX_MULT  # clamped above redline
+    mid = engine_freq_mult((ENGINE_RPM_IDLE + ENGINE_RPM_MAX) / 2)
+    assert abs(mid - (1.0 + ENGINE_FREQ_MAX_MULT) / 2) < 1e-9
+
+
+def test_bass_engine_uses_single_pitched_loop(monkeypatch):
+    monkeypatch.delenv("FREIGHT_FATE_AUDIO_BACKEND", raising=False)
+    a = AudioEngine()
+    if a.backend_name != "bass":
+        pytest.skip("BASS backend unavailable")
+    impl = a._impl
+    a.engine_start()
+    assert a.engine_running
+    assert impl._engine_stream is not None
+    assert impl._engine_base_freq > 0
+    # frequency targets follow RPM; repeated slides must be safe
+    for rpm in (600, 1100, 1800, 2200, 900):
+        a.set_engine_rpm(rpm, throttle=0.7)
+    a.engine_stop()
+    assert not a.engine_running
+    assert impl._engine_stream is None
+    a.shutdown()
+
+
+def test_bass_headless_uses_no_sound_device(monkeypatch):
+    # conftest sets SDL_AUDIODRIVER=dummy, which must route BASS to the
+    # "no sound" device so CI runs the full pipeline without hardware
+    monkeypatch.delenv("FREIGHT_FATE_AUDIO_BACKEND", raising=False)
+    monkeypatch.setenv("SDL_AUDIODRIVER", "dummy")
+    a = AudioEngine()
+    if a.backend_name != "bass":
+        pytest.skip("BASS backend unavailable")
+    assert a.enabled
+    assert a._impl._output.get_device() == audio.BASS_NO_SOUND_DEVICE
+    a.shutdown()

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -1,0 +1,106 @@
+"""Freight market drift, determinism, and job pay integration."""
+
+from freight_fate.models.jobs import JobBoard
+from freight_fate.models.market import (
+    MARKET_CARGO_KEYS,
+    MARKET_MAX,
+    MARKET_MIN,
+    Market,
+    market_condition,
+)
+from freight_fate.models.profile import Profile
+
+
+def assert_in_bounds(market: Market) -> None:
+    for key, mult in market.multipliers.items():
+        assert MARKET_MIN <= mult <= MARKET_MAX, (key, mult)
+
+
+def test_initial_multipliers_cover_all_cargo_classes():
+    m = Market(seed=42)
+    assert set(m.multipliers) == set(MARKET_CARGO_KEYS)
+    assert_in_bounds(m)
+
+
+def test_drift_stays_within_bounds_over_a_long_career():
+    m = Market(seed=7)
+    m.advance_to(400)
+    assert m.day == 400
+    assert_in_bounds(m)
+
+
+def test_drift_is_deterministic_stepwise_vs_jump():
+    a = Market(seed=99)
+    b = Market(seed=99)
+    for day in range(1, 31):
+        a.advance_to(day)
+    b.advance_to(30)
+    assert a.multipliers == b.multipliers
+    assert a.day == b.day == 30
+
+
+def test_different_seeds_diverge():
+    a = Market(seed=1)
+    b = Market(seed=2)
+    a.advance_to(10)
+    b.advance_to(10)
+    assert a.multipliers != b.multipliers
+
+
+def test_advance_reports_whether_anything_changed():
+    m = Market(seed=5)
+    assert m.advance_to(0) is False
+    assert m.advance_to(2) is True
+    assert m.advance_to(2) is False
+
+
+def test_market_condition_labels():
+    assert market_condition(1.3) == "hot"
+    assert market_condition(1.1) == "strong"
+    assert market_condition(1.0) == "steady"
+    assert market_condition(0.95) == "soft"
+    assert market_condition(0.8) == "cold"
+
+
+def test_summary_names_the_standouts():
+    m = Market(seed=1)
+    m.multipliers["electronics"] = 1.3
+    m.multipliers["bulk"] = 0.8
+    summary = m.summary()
+    assert "electronics hot" in summary
+    assert "bulk cold" in summary
+
+
+def test_job_pay_scales_with_market(world):
+    hot = Market(seed=0)
+    hot.multipliers = {k: 1.3 for k in MARKET_CARGO_KEYS}
+    cold = Market(seed=0)
+    cold.multipliers = {k: 0.8 for k in MARKET_CARGO_KEYS}
+    # identical board seeds generate the same jobs, so pay isolates the market
+    jobs_hot = JobBoard(world, seed=11).offers("Chicago", set(), market=hot)
+    jobs_cold = JobBoard(world, seed=11).offers("Chicago", set(), market=cold)
+    assert jobs_hot and len(jobs_hot) == len(jobs_cold)
+    for jh, jc in zip(jobs_hot, jobs_cold, strict=True):
+        assert jh.cargo.key == jc.cargo.key
+        assert abs(jh.pay / jc.pay - 1.3 / 0.8) < 0.01
+        assert "Market is hot." in jh.describe()
+        assert "Market is cold." in jc.describe()
+
+
+def test_steady_market_is_not_called_out_per_job(world):
+    steady = Market(seed=0)
+    steady.multipliers = {k: 1.0 for k in MARKET_CARGO_KEYS}
+    jobs = JobBoard(world, seed=11).offers("Chicago", set(), market=steady)
+    assert jobs
+    assert all("Market is" not in j.describe() for j in jobs)
+
+
+def test_profile_persists_market_state():
+    p = Profile(name="Market Test")
+    p.market.advance_to(5)
+    snapshot = dict(p.market.multipliers)
+    path = p.save()
+    loaded = Profile.load(path)
+    assert loaded.market.seed == p.market.seed
+    assert loaded.market.day == 5
+    assert loaded.market.multipliers == snapshot

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -114,7 +114,7 @@ def test_profile_save_is_atomic_and_versioned():
     p = Profile(name="Atomic")
     path = p.save()
     data = json.loads(path.read_text())
-    assert data["version"] == 1
+    assert data["version"] == 2
     assert not path.with_suffix(".json.tmp").exists()
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -99,6 +99,101 @@ def test_menu_first_letter_navigation():
 
 
 @pytest.mark.smoke
+def test_garage_upgrade_and_truck_purchase_flow():
+    from freight_fate.app import App
+    from freight_fate.states.city import (
+        CityMenuState,
+        GarageState,
+        TruckShopState,
+        UpgradeShopState,
+    )
+    from freight_fate.states.main_menu import MainMenuState, NameEntryState
+
+    app = App()
+    try:
+        app.push_state(MainMenuState(app.ctx))
+        while app.state.items[app.state.index].text != "New career":
+            app.state.handle_event(key_event(pygame.K_DOWN))
+        app.state.handle_event(key_event(pygame.K_RETURN))
+        assert isinstance(app.state, NameEntryState)
+        app.state.handle_event(key_event(pygame.K_RETURN))  # default name
+        assert isinstance(app.state, CityMenuState)
+        p = app.ctx.profile
+        p.money = 200_000.0
+
+        # city -> garage -> upgrades
+        while not app.state.items[app.state.index].text.startswith("Garage"):
+            app.state.handle_event(key_event(pygame.K_DOWN))
+        app.state.handle_event(key_event(pygame.K_RETURN))
+        assert isinstance(app.state, GarageState)
+        while app.state.items[app.state.index].text != "Upgrades":
+            app.state.handle_event(key_event(pygame.K_DOWN))
+        app.state.handle_event(key_event(pygame.K_RETURN))
+        assert isinstance(app.state, UpgradeShopState)
+
+        # buy engine tune tier 1, then tier 2; a third press must not charge
+        shop = app.state
+        while "Engine tune" not in shop.items[shop.index].text:
+            shop.handle_event(key_event(pygame.K_DOWN))
+        shop.handle_event(key_event(pygame.K_RETURN))
+        assert p.upgrades.get("engine_tune") == 1
+        shop.handle_event(key_event(pygame.K_RETURN))
+        assert p.upgrades.get("engine_tune") == 2
+        money_after_tiers = p.money
+        shop.handle_event(key_event(pygame.K_RETURN))
+        assert p.upgrades.get("engine_tune") == 2
+        assert p.money == money_after_tiers
+        assert "owned" in shop.items[shop.index].text
+
+        # back to garage, then the truck shop
+        shop.handle_event(key_event(pygame.K_ESCAPE))
+        assert isinstance(app.state, GarageState)
+        while app.state.items[app.state.index].text != "Trucks":
+            app.state.handle_event(key_event(pygame.K_DOWN))
+        app.state.handle_event(key_event(pygame.K_RETURN))
+        assert isinstance(app.state, TruckShopState)
+
+        trucks = app.state
+        while "Heavy hauler" not in trucks.items[trucks.index].text:
+            trucks.handle_event(key_event(pygame.K_DOWN))
+        money_before = p.money
+        trucks.handle_event(key_event(pygame.K_RETURN))
+        assert p.truck == "heavy_hauler"
+        assert "heavy_hauler" in p.owned_trucks
+        assert p.money == money_before - 52_000.0
+        assert "currently driving" in trucks.items[trucks.index].text
+
+        # switch back to the standard rig (already owned, no charge)
+        money_before = p.money
+        while "Standard rig" not in trucks.items[trucks.index].text:
+            trucks.handle_event(key_event(pygame.K_DOWN))
+        trucks.handle_event(key_event(pygame.K_RETURN))
+        assert p.truck == "rig"
+        assert p.money == money_before
+    finally:
+        app.shutdown()
+
+
+@pytest.mark.smoke
+def test_upgrades_are_money_gated():
+    from freight_fate.app import App
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.city import UpgradeShopState
+
+    app = App()
+    try:
+        app.ctx.profile = Profile(name="Broke")
+        app.ctx.profile.money = 10.0
+        app.push_state(UpgradeShopState(app.ctx))
+        shop = app.state
+        shop.handle_event(key_event(pygame.K_RETURN))
+        assert app.ctx.profile.upgrades == {}
+        assert app.ctx.profile.money == 10.0
+    finally:
+        app.shutdown()
+
+
+@pytest.mark.smoke
 def test_pause_and_abandon_returns_to_city():
     from freight_fate.app import App
     from freight_fate.states.city import CityMenuState

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -35,10 +35,14 @@ def test_full_game_flow_headless():
         assert app.ctx.profile is not None
         assert app.ctx.profile.name == "Smoke"
 
-        # open job board, accept the first job
+        # open job board, accept the first job we hold the endorsement for
+        # (the board may show one locked "teaser" job, sometimes sorted first)
         app.state.handle_event(key_event(pygame.K_RETURN))
         assert isinstance(app.state, JobBoardState)
         assert app.state.jobs
+        board = app.state
+        while board.jobs[board.index].cargo.endorsement:
+            board.handle_event(key_event(pygame.K_DOWN))
         app.state.handle_event(key_event(pygame.K_RETURN))
         assert isinstance(app.state, RouteSelectState)
         app.state.handle_event(key_event(pygame.K_RETURN))
@@ -209,6 +213,9 @@ def test_pause_and_abandon_returns_to_city():
         assert isinstance(app.state, NameEntryState)
         app.state.handle_event(key_event(pygame.K_RETURN))  # default name
         app.state.handle_event(key_event(pygame.K_RETURN))  # job board
+        board = app.state
+        while board.jobs[board.index].cargo.endorsement:  # skip locked teasers
+            board.handle_event(key_event(pygame.K_DOWN))
         app.state.handle_event(key_event(pygame.K_RETURN))  # accept job
         app.state.handle_event(key_event(pygame.K_RETURN))  # pick route
         assert isinstance(app.state, DrivingState)

--- a/tests/test_trucks.py
+++ b/tests/test_trucks.py
@@ -1,0 +1,162 @@
+"""Truck catalog, garage upgrades, and their effects on the physics model."""
+
+from freight_fate.models.profile import Profile
+from freight_fate.models.trucks import (
+    TRUCK_CATALOG,
+    UPGRADE_CATALOG,
+    build_truck_specs,
+)
+from freight_fate.sim.vehicle import TruckSpecs, TruckState
+
+
+def drive(truck: TruckState, seconds: float, dt: float = 1 / 60) -> None:
+    for _ in range(int(seconds / dt)):
+        truck.auto_shift()
+        truck.update(dt)
+
+
+def make_auto_truck(specs: TruckSpecs) -> TruckState:
+    t = TruckState(specs=specs)
+    t.transmission.automatic = True
+    t.start_engine()
+    return t
+
+
+# -- spec building ---------------------------------------------------------------
+
+def test_no_upgrades_returns_base_specs():
+    assert build_truck_specs("rig", {}) == TruckSpecs()
+
+
+def test_unknown_truck_falls_back_to_rig():
+    assert build_truck_specs("hover_truck", {}) == TruckSpecs()
+
+
+def test_engine_tune_adds_ten_percent_torque_per_tier():
+    base = TruckSpecs()
+    t1 = build_truck_specs("rig", {"engine_tune": 1})
+    t2 = build_truck_specs("rig", {"engine_tune": 2})
+    assert abs(t1.max_torque_nm - base.max_torque_nm * 1.1) < 1e-6
+    assert abs(t2.max_torque_nm - base.max_torque_nm * 1.2) < 1e-6
+
+
+def test_aero_kit_cuts_drag_twelve_percent():
+    base = TruckSpecs()
+    s = build_truck_specs("rig", {"aero_kit": 1})
+    assert abs(s.drag_coefficient - base.drag_coefficient * 0.88) < 1e-9
+
+
+def test_long_range_tank_adds_fifty_gallons():
+    s = build_truck_specs("rig", {"long_range_tank": 1})
+    assert s.fuel_tank_gal == TruckSpecs().fuel_tank_gal + 50.0
+
+
+def test_reinforced_brakes_raise_fade_threshold():
+    s = build_truck_specs("rig", {"reinforced_brakes": 1})
+    assert s.brake_fade_temp_c > TruckSpecs().brake_fade_temp_c
+
+
+def test_upgrades_stack():
+    s = build_truck_specs("rig", {"engine_tune": 2, "aero_kit": 1,
+                                  "long_range_tank": 1, "reinforced_brakes": 1})
+    base = TruckSpecs()
+    assert s.max_torque_nm > base.max_torque_nm
+    assert s.drag_coefficient < base.drag_coefficient
+    assert s.fuel_tank_gal > base.fuel_tank_gal
+    assert s.brake_fade_temp_c > base.brake_fade_temp_c
+
+
+def test_heavy_hauler_tradeoffs():
+    rig = TRUCK_CATALOG["rig"].specs
+    hauler = TRUCK_CATALOG["heavy_hauler"].specs
+    assert hauler.max_torque_nm > rig.max_torque_nm
+    assert hauler.fuel_tank_gal > rig.fuel_tank_gal
+    assert hauler.drag_coefficient > rig.drag_coefficient
+    assert hauler.fuel_burn_factor > rig.fuel_burn_factor
+
+
+def test_heavy_hauler_upgrades_apply_on_top():
+    s = build_truck_specs("heavy_hauler", {"long_range_tank": 1})
+    assert s.fuel_tank_gal == TRUCK_CATALOG["heavy_hauler"].specs.fuel_tank_gal + 50.0
+
+
+# -- physics effects ---------------------------------------------------------------
+
+def test_engine_tune_accelerates_faster():
+    stock = make_auto_truck(build_truck_specs("rig", {}))
+    tuned = make_auto_truck(build_truck_specs("rig", {"engine_tune": 2}))
+    for t in (stock, tuned):
+        t.throttle = 1.0
+        drive(t, 45)
+    assert tuned.velocity_mps > stock.velocity_mps
+
+
+def test_aero_kit_raises_cruise_speed():
+    stock = make_auto_truck(build_truck_specs("rig", {}))
+    sleek = make_auto_truck(build_truck_specs("rig", {"aero_kit": 1}))
+    for t in (stock, sleek):
+        t.throttle = 1.0
+        drive(t, 120)
+    assert sleek.velocity_mps > stock.velocity_mps
+
+
+def test_reinforced_brakes_resist_fade_when_hot():
+    stock = TruckState()
+    upgraded = TruckState(specs=build_truck_specs("rig", {"reinforced_brakes": 1}))
+    for t in (stock, upgraded):
+        t.velocity_mps = 25.0
+        t.brake = 1.0
+        t.brake_temp_c = 480.0  # past stock fade onset, below upgraded onset
+    assert upgraded.brake_force() > stock.brake_force()
+
+
+def test_heavy_hauler_burns_more_fuel():
+    rig = make_auto_truck(build_truck_specs("rig", {}))
+    hauler = make_auto_truck(build_truck_specs("heavy_hauler", {}))
+    for t in (rig, hauler):
+        t.fuel_gal = 50.0
+        t.velocity_mps = 25.0
+        t.throttle = 0.0  # idle burn isolates the model's thirst factor
+        t._update_fuel(60.0)
+    assert hauler.fuel_gal < rig.fuel_gal
+
+
+# -- profile persistence ------------------------------------------------------------
+
+def test_profile_persists_truck_and_upgrades():
+    p = Profile(name="Garage Test")
+    p.truck = "heavy_hauler"
+    p.owned_trucks = ["rig", "heavy_hauler"]
+    p.upgrades = {"engine_tune": 2, "aero_kit": 1}
+    path = p.save()
+    loaded = Profile.load(path)
+    assert loaded.truck == "heavy_hauler"
+    assert loaded.owned_trucks == ["rig", "heavy_hauler"]
+    assert loaded.upgrades == {"engine_tune": 2, "aero_kit": 1}
+    specs = loaded.truck_specs()
+    hauler = TRUCK_CATALOG["heavy_hauler"].specs
+    assert abs(specs.max_torque_nm - hauler.max_torque_nm * 1.2) < 1e-6
+
+
+def test_old_save_without_truck_fields_loads_with_defaults():
+    p = Profile(name="Legacy")
+    path = p.save()
+    import json
+
+    data = json.loads(path.read_text())
+    for legacy_missing in ("truck", "owned_trucks", "upgrades", "market"):
+        data.pop(legacy_missing, None)
+    path.write_text(json.dumps(data))
+    loaded = Profile.load(path)
+    assert loaded.truck == "rig"
+    assert loaded.owned_trucks == ["rig"]
+    assert loaded.upgrades == {}
+    assert loaded.market.multipliers  # fresh market seeded on load
+
+
+def test_upgrade_catalog_prices_and_tiers():
+    assert UPGRADE_CATALOG["engine_tune"].max_tier == 2
+    for upgrade in UPGRADE_CATALOG.values():
+        assert upgrade.max_tier >= 1
+        assert all(price > 0 for price in upgrade.prices)
+        assert upgrade.description

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,28 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -86,6 +108,111 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -229,13 +356,14 @@ wheels = [
 
 [[package]]
 name = "freight-fate"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "prismatoid" },
     { name = "pygame" },
+    { name = "sound-lib" },
 ]
 
 [package.dev-dependencies]
@@ -251,6 +379,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26" },
     { name = "prismatoid", specifier = ">=0.16" },
     { name = "pygame", specifier = ">=2.6" },
+    { name = "sound-lib", specifier = "==0.8.8" },
 ]
 
 [package.metadata.requires-dev]
@@ -262,12 +391,151 @@ dev = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "libloader"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/dd/58864bd93f74cd227996cec701713e27f6a57b1c189747cfefc9c9c2e00e/libloader-1.4.3.tar.gz", hash = "sha256:9c56b1ee2e866e314c35d1095d1e3b99c1c762e89a27bf26c98bd65d58f4e182", size = 6165, upload-time = "2026-01-14T03:18:21.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/cb/dac60d530791146d52e2dab3a16531963d03899ea37eec77cc03ea8c281d/libloader-1.4.3-py3-none-any.whl", hash = "sha256:4cfd541496bed79a2b5f72c316e16312ce1dd72fab6ed837801aa5e53299d6da", size = 6190, upload-time = "2026-01-14T03:18:20.84Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/da/dbe4dfc01ac226fb0504fad035f4d69f3202f3502e20e68537631daddd96/lxml-6.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09dd5b7075dc2f7709654a46543ba1ea3c2e217b2ed8fbd413a8a945a0f40f60", size = 8541124, upload-time = "2026-05-18T19:17:11.589Z" },
+    { url = "https://files.pythonhosted.org/packages/78/20/f7095ed9fc2c025f9cfe71cc6ec9f1feb05624edc1812423b5f1aecf3d4b/lxml-6.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6ac4ef4d82dff54670227a69c67782ae0b811b5cf6b17954f1e8f7502fc0d1d", size = 4602783, upload-time = "2026-05-18T19:17:20.888Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a4/65c63ca98bd129f6cff7b8c2fa48953ab058cc6005b541354e7dd54d8000/lxml-6.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:556e94a63c9b04716f8e4de2abb65775061f846e89331b6c5be79183a24f98ea", size = 5002687, upload-time = "2026-05-18T19:17:01.738Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1d/ab7a5c4b5a394d98a94e2d0fc67bab8297597426770dd4978370fbdaf531/lxml-6.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6bf403fbb3b3e348a561a5f4f0b9961835657981c802a1df03653eef8a9074", size = 5155099, upload-time = "2026-05-18T19:17:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b1/07603bfeeb891a2596d5c2a68f7d2f70f7d11c841ebe391412c69c2857b0/lxml-6.1.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dde6131244bba38a17c745836ba190bc753fd73c9291666287fd0a3fa3dcf30", size = 5057225, upload-time = "2026-05-18T19:17:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/16/cb391ee4b90186fa16d9ebcbe3ea96c71b8da3b0686386c8dcbcc3c67d44/lxml-6.1.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98fc784c2c1440667aeedf8465bdfe10208acf0ead656a2c68627299f546b315", size = 5287643, upload-time = "2026-05-18T19:17:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d6/b619717f918fd76747448fdbaee0e769edbc70e659b5b5d0112b7020b7a3/lxml-6.1.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:add8cf6ddf9a65116119a28ece0f7886e30af27ba724a7594305f1d1b58a92a1", size = 5412445, upload-time = "2026-05-18T19:17:22.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/12bc5390ac0a3edeb579d9535e5049a5dda663438728e179d52fb319c33a/lxml-6.1.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cf9d57306d848218f3601fee7601fab1a327c942d56e2e97610583cb4dd74206", size = 4770864, upload-time = "2026-05-18T19:17:26.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/6500c09da3137f54f020e908d81cfc5ee3e8888e908fd380207afad7c2e6/lxml-6.1.1-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88136950da4d13c318bde414ce10219931937851327f44328f2df4d2c4614067", size = 5359594, upload-time = "2026-05-18T19:17:32.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9b/f64b4cc6b7ebcf75d95af3cde934d254b5f2f10d4163928d838d86b6eb48/lxml-6.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cecdd5dfdc87b1fd87dbf81d4b037a544f47f4c744200a67013771682d67686a", size = 5107713, upload-time = "2026-05-18T19:17:04.402Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/c7388ad5d3a72315d2832dc1458cbf4f2af7f2b990b606ff4876efd04511/lxml-6.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd312b9692e831d2ffcad61eab31d91d4b4655a962e61de8fb410472cbcd37aa", size = 4803973, upload-time = "2026-05-18T19:17:06.545Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/76197f0bbf165f0b9e75be59be4997e5259cde973f12f098c1b54c7f5d60/lxml-6.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b7328b46d49fc9477d91ae8f6d55340347d827b7734ba3ea33faae0efef1383", size = 5349925, upload-time = "2026-05-18T19:17:09.743Z" },
+    { url = "https://files.pythonhosted.org/packages/24/52/d2a0cfeccb9bcdc47c7ee05cdae5d69b48c9acf20997790a6338bb0d0b3b/lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1", size = 5309825, upload-time = "2026-05-18T19:17:13.831Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4a/b30944266776c2f49749ef2445aa7e78898194134b80ad776386f61b56ae/lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a", size = 3598402, upload-time = "2026-05-18T19:17:08.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/97/33691c66a4d7ec1a5a98e7c909a5b83ee45c7f7ba4cf92b1c4cf26e98079/lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5", size = 4021295, upload-time = "2026-05-18T19:17:28.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5f/26a4dd0e12b9456ff7b12a21af5b491eb6629680d1edd73f4140fd386bcf/lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485", size = 3667717, upload-time = "2026-05-19T19:22:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461, upload-time = "2026-05-18T19:17:25.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375, upload-time = "2026-05-18T19:17:34.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654, upload-time = "2026-05-18T19:17:42.917Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921, upload-time = "2026-05-18T19:17:49.175Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3c/c0690d74bd2bc17bc03b5b0d093569ead597dd0bfa088bf99eef8c24e19c/lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d", size = 5002456, upload-time = "2026-05-18T19:17:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776, upload-time = "2026-05-18T19:18:08.924Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/689824ffb237fd10125ad273f32b28ff04dc6203c2822c85ff65a93df65e/lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009", size = 5329945, upload-time = "2026-05-18T19:18:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237, upload-time = "2026-05-18T19:18:18.657Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904, upload-time = "2026-05-18T19:18:24.883Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/16/8687e5d1400ed1c0bc41dace232ebb7553952b618ea1f2e5fb6e2cfbbe23/lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83", size = 5045225, upload-time = "2026-05-18T19:17:20.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721, upload-time = "2026-05-18T19:17:40.512Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549, upload-time = "2026-05-18T19:17:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877, upload-time = "2026-05-18T19:18:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/00/84c4b5302d42a2d0184f38d538c8a197f33b52a50bd4f7bcfe990bce3036/lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621", size = 3594072, upload-time = "2026-05-18T19:17:12.714Z" },
+    { url = "https://files.pythonhosted.org/packages/61/9d/2e2f7d876349f45e0f3e29f72da311668853d59b58d473a2dea4f0160135/lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28", size = 4025469, upload-time = "2026-05-18T19:17:50.566Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/570e6390e4110331e6208b2ba83d1482cc9146808ee118b22824a34c1070/lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b", size = 3667640, upload-time = "2026-05-19T19:22:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/32/86a3f0f724a3a402d4627937a7fc27b160e45e7012b4adf47f6e1e844511/lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e", size = 3930127, upload-time = "2026-05-18T19:19:02.27Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/d832e82af08723761556d004b1d04d281c09f9a8cecd7d3148548c9941a3/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004", size = 4210769, upload-time = "2026-05-18T19:20:41.427Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163, upload-time = "2026-05-18T19:20:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
 ]
 
 [[package]]
@@ -424,6 +692,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "platform-utils"
+version = "1.5.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/9b/cb3a9d71f5ca4d56bbb82bb2c63dbe8065f1927224e7a4f1727e7170f12c/platform_utils-1.5.10.tar.gz", hash = "sha256:537c62c4a69a949a5232d302fbc41798b44d167a93cc97579a74fa8718314f83", size = 12664, upload-time = "2025-08-31T22:48:34.633Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/af/425727da8f3a9c15ed6f42fc34a7fbe35dcae8bd76e7f24aaf6e3085b060/platform_utils-1.5.10-py3-none-any.whl", hash = "sha256:00cf7b5c7196347180de0f15769a4b152c65bccee13e5fdfaa3211f849e1d0ad", size = 9401, upload-time = "2025-08-31T22:48:33.497Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -601,6 +891,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387, upload-time = "2026-06-04T07:49:14.329Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780, upload-time = "2026-06-04T07:49:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203, upload-time = "2026-06-04T07:49:18.993Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
@@ -626,6 +956,23 @@ wheels = [
 ]
 
 [[package]]
+name = "sound-lib"
+version = "0.8.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "libloader" },
+    { name = "lxml" },
+    { name = "platform-utils" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/cb/d2f27c25c14bc8e37bc9028ca8ce637b09a12c1bccab8e162ff354e98c56/sound_lib-0.8.8.tar.gz", hash = "sha256:c4a8048df957265c882a10b18c33665ccb03b4657e9190079181cf8529f9ce08", size = 4891177, upload-time = "2026-01-15T07:46:45.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/cd/512551d923ef9d1f20948b671843b6f23935ac9613cbb7eca4bc212f3f8d/sound_lib-0.8.8-py3-none-any.whl", hash = "sha256:e52167b9c66d13a16ff6ad40c00fe0e3afdf768de8b6470aa2af03f34320818b", size = 4915761, upload-time = "2026-01-15T07:46:48.188Z" },
+]
+
+[[package]]
 name = "soundfile"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -645,6 +992,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/34/c9e80783d83eab739a9531fdee03675d53e0bf1b2ccb4bb3af5844675046/soundfile-0.14.0-py2.py3-none-win32.whl", hash = "sha256:0a6ae43c50c71b4e020cc55382925cb89451c1ed1a0c3d0f5d802da269226849", size = 902199, upload-time = "2026-06-06T08:58:43.289Z" },
     { url = "https://files.pythonhosted.org/packages/ed/97/b39c18ac1df45e755ca22b8b00e872929da5d107998a207a5e4ac831bfda/soundfile-0.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:299491d3499460fb1b74bb4bd78b57ffc2d243a5fafa7b6ec1b264875c78453e", size = 1021480, upload-time = "2026-06-06T08:58:45.016Z" },
     { url = "https://files.pythonhosted.org/packages/f4/83/55c65e61cf457805ce2ec157c1c6ae17715d0851aa2374422de0538838ca/soundfile-0.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:e090704718e124e7c844695236f1fce8d18a5e761eaf7c82dfcd124620805f98", size = 888858, upload-time = "2026-06-06T08:58:46.593Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -702,12 +1058,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.68.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two workstreams for the 1.2.0 release.

### Audio engine upgrade (pygame.mixer -> sound_lib/BASS)

- Adds `sound_lib==0.8.8`, **pinned exactly**: PyPI's version ordering for this package is broken — `0.83` (2022) sorts above `0.8.8` (2026) — so any unpinned install resolves to the stale build that ships no Linux library. A comment in `pyproject.toml` guards the pin.
- `AudioEngine` keeps its public API and becomes a facade over interchangeable backends. Callers (`states/*`, `app.py`) are untouched.
- **BASS backend:** the four-band engine crossfade is replaced by a single engine loop whose playback frequency tracks RPM in real time via `BASS_ChannelSlideAttribute` on `BASS_ATTRIB_FREQ` (600 RPM -> 1.0x base frequency, 2200 RPM -> 2.2x, 120 ms slides). Loops and music fade via volume slides; one-shots are autofreed streams.
- **pygame.mixer fallback:** kept verbatim (including the band assets) and selected automatically when sound_lib/BASS fails to initialize; `FREIGHT_FATE_AUDIO_BACKEND=pygame` forces it.
- **Headless CI:** with `SDL_AUDIODRIVER=dummy` (or when no device exists) the BASS backend initializes the "no sound" device, so the whole pipeline runs silently and all tests stay headless-safe with `FREIGHT_FATE_NO_SPEECH=1`.
- README documents the **BASS license caveat**: free for non-commercial use; a paid un4seen license is required if the game is ever sold.

### Progression depth

- **Garage -> Upgrades** (money-gated, persisted on the profile): engine tune (+10% torque per tier, 2 tiers), aerodynamic kit (-12% drag), long-range tank (+50 gal), reinforced brakes (fade onset +150 °C). `build_truck_specs()` applies them when `DrivingState` builds the truck.
- **Garage -> Trucks**: the heavy hauler — +25% torque and a 200-gallon tank, but worse drag and a 1.2x fuel-burn factor. Owned trucks are switchable at any garage; fuel clamps to the new tank.
- **Freight market**: per-cargo-class multipliers (0.8–1.3) drifting each in-game day with a seeded random walk persisted in the profile. Day-stepped and jump advances are deterministic and identical. Job pay applies the multiplier, job descriptions speak "Market is hot/cold", and the job board opens with a market watch headline.
- Accessibility: every new menu is fully spoken with prices and owned state (Prism only), F1 help everywhere, and the in-game manual gains a garage page.

### Housekeeping

- Version 1.2.0 (`pyproject.toml`, `__init__.py`), CHANGELOG and ROADMAP updated, save format v2 (older saves load with defaults).

## Testing

- 111 tests pass headless on Windows (`uv run pytest`), under **both** backends (default BASS and `FREIGHT_FATE_AUDIO_BACKEND=pygame`).
- New coverage: backend selection and pygame fallback when BASS init fails, the RPM->frequency mapping, no-sound device selection, upgrade effects on specs *and* physics (acceleration, cruise speed, brake fade, fuel burn), market bounds/determinism/divergence/persistence, market-scaled job pay, and end-to-end garage purchase flows via the smoke-test harness.
- `uv run ruff check src tests tools` clean; `actionlint` clean on the workflow; `uv build` produces the 1.2.0 wheel and sdist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)