### PR TITLE
Fix BASS one-shots and fade-outs cut off by garbage collection

### DIFF
--- a/src/freight_fate/audio.py
+++ b/src/freight_fate/audio.py
@@ -266,6 +266,7 @@ class _BassBackend:
         self.sfx_volume = 0.8
         self.music_volume = 0.55
         self._loops: dict[int, tuple[str, float, object]] = {}  # slot -> (key, gain, stream)
+        self._retained: list = []  # streams kept alive until BASS finishes them
         self._music_track: str | None = None
         self._music_stream = None
         self._engine_running = False
@@ -309,6 +310,24 @@ class _BassBackend:
             return None
         return self._stream(path, looping)
 
+    def _retain(self, stream) -> None:
+        """Keep a reference until BASS finishes with the stream.
+
+        ``Channel.__del__`` frees the BASS handle when the Python object is
+        garbage collected, which would cut one-shots and fade-outs short the
+        moment the last reference is dropped. Finished streams (autofreed by
+        BASS) are pruned on each call.
+        """
+        alive = []
+        for s in self._retained:
+            try:
+                if s.is_playing:
+                    alive.append(s)
+            except self._BassError:
+                pass  # already stopped and autofreed
+        alive.append(stream)
+        self._retained = alive
+
     def _fade_out(self, stream, fade_ms: int) -> None:
         """Slide volume to -1: BASS stops (and autofrees) the channel at 0."""
         try:
@@ -316,6 +335,8 @@ class _BassBackend:
                             -1.0, max(0, int(fade_ms)))
         except self._BassError:
             log.debug("Fade-out failed; stream already gone", exc_info=True)
+            return
+        self._retain(stream)  # keep it alive for the duration of the fade
 
     # -- one-shots ----------------------------------------------------------
 
@@ -328,6 +349,8 @@ class _BassBackend:
             stream.play()
         except self._BassError:
             log.warning("Could not play %s", key, exc_info=True)
+            return
+        self._retain(stream)
 
     # -- loops on reserved slots ------------------------------------------------
 
@@ -488,6 +511,7 @@ class _BassBackend:
             self.stop_loop(ch, fade_ms=0)
         self.engine_stop(shutdown_sound=False)
         self.stop_music(fade_ms=0)
+        self._retained.clear()
         with contextlib.suppress(self._BassError):
             self._output.free()
         self.enabled = False

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -89,6 +89,42 @@ def test_bass_engine_uses_single_pitched_loop(monkeypatch):
     a.shutdown()
 
 
+def test_bass_one_shots_survive_garbage_collection(monkeypatch):
+    # Channel.__del__ in sound_lib frees the BASS handle on garbage
+    # collection; the backend must hold a reference until playback ends,
+    # or every one-shot (menu sounds, horn, warnings) is cut off instantly
+    import gc
+
+    monkeypatch.delenv("FREIGHT_FATE_AUDIO_BACKEND", raising=False)
+    a = AudioEngine()
+    if a.backend_name != "bass":
+        pytest.skip("BASS backend unavailable")
+    impl = a._impl
+    a.play("ui/menu_move")
+    gc.collect()
+    assert impl._retained
+    assert impl._retained[-1].is_playing
+    a.shutdown()
+
+
+def test_bass_fading_loops_stay_alive_during_fade(monkeypatch):
+    import gc
+
+    monkeypatch.delenv("FREIGHT_FATE_AUDIO_BACKEND", raising=False)
+    a = AudioEngine()
+    if a.backend_name != "bass":
+        pytest.skip("BASS backend unavailable")
+    impl = a._impl
+    a.set_weather("weather/rain_light", 0.8)
+    assert impl._loops
+    a.set_weather(None)  # 1200 ms fade-out
+    gc.collect()
+    assert not impl._loops
+    assert impl._retained
+    assert impl._retained[-1].is_playing  # still fading, not cut off
+    a.shutdown()
+
+
 def test_bass_headless_uses_no_sound_device(monkeypatch):
     # conftest sets SDL_AUDIODRIVER=dummy, which must route BASS to the
     # "no sound" device so CI runs the full pipeline without hardware


### PR DESCRIPTION
## Summary

sound_lib's `Channel.__del__` frees the BASS handle when the Python object is garbage collected. The BASS backend created a fresh stream per one-shot and dropped the reference right after `play()`, so CPython freed the handle instantly — every one-shot (menu move/select/back ticks, horn, hazard warnings, engine start/shutdown) was silenced at birth. The same flaw cut fade-outs short: `stop_loop`/`stop_music` dropped the reference right after starting the volume slide, so weather, road noise, and music stopped abruptly instead of fading.

## Fix

The backend now retains each one-shot and each fading stream in a `_retained` list until BASS reports playback finished; autofreed (finished) streams are pruned on the next retain. Cleared on shutdown.

## Testing

- Two regression tests force `gc.collect()` right after `play()` / fade-out and assert the stream is still playing (they fail on the previous code).
- 113 tests pass headless under both backends (default BASS and `FREIGHT_FATE_AUDIO_BACKEND=pygame`); ruff clean.
- Verified by ear in-game on Windows with NVDA: menu sounds are back and fades are smooth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)