### PR TITLE
Fix construction-zone warning window for speech users

### DIFF
--- a/src/freight_fate/sim/trip.py
+++ b/src/freight_fate/sim/trip.py
@@ -23,6 +23,8 @@ NIGHT_HAZARD_BONUS = 0.10          # extra hazard risk after dark
 NIGHT_TRAFFIC_KEEP = 0.4           # chance a traffic zone still forms at night
 TRAFFIC_LOOKAHEAD_MI = 2.5
 TRAFFIC_WARNING_GAP_S = 2.2
+ZONE_WARNING_LOOKAHEAD_MI = 2.0
+CONSTRUCTION_ENFORCEMENT_GRACE_MI = 1.0
 
 # Hazards that can appear anywhere in the country...
 GENERIC_HAZARDS = ("debris on the road", "a slow vehicle ahead",
@@ -179,6 +181,8 @@ class Trip:
         self._announced_navigation: set[str] = set()
         self._charged_tolls: set[str] = set()
         self._active_zone: Zone | None = None
+        self._announced_zone_warnings: set[str] = set()
+        self._construction_zone_grace_start: dict[str, float] = {}
         self._hazard_check_mi = 5.0
         self._inspection_check_mi = 10.0
         self._traffic_warning_mi = 1.0
@@ -614,6 +618,18 @@ class Trip:
         self._events.append(TripEvent(kind, message, data))
 
     def _check_zones(self) -> None:
+        for zone in self.zones:
+            if zone.reason != "construction":
+                continue
+            key = _zone_key(zone)
+            ahead = zone.start_mi - self.position_mi
+            if 0 < ahead <= ZONE_WARNING_LOOKAHEAD_MI and key not in self._announced_zone_warnings:
+                self._announced_zone_warnings.add(key)
+                self._emit(
+                    TripEventKind.GPS_CUE,
+                    f"In {ahead:.0f} miles, construction ahead. Speed limit {zone.limit_mph:.0f}.",
+                    zone=zone,
+                )
         zone = None
         for z in self.zones:
             if z.start_mi <= self.position_mi <= z.end_mi:
@@ -621,10 +637,14 @@ class Trip:
                 break
         if zone is not self._active_zone:
             if zone is not None:
+                if zone.reason == "construction":
+                    self._construction_zone_grace_start[_zone_key(zone)] = zone.start_mi
                 self._emit(TripEventKind.ZONE_ENTER,
                            f"{zone.reason} ahead. Speed limit {zone.limit_mph:.0f}.",
                            zone=zone)
             elif self._active_zone is not None:
+                self._construction_zone_grace_start.pop(
+                    _zone_key(self._active_zone), None)
                 self._emit(TripEventKind.ZONE_EXIT,
                            f"End of {self._active_zone.reason} zone. "
                            f"Speed limit {BASE_SPEED_LIMIT_MPH:.0f}.")
@@ -804,6 +824,12 @@ class Trip:
 
         limit, reason = self.speed_limit_at(self.position_mi)
         if reason == "construction" and self.truck.speed_mph > limit + 9:
+            active_zone = self._active_zone
+            if active_zone is not None and active_zone.reason == "construction":
+                zone_key = _zone_key(active_zone)
+                grace_start = self._construction_zone_grace_start.get(zone_key, active_zone.start_mi)
+                if self.position_mi - grace_start < CONSTRUCTION_ENFORCEMENT_GRACE_MI:
+                    return
             key = f"construction:{round(self.position_mi)}"
             if key not in self._announced_enforcement:
                 self._announced_enforcement.add(key)
@@ -837,6 +863,10 @@ class Trip:
 
 def _stop_offset_for_direction(at_mi: float, leg_miles: float, forward: bool) -> float:
     return at_mi if forward else leg_miles - at_mi
+
+
+def _zone_key(zone: Zone) -> str:
+    return f"{zone.reason}:{zone.start_mi:.3f}:{zone.end_mi:.3f}:{zone.limit_mph:.0f}"
 
 
 def _fallback_grade(terrain: str, mile: float, highway: str) -> float:

--- a/tests/test_weather_trip.py
+++ b/tests/test_weather_trip.py
@@ -125,6 +125,61 @@ def test_zone_speed_limits_apply(world):
     assert reason is None or limit != zone.limit_mph
 
 
+def test_construction_zone_warns_before_entry(world):
+    trip, _ = make_trip(world, "Chicago", "Indianapolis", seed=12345)
+    zone = next(z for z in trip.zones if z.reason == "construction")
+
+    trip.position_mi = zone.start_mi - 2.0
+    events = trip.update(0.0)
+
+    warnings = [event.message for event in events if event.kind == TripEventKind.GPS_CUE]
+    assert warnings == [
+        f"In 2 miles, construction ahead. Speed limit {zone.limit_mph:.0f}."
+    ]
+
+
+def test_construction_zone_does_not_fine_on_entry_tick(world):
+    trip, truck = make_trip(world, "Chicago", "Indianapolis", seed=12345)
+    zone = next(z for z in trip.zones if z.reason == "construction")
+    truck.velocity_mps = 31.3   # about 70 mph
+
+    trip.position_mi = zone.start_mi - 0.2
+    moved_mi = 0.35
+    trip.position_mi += moved_mi
+    trip._check_zones()
+    trip._check_inspections(moved_mi)
+
+    kinds = [event.kind for event in trip._events]
+    assert TripEventKind.ZONE_ENTER in kinds
+    assert TripEventKind.INSPECTION not in kinds
+
+
+def test_construction_zone_speeding_fine_waits_for_grace_distance(world):
+    trip, truck = make_trip(world, "Chicago", "Indianapolis", seed=12345)
+    zone = next(z for z in trip.zones if z.reason == "construction")
+    truck.velocity_mps = 31.3   # about 70 mph
+
+    trip.position_mi = zone.start_mi - 2.0
+    advance = trip.update(0.0)
+    assert [event.message for event in advance if event.kind == TripEventKind.GPS_CUE] == [
+        f"In 2 miles, construction ahead. Speed limit {zone.limit_mph:.0f}."
+    ]
+
+    trip.position_mi = zone.start_mi + 0.3
+    trip._events = []
+    trip._check_zones()
+    trip._check_inspections(0.4)
+    assert not [event for event in trip._events if event.kind == TripEventKind.INSPECTION]
+
+    trip.position_mi = zone.start_mi + 1.1
+    trip._events = []
+    trip._check_inspections(0.8)
+    inspection = [event for event in trip._events if event.kind == TripEventKind.INSPECTION]
+    assert [event.message for event in inspection] == [
+        "Trooper in the construction zone clocks your speed."
+    ]
+
+
 def test_grades_are_bounded(world):
     trip, _ = make_trip(world, "Denver", "Salt Lake City")
     for mile in range(0, int(trip.total_miles), 3):


### PR DESCRIPTION
## Summary

This PR fixes a construction-zone regression that made speech-driven slowdown warnings non-actionable.

Players reported that they could enter a construction zone with no useful warning and then be fined for speeding through it. Investigation showed that the construction-zone message still existed, but it was only spoken at zone entry, and newer route-enforcement logic could issue a construction-zone speeding citation on the same update. In practice that meant the player had no fair chance to slow down before punishment became unavoidable.

## Root Cause

The historical problem was not that the construction-zone announcement was removed.

The real regression was sequencing:

- the trip layer still emitted the zone-entry message;
- construction-zone trooper enforcement was added later;
- enforcement checked speed immediately once the truck was inside the zone;
- a single update could therefore both announce zone entry and issue the fine.

Older gameplay already relied on an entry-time warning, but that was still usable because immediate construction-zone trooper enforcement did not yet exist.

## What Changed

### Tests

The first commit adds focused trip-level regression coverage for the player-facing contract:

- construction zones warn before entry;
- entering the zone too fast does not trigger an immediate same-tick citation;
- enforcement still exists after a meaningful grace distance.

### Runtime behavior

The second commit restores a fair slowdown window by:

- adding a 2-mile advance GPS cue for construction zones;
- preserving the existing zone-entry cue at the boundary;
- delaying construction-zone speeding enforcement until 1 mile of in-zone grace has passed;
- anchoring that grace distance to the zone boundary, not the first in-zone frame position.

## Player Impact

Speech users once again get a warning that can actually be acted on before a construction-zone speeding fine becomes possible.

## Verification

Ran:

- `uv run pytest tests/test_weather_trip.py -q`
- `uv run pytest tests/test_driving_features.py tests/test_trip_resume.py -q`
- `uv run pytest tests/test_weather_trip.py tests/test_driving_features.py tests/test_trip_resume.py -q`