### PR TITLE
Make saves portable: store everything in the game directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ live_*.txt
 
 # Release packaging
 tools/_entry.py
+
+# Portable save data (lives in the game directory)
+saves/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Portable saves.** Profiles and settings now live in a `saves` folder
+  inside the game's own directory (next to the executable in release
+  builds, the project root from source) instead of the per-user data
+  directory. Existing saves are migrated over automatically on first
+  launch; the originals are left in place. `FREIGHT_FATE_DATA_DIR`
+  still overrides the location.
+
 ## 1.5.0 — 2026-06-10
 
 "On the Clock": hours of service, fatigue, day and night, and overnight

--- a/src/freight_fate/models/profile.py
+++ b/src/freight_fate/models/profile.py
@@ -1,7 +1,13 @@
 """Player profile with atomic JSON save/load.
 
-Profiles live in the per-user data directory (override with the
-``FREIGHT_FATE_DATA_DIR`` environment variable, which the tests use).
+Freight Fate is portable: profiles and settings live in a ``saves``
+directory inside the game's own main directory — next to the executable
+in frozen builds, the project root when running from source. Nothing is
+written to per-user system folders. Override the location with the
+``FREIGHT_FATE_DATA_DIR`` environment variable (which the tests use).
+Saves from older versions, which lived in the per-user data directory,
+are migrated over automatically on first run.
+
 Saves are atomic: written to a temp file, then renamed over the old save,
 so a crash mid-write can never corrupt an existing profile.
 """
@@ -10,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -22,11 +29,11 @@ SAVE_VERSION = 3
 STARTING_MONEY = 5_000.0
 DEFAULT_CITY = "Chicago"
 
+_legacy_checked = False
 
-def data_dir() -> Path:
-    override = os.environ.get("FREIGHT_FATE_DATA_DIR")
-    if override:
-        return Path(override)
+
+def _legacy_data_dir() -> Path:
+    """Where saves lived before the portable layout (per-user folders)."""
     if sys.platform == "win32":
         base = Path(os.environ.get("APPDATA", Path.home()))
     elif sys.platform == "darwin":
@@ -34,6 +41,37 @@ def data_dir() -> Path:
     else:
         base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
     return base / "FreightFate"
+
+
+def game_root() -> Path:
+    """The game's main directory: the executable's directory when frozen,
+    the project root when running from source."""
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return Path(__file__).resolve().parents[3]
+
+
+def _migrate_legacy(target: Path) -> None:
+    """One-time copy of an old per-user save folder into the portable one."""
+    legacy = _legacy_data_dir()
+    if target.exists() or not legacy.is_dir():
+        return
+    try:
+        shutil.copytree(legacy, target)
+    except OSError:
+        pass  # never block startup on a migration; old saves stay where they are
+
+
+def data_dir() -> Path:
+    override = os.environ.get("FREIGHT_FATE_DATA_DIR")
+    if override:
+        return Path(override)
+    global _legacy_checked
+    portable = game_root() / "saves"
+    if not _legacy_checked:
+        _legacy_checked = True
+        _migrate_legacy(portable)
+    return portable
 
 
 def profiles_dir() -> Path:

--- a/tests/test_portable_saves.py
+++ b/tests/test_portable_saves.py
@@ -1,0 +1,65 @@
+"""Portable save layout: game-directory storage and legacy migration."""
+
+import sys
+from pathlib import Path
+
+from freight_fate.models import profile as profile_mod
+
+
+def _reset(monkeypatch, tmp_path, game_dir=None, legacy_dir=None):
+    """Point both roots at controlled temp locations."""
+    monkeypatch.delenv("FREIGHT_FATE_DATA_DIR", raising=False)
+    monkeypatch.setattr(profile_mod, "_legacy_checked", False)
+    game = game_dir or tmp_path / "game"
+    game.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(profile_mod, "game_root", lambda: game)
+    legacy = legacy_dir or tmp_path / "appdata"
+    monkeypatch.setattr(profile_mod, "_legacy_data_dir", lambda: legacy / "FreightFate")
+    return game, legacy / "FreightFate"
+
+
+def test_env_override_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("FREIGHT_FATE_DATA_DIR", str(tmp_path / "custom"))
+    assert profile_mod.data_dir() == tmp_path / "custom"
+
+
+def test_data_dir_is_saves_inside_game_root(monkeypatch, tmp_path):
+    game, _ = _reset(monkeypatch, tmp_path)
+    assert profile_mod.data_dir() == game / "saves"
+
+
+def test_game_root_when_frozen(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(Path("C:/Games/FreightFate/FreightFate.exe")))
+    assert profile_mod.game_root() == Path("C:/Games/FreightFate")
+
+
+def test_game_root_from_source_is_project_root():
+    root = profile_mod.game_root()
+    assert (root / "src" / "freight_fate").is_dir()
+
+
+def test_legacy_saves_migrate_once(monkeypatch, tmp_path):
+    game, legacy = _reset(monkeypatch, tmp_path)
+    old_profile = legacy / "profiles" / "Driver.json"
+    old_profile.parent.mkdir(parents=True)
+    old_profile.write_text("{}", encoding="utf-8")
+    (legacy / "settings.json").write_text("{}", encoding="utf-8")
+
+    target = profile_mod.data_dir()
+    assert (target / "profiles" / "Driver.json").is_file()
+    assert (target / "settings.json").is_file()
+    assert old_profile.is_file()  # originals are left in place
+
+
+def test_migration_never_overwrites_portable_saves(monkeypatch, tmp_path):
+    game, legacy = _reset(monkeypatch, tmp_path)
+    (legacy / "profiles").mkdir(parents=True)
+    (legacy / "profiles" / "Old.json").write_text("{}", encoding="utf-8")
+    existing = game / "saves" / "profiles"
+    existing.mkdir(parents=True)
+    (existing / "Current.json").write_text("{}", encoding="utf-8")
+
+    target = profile_mod.data_dir()
+    assert (target / "profiles" / "Current.json").is_file()
+    assert not (target / "profiles" / "Old.json").exists()


### PR DESCRIPTION
Profiles and settings move from the per-user data directory (APPDATA, Application Support, XDG) to a `saves` folder inside the game''s own main directory: the executable''s directory in frozen builds, the project root from source. `FREIGHT_FATE_DATA_DIR` still overrides (tests rely on it).

Legacy per-user saves are copied over automatically on first run — never overwriting portable saves, never deleting the originals.

All 191 tests pass (6 new: portable resolution, frozen-build root, env override, migration, no-overwrite, originals preserved). Matches the portable layout just shipped in Saltwake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)