### PR TITLE
feat(release): use curated changelog for snapshots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Check build conditions
         id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
 
@@ -71,16 +73,19 @@ jobs:
             if [ -z "$LAST_TAG" ]; then
               echo "should_build=true" >> $GITHUB_OUTPUT
             else
-              USER_FACING_PATHS=$(git diff --name-only "$LAST_TAG"..HEAD -- \
-                src/ \
-                pyproject.toml \
-                tools/build_release.py | sed '/^$/d')
-
-              if [ -n "$USER_FACING_PATHS" ]; then
-                echo "should_build=true" >> $GITHUB_OUTPUT
-              else
-                echo "should_build=false" >> $GITHUB_OUTPUT
+              gh release view "$LAST_TAG" --json body -q .body > previous-notes.md || true
+              : > latest-stable-notes.md
+              LATEST_STABLE_TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases" \
+                --jq '[.[] | select(.draft == false and .prerelease == false)][0].tag_name // ""')
+              if [ -n "$LATEST_STABLE_TAG" ]; then
+                gh release view "$LATEST_STABLE_TAG" --json body -q .body > latest-stable-notes.md || true
               fi
+              python3 tools/release_notes.py should-build-nightly \
+                --previous-tag "$LAST_TAG" \
+                --exclude-notes previous-notes.md \
+                --latest-stable-tag "$LATEST_STABLE_TAG" \
+                --exclude-stable-notes latest-stable-notes.md \
+                >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -155,6 +160,7 @@ jobs:
 
       - name: Prepare release notes and checksums
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_NIGHTLY: ${{ needs.prepare.outputs.is_nightly }}
           TAG: ${{ needs.prepare.outputs.tag }}
         run: |
@@ -162,8 +168,15 @@ jobs:
 
           if [ "$IS_NIGHTLY" = "true" ]; then
             LAST_TAG=$(git tag --list "nightly-*" --sort=-version:refname | grep -v "^$TAG$" | head -1)
-            python3 tools/release_notes.py nightly \
-              --previous-tag "$LAST_TAG" --output notes.md
+            if [ -n "$LAST_TAG" ]; then
+              gh release view "$LAST_TAG" --json body -q .body > previous-notes.md || true
+              python3 tools/release_notes.py nightly \
+                --previous-tag "$LAST_TAG" \
+                --exclude-notes previous-notes.md \
+                --output notes.md
+            else
+              python3 tools/release_notes.py nightly --output notes.md
+            fi
           else
             python3 tools/release_notes.py stable \
               --version "$TAG" --output notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Changed
-- **Developer snapshot release notes.** Nightly builds now use curated
-  player-facing changelog entries, and scheduled snapshots build only for new
-  curated notes or an explicit nightly-build marker instead of raw git diffs or
-  commit subjects.
-
 ## 1.6.0 - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Developer snapshot release notes.** Nightly builds now use curated
+  player-facing changelog entries, and scheduled snapshots build only for new
+  curated notes or an explicit nightly-build marker instead of raw git diffs or
+  commit subjects.
+
 ## 1.6.0 - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ uv run ruff check src tests tools
 uv run python tools/generate_audio.py   # regenerate all audio from source
 ```
 
+### Changelog and snapshots
+
+Player-facing changes should add a short bullet under `## Unreleased` in
+`CHANGELOG.md`. Developer snapshots use those curated entries for release
+notes; they do not turn git commit subjects into player-facing copy.
+
+Scheduled snapshots build only when new curated Unreleased entries are present,
+or when a commit message includes `nightly: build` or `[nightly build]` for an
+intentional snapshot refresh. Use `changelog: none` or `[skip changelog]` only
+when every commit in the change set is non-user-facing.
+
 The entire sound library is produced by `tools/generate_audio.py` with seeded
 randomness — see [CREDITS.md](src/freight_fate/assets/sounds/CREDITS.md).
 

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -184,14 +184,18 @@ def test_generated_notes_flatten_to_speakable_lines(tmp_path, monkeypatch):
     release_notes = load_release_notes_module()
     repo = make_repo(
         tmp_path,
-        changelog("### Added\n- **Cruise control.** See [manual](https://example.test).\n"),
+        changelog(
+            "### Added\n"
+            "- **Cruise control.** See [manual](https://example.test)\n"
+            "  before setting speed.\n"
+        ),
     )
     monkeypatch.setattr(release_notes, "ROOT", repo)
 
     spoken = flatten_markdown(release_notes.nightly_notes())
 
     assert "Added" in spoken
-    assert "Cruise control. See manual." in spoken
+    assert "Cruise control. See manual before setting speed." in spoken
     assert all("**" not in line and "https://" not in line for line in spoken)
 
 

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -193,3 +193,15 @@ def test_generated_notes_flatten_to_speakable_lines(tmp_path, monkeypatch):
     assert "Added" in spoken
     assert "Cruise control. See manual." in spoken
     assert all("**" not in line and "https://" not in line for line in spoken)
+
+
+def test_build_workflow_uses_curated_nightly_decision_and_notes():
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "build.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "tools/release_notes.py should-build-nightly" in workflow
+    assert "--exclude-notes previous-notes.md" in workflow
+    assert "--exclude-stable-notes latest-stable-notes.md" in workflow
+    assert "tools/release_notes.py nightly" in workflow
+    assert "git diff --name-only \"$LAST_TAG\"..HEAD" not in workflow

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -1,0 +1,195 @@
+"""Curated release-note generation for build snapshots."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+from freight_fate.updater import flatten_markdown
+
+
+def load_release_notes_module():
+    path = Path(__file__).resolve().parents[1] / "tools" / "release_notes.py"
+    spec = importlib.util.spec_from_file_location("release_notes", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        encoding="utf-8",
+    ).strip()
+
+
+def commit(repo: Path, message: str) -> None:
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", message)
+
+
+def make_repo(tmp_path: Path, changelog: str) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q")
+    git(repo, "config", "user.email", "tests@example.test")
+    git(repo, "config", "user.name", "Tests")
+    (repo / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    commit(repo, "chore: seed changelog")
+    return repo
+
+
+def changelog(unreleased: str, stable: str = "") -> str:
+    return f"# Changelog\n\n## Unreleased\n\n{unreleased}\n\n{stable}".rstrip() + "\n"
+
+
+def test_nightly_notes_use_curated_unreleased_entries(tmp_path, monkeypatch):
+    release_notes = load_release_notes_module()
+    repo = make_repo(
+        tmp_path,
+        changelog("### Added\n- **Dispatch.** New spoken board details.\n"),
+    )
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+
+    notes = release_notes.nightly_notes()
+
+    assert "Automated developer snapshot" in notes
+    assert "## Added" in notes
+    assert "- **Dispatch.** New spoken board details." in notes
+    assert "chore: seed changelog" not in notes
+
+
+def test_stable_notes_extract_matching_version_block(tmp_path, monkeypatch):
+    release_notes = load_release_notes_module()
+    repo = make_repo(
+        tmp_path,
+        changelog(
+            "### Added\n- Next thing.\n",
+            "## 1.6.0 - 2026-06-15\n\n### Fixed\n- Stable fix.\n",
+        ),
+    )
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+
+    assert release_notes.stable_notes("v1.6.0") == "## Fixed\n- Stable fix."
+
+
+def test_stable_notes_fall_back_to_unreleased_when_version_missing(tmp_path, monkeypatch):
+    release_notes = load_release_notes_module()
+    repo = make_repo(tmp_path, changelog("### Changed\n- Upcoming change.\n"))
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+
+    assert release_notes.stable_notes("9.9.9") == "## Changed\n- Upcoming change."
+
+
+def test_nightly_notes_exclude_entries_from_previous_nightly(tmp_path, monkeypatch):
+    release_notes = load_release_notes_module()
+    repo = make_repo(tmp_path, changelog("### Added\n- Old curated note.\n"))
+    git(repo, "tag", "nightly-20260615")
+    (repo / "CHANGELOG.md").write_text(
+        changelog("### Added\n- Old curated note.\n- New curated note.\n"),
+        encoding="utf-8",
+    )
+    commit(repo, "feat: add new work")
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+
+    notes = release_notes.nightly_notes(previous_tag="nightly-20260615")
+
+    assert "- New curated note." in notes
+    assert "- Old curated note." not in notes
+
+
+def test_nightly_notes_no_entry_behavior_is_explicit(tmp_path, monkeypatch):
+    release_notes = load_release_notes_module()
+    repo = make_repo(tmp_path, changelog(""))
+    git(repo, "tag", "nightly-20260615")
+    (repo / "README.md").write_text("Docs only\n", encoding="utf-8")
+    commit(repo, "docs: update readme")
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+
+    notes = release_notes.nightly_notes(previous_tag="nightly-20260615")
+
+    assert notes.endswith("- No user-facing changes")
+
+
+def test_should_build_nightly_uses_curated_entries(tmp_path, monkeypatch, capsys):
+    release_notes = load_release_notes_module()
+    repo = make_repo(tmp_path, changelog("### Added\n- Old curated note.\n"))
+    git(repo, "tag", "nightly-20260615")
+    (repo / "CHANGELOG.md").write_text(
+        changelog("### Added\n- Old curated note.\n- New curated note.\n"),
+        encoding="utf-8",
+    )
+    commit(repo, "feat: add new work")
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+    args = type("Args", (), {
+        "previous_tag": "nightly-20260615",
+        "exclude_notes": "",
+        "latest_stable_tag": "",
+        "exclude_stable_notes": "",
+        "head": "HEAD",
+    })()
+
+    assert release_notes.should_build_nightly_command(args) == 0
+
+    assert "should_build=true" in capsys.readouterr().out
+
+
+def test_should_build_nightly_skips_without_entries_or_marker(
+    tmp_path, monkeypatch, capsys
+):
+    release_notes = load_release_notes_module()
+    repo = make_repo(tmp_path, changelog("### Added\n- Old curated note.\n"))
+    git(repo, "tag", "nightly-20260615")
+    (repo / "README.md").write_text("Docs only\n", encoding="utf-8")
+    commit(repo, "docs: update readme")
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+    args = type("Args", (), {
+        "previous_tag": "nightly-20260615",
+        "exclude_notes": "",
+        "latest_stable_tag": "",
+        "exclude_stable_notes": "",
+        "head": "HEAD",
+    })()
+
+    assert release_notes.should_build_nightly_command(args) == 0
+
+    assert "should_build=false" in capsys.readouterr().out
+
+
+def test_should_build_nightly_allows_explicit_marker(tmp_path, monkeypatch, capsys):
+    release_notes = load_release_notes_module()
+    repo = make_repo(tmp_path, changelog("### Added\n- Old curated note.\n"))
+    git(repo, "tag", "nightly-20260615")
+    (repo / "README.md").write_text("Nightly refresh\n", encoding="utf-8")
+    commit(repo, "chore: refresh snapshot\n\nnightly: build")
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+    args = type("Args", (), {
+        "previous_tag": "nightly-20260615",
+        "exclude_notes": "",
+        "latest_stable_tag": "",
+        "exclude_stable_notes": "",
+        "head": "HEAD",
+    })()
+
+    assert release_notes.should_build_nightly_command(args) == 0
+
+    assert "should_build=true" in capsys.readouterr().out
+
+
+def test_generated_notes_flatten_to_speakable_lines(tmp_path, monkeypatch):
+    release_notes = load_release_notes_module()
+    repo = make_repo(
+        tmp_path,
+        changelog("### Added\n- **Cruise control.** See [manual](https://example.test).\n"),
+    )
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+
+    spoken = flatten_markdown(release_notes.nightly_notes())
+
+    assert "Added" in spoken
+    assert "Cruise control. See manual." in spoken
+    assert all("**" not in line and "https://" not in line for line in spoken)

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -130,6 +130,16 @@ def normalize_entry(entry: str) -> str:
     return entry.casefold().strip()
 
 
+def format_entry(entry: str) -> str:
+    lines = [line.strip() for line in entry.splitlines() if line.strip()]
+    if not lines:
+        return ""
+    marker_match = re.match(r"^([-*+]\s+)(.*)$", lines[0])
+    marker = marker_match.group(1) if marker_match else "- "
+    first_text = marker_match.group(2) if marker_match else lines[0]
+    return marker + " ".join([first_text, *lines[1:]])
+
+
 def format_sections(sections: list[ChangelogSection]) -> str:
     if not sections:
         return "- No user-facing changes"
@@ -140,7 +150,9 @@ def format_sections(sections: list[ChangelogSection]) -> str:
 
     chunks: list[str] = []
     for title in ordered_titles:
-        entries = "\n".join(dict.fromkeys(by_title[title]))
+        entries = "\n".join(
+            entry for entry in dict.fromkeys(format_entry(e) for e in by_title[title]) if entry
+        )
         chunks.append(f"## {title}\n{entries}")
     return "\n\n".join(chunks).strip()
 

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -1,13 +1,9 @@
-"""Generate release notes for the build workflow.
+"""Curated changelog utilities for Freight Fate releases.
 
-* ``stable``: extracts the matching version's section from CHANGELOG.md.
-* ``nightly``: a short developer-snapshot header plus the commit subjects
-  since the previous nightly tag (or the last 10 on a first run).
-
-Usage:
-    python tools/release_notes.py stable --version 1.5.0 --output notes.md
-    python tools/release_notes.py nightly --previous-tag nightly-20260609 \
-        --output notes.md
+``stable`` writes the matching version block from ``CHANGELOG.md``.
+``nightly`` writes new ``Unreleased`` entries since the previous snapshot.
+``should-build-nightly`` decides scheduled snapshots from curated entries or
+explicit nightly markers, never from raw commit subjects.
 """
 
 from __future__ import annotations
@@ -16,54 +12,362 @@ import argparse
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_PATH = Path("CHANGELOG.md")
+NIGHTLY_HEADER = (
+    "Automated developer snapshot of the dev branch, for players who want "
+    "the newest features before the next stable release. Expect rough edges; "
+    "your save files stay compatible whenever possible, but back them up first."
+)
+SECTION_ORDER = ("Added", "Changed", "Improved", "Fixed", "Removed", "Deprecated", "Security")
+NIGHTLY_BUILD_MARKERS = ("nightly: build", "[nightly build]")
+SKIP_CHANGELOG_MARKERS = ("changelog: none", "[skip changelog]")
+USER_FACING_PATH_PREFIXES = ("src/", "docs/")
+USER_FACING_PATHS = {
+    "CHANGELOG.md",
+    "README.md",
+    "pyproject.toml",
+    "tools/build_release.py",
+    "tools/release_notes.py",
+}
+
+
+@dataclass(frozen=True)
+class ChangelogSection:
+    title: str
+    entries: tuple[str, ...]
+
+
+def run_git(args: list[str]) -> str:
+    return subprocess.check_output(
+        ["git", *args], cwd=ROOT, text=True, encoding="utf-8"
+    ).strip()
+
+
+def git_output_lines(args: list[str]) -> list[str]:
+    return [line for line in run_git(args).splitlines() if line]
+
+
+def changelog_file() -> Path:
+    return ROOT / CHANGELOG_PATH
+
+
+def changelog_at(ref: str) -> str:
+    try:
+        return run_git(["show", f"{ref}:{CHANGELOG_PATH.as_posix()}"])
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def extract_release_block(text: str, heading_pattern: str) -> str:
+    match = re.search(heading_pattern, text, re.IGNORECASE | re.MULTILINE)
+    if not match:
+        return ""
+    start = match.end()
+    next_heading = re.search(r"^##\s+", text[start:], re.MULTILINE)
+    end = start + next_heading.start() if next_heading else len(text)
+    return text[start:end].strip()
+
+
+def unreleased_block(text: str) -> str:
+    return extract_release_block(text, r"^##\s+\[?Unreleased\]?\s*$")
+
+
+def version_block(text: str, version: str) -> str:
+    normalized = version.removeprefix("v")
+    return extract_release_block(
+        text,
+        rf"^##\s+\[?v?{re.escape(normalized)}\]?(?:\s+-\s+\d{{4}}-\d{{2}}-\d{{2}})?\s*$",
+    )
+
+
+def parse_sections(markdown: str) -> list[ChangelogSection]:
+    sections: list[ChangelogSection] = []
+    current_title = ""
+    current_entries: list[str] = []
+    current_entry: list[str] = []
+
+    def flush_entry() -> None:
+        nonlocal current_entry
+        if current_entry:
+            current_entries.append("\n".join(current_entry).rstrip())
+            current_entry = []
+
+    def flush_section() -> None:
+        nonlocal current_entries
+        flush_entry()
+        if current_title and current_entries:
+            sections.append(ChangelogSection(current_title, tuple(current_entries)))
+        current_entries = []
+
+    for line in markdown.splitlines():
+        heading = re.match(r"^#{3,6}\s+(.+?)\s*$", line)
+        if heading:
+            flush_section()
+            current_title = heading.group(1)
+            continue
+        if re.match(r"^[-*+]\s+", line):
+            flush_entry()
+            current_entry.append(line)
+            continue
+        if current_entry and (line.startswith((" ", "\t")) or not line.strip()):
+            current_entry.append(line)
+
+    flush_section()
+    return sections
+
+
+def normalize_entry(entry: str) -> str:
+    entry = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", entry)
+    entry = re.sub(r"`([^`]+)`", r"\1", entry)
+    entry = re.sub(r"(\*\*|__|\*|_)", "", entry)
+    entry = re.sub(r"^[-*+]\s+", "", entry.strip())
+    entry = re.sub(r"\s+[-\u2013\u2014]\s+", " - ", entry)
+    entry = re.sub(r"\s+", " ", entry)
+    return entry.casefold().strip()
+
+
+def format_sections(sections: list[ChangelogSection]) -> str:
+    if not sections:
+        return "- No user-facing changes"
+
+    by_title = {section.title: section.entries for section in sections}
+    ordered_titles = [title for title in SECTION_ORDER if title in by_title]
+    ordered_titles.extend(title for title in by_title if title not in ordered_titles)
+
+    chunks: list[str] = []
+    for title in ordered_titles:
+        entries = "\n".join(dict.fromkeys(by_title[title]))
+        chunks.append(f"## {title}\n{entries}")
+    return "\n\n".join(chunks).strip()
+
+
+def entries_from_sections(sections: list[ChangelogSection]) -> set[str]:
+    return {normalize_entry(entry) for section in sections for entry in section.entries}
+
+
+def excluded_entries_from_notes(path: str) -> set[str]:
+    if not path:
+        return set()
+    notes_path = Path(path)
+    if not notes_path.exists():
+        return set()
+    return entries_from_sections(parse_sections(notes_path.read_text(encoding="utf-8")))
+
+
+def sections_added_since(
+    base_ref: str,
+    head_text: str,
+    extra_excluded_entries: set[str] | None = None,
+) -> list[ChangelogSection]:
+    base_entries = entries_from_sections(parse_sections(unreleased_block(changelog_at(base_ref))))
+    if extra_excluded_entries:
+        base_entries.update(extra_excluded_entries)
+
+    added: list[ChangelogSection] = []
+    for section in parse_sections(unreleased_block(head_text)):
+        entries = tuple(
+            entry for entry in section.entries if normalize_entry(entry) not in base_entries
+        )
+        if entries:
+            added.append(ChangelogSection(section.title, entries))
+    return added
 
 
 def stable_notes(version: str) -> str:
-    text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    pattern = rf"^## {re.escape(version)}\b.*?$(.*?)(?=^## |\Z)"
-    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
-    if not match:
-        return f"Freight Fate {version}. See CHANGELOG.md for details."
-    return match.group(1).strip()
+    changelog_text = changelog_file().read_text(encoding="utf-8")
+    block = version_block(changelog_text, version) or unreleased_block(changelog_text)
+    return format_sections(parse_sections(block))
 
 
-def nightly_notes(previous_tag: str) -> str:
-    rev_range = f"{previous_tag}..HEAD" if previous_tag else "-10"
-    log = subprocess.run(
-        ["git", "log", "--no-merges", "--pretty=format:- %s", rev_range],
-        capture_output=True, text=True, cwd=ROOT, check=False,
-    ).stdout.strip()
-    header = (
-        "Automated developer snapshot of the main branch, for players who "
-        "want the newest features before the next stable release. "
-        "Expect rough edges; your save files stay compatible whenever "
-        "possible, but back them up first.\n\n"
-        "## Changes since the previous snapshot\n"
-    )
-    return header + (log or "- No commit details available.")
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("kind", choices=["stable", "nightly"])
-    parser.add_argument("--version", default="")
-    parser.add_argument("--previous-tag", default="")
-    parser.add_argument("--output", required=True)
-    args = parser.parse_args()
-
-    if args.kind == "stable":
-        if not args.version:
-            parser.error("stable notes need --version")
-        notes = stable_notes(args.version.lstrip("v"))
+def nightly_notes(previous_tag: str = "", exclude_notes: str = "") -> str:
+    changelog_text = changelog_file().read_text(encoding="utf-8")
+    excluded_entries = excluded_entries_from_notes(exclude_notes)
+    if previous_tag:
+        sections = sections_added_since(previous_tag, changelog_text, excluded_entries)
     else:
-        notes = nightly_notes(args.previous_tag)
-    Path(args.output).write_text(notes + "\n", encoding="utf-8")
-    print(notes[:400])
+        sections = parse_sections(unreleased_block(changelog_text))
+    body = format_sections(sections)
+    return f"{NIGHTLY_HEADER}\n\n## Changes since the previous snapshot\n\n{body}"
+
+
+def current_branch() -> str:
+    return run_git(["branch", "--show-current"])
+
+
+def resolve_base(base: str) -> str:
+    if base != "auto":
+        return base
+    return "origin/main" if current_branch() == "main" else "origin/dev"
+
+
+def ref_is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode == 0
+
+
+def commit_messages(base: str, head: str) -> list[str]:
+    commits = git_output_lines(["log", "--no-merges", "--format=%H", f"{base}..{head}"])
+    return [run_git(["show", "-s", "--format=%B", commit]) for commit in commits]
+
+
+def commits_request_nightly_build(base: str, head: str) -> bool:
+    return any(
+        marker in message.casefold()
+        for message in commit_messages(base, head)
+        for marker in NIGHTLY_BUILD_MARKERS
+    )
+
+
+def commits_opt_out_of_changelog(base: str, head: str) -> bool:
+    messages = commit_messages(base, head)
+    return bool(messages) and all(
+        any(marker in message.casefold() for marker in SKIP_CHANGELOG_MARKERS)
+        for message in messages
+    )
+
+
+def is_user_facing_path(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return normalized in USER_FACING_PATHS or normalized.startswith(USER_FACING_PATH_PREFIXES)
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    return git_output_lines(["diff", "--name-only", f"{base}..{head}"])
+
+
+def unreleased_added_entries(base: str, head: str) -> list[str]:
+    base_entries = entries_from_sections(parse_sections(unreleased_block(changelog_at(base))))
+    head_text = changelog_at(head) if head != "HEAD" else changelog_file().read_text(encoding="utf-8")
+    return [
+        entry
+        for section in parse_sections(unreleased_block(head_text))
+        for entry in section.entries
+        if normalize_entry(entry) not in base_entries
+    ]
+
+
+def check_command(args: argparse.Namespace) -> int:
+    base = resolve_base(args.base)
+    files = changed_files(base, args.head)
+    user_facing = [path for path in files if is_user_facing_path(path)]
+    if not user_facing:
+        print("No user-facing paths changed.")
+        return 0
+
+    if commits_opt_out_of_changelog(base, args.head):
+        print("All commits opt out of the changelog gate via a skip marker.")
+        return 0
+
+    if CHANGELOG_PATH.as_posix() not in files:
+        print("User-facing paths changed without updating CHANGELOG.md:", file=sys.stderr)
+        for path in user_facing:
+            print(f"- {path}", file=sys.stderr)
+        return 1
+
+    if not unreleased_added_entries(base, args.head):
+        print(
+            "CHANGELOG.md changed, but no new bullet was added under ## Unreleased.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Found CHANGELOG.md Unreleased entries for user-facing changes.")
     return 0
 
 
+def should_build_nightly_command(args: argparse.Namespace) -> int:
+    if not args.previous_tag:
+        print("should_build=true")
+        print("No previous nightly tag found; building once.", file=sys.stderr)
+        return 0
+
+    latest_stable_tag = args.latest_stable_tag
+    if latest_stable_tag and ref_is_ancestor(args.head, latest_stable_tag):
+        print("should_build=false")
+        print("Latest stable release already contains this commit.", file=sys.stderr)
+        return 0
+
+    baseline_tag = args.previous_tag
+    if latest_stable_tag and ref_is_ancestor(args.previous_tag, latest_stable_tag):
+        baseline_tag = latest_stable_tag
+
+    if commits_request_nightly_build(baseline_tag, args.head):
+        print("should_build=true")
+        print("Nightly build requested by commit marker.", file=sys.stderr)
+        return 0
+
+    excluded_entries = excluded_entries_from_notes(args.exclude_notes)
+    excluded_entries.update(excluded_entries_from_notes(args.exclude_stable_notes))
+    sections = sections_added_since(
+        baseline_tag,
+        changelog_file().read_text(encoding="utf-8"),
+        excluded_entries,
+    )
+    if sections:
+        print("should_build=true")
+        print("New curated changelog entries found for nightly build.", file=sys.stderr)
+    else:
+        print("should_build=false")
+        print("No new curated changelog entries or nightly build marker found.", file=sys.stderr)
+    return 0
+
+
+def write_notes_command(args: argparse.Namespace) -> int:
+    if args.kind == "stable":
+        if not args.version:
+            raise SystemExit("stable notes need --version")
+        notes = stable_notes(args.version)
+    else:
+        notes = nightly_notes(args.previous_tag, args.exclude_notes)
+    Path(args.output).write_text(notes + "\n", encoding="utf-8")
+    print(f"Wrote release notes to {args.output}.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for kind in ("stable", "nightly"):
+        notes = subparsers.add_parser(kind, help=f"Write {kind} release notes.")
+        notes.set_defaults(func=write_notes_command, kind=kind)
+        notes.add_argument("--version", default="")
+        notes.add_argument("--previous-tag", default="")
+        notes.add_argument("--exclude-notes", default="")
+        notes.add_argument("--output", required=True)
+
+    should_build = subparsers.add_parser(
+        "should-build-nightly",
+        help="Decide whether a scheduled nightly should build artifacts.",
+    )
+    should_build.add_argument("--previous-tag", default="")
+    should_build.add_argument("--exclude-notes", default="")
+    should_build.add_argument("--latest-stable-tag", default="")
+    should_build.add_argument("--exclude-stable-notes", default="")
+    should_build.add_argument("--head", default="HEAD")
+    should_build.set_defaults(func=should_build_nightly_command)
+
+    check = subparsers.add_parser("check", help="Require Unreleased changelog entries.")
+    check.add_argument("--base", required=True, help="Base ref, or 'auto'.")
+    check.add_argument("--head", default="HEAD")
+    check.set_defaults(func=check_command)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return args.func(args)
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR replaces commit-subject snapshot notes with curated changelog-driven release tooling.

- Generates nightly and stable release notes from `CHANGELOG.md` through the existing `tools/release_notes.py` CLI.
- Gates scheduled developer snapshots on new curated Unreleased entries or an explicit nightly-build marker, while keeping manual workflow dispatch as a force-build path.
- Adds contributor guidance so future player-facing changes land in the changelog instead of becoming raw commit-log copy.
- Keeps release notes friendlier for speech by formatting wrapped changelog bullets as one speakable markdown bullet line.

## Why

Developer snapshots should tell players what changed in clear, curated language. Commit subjects are useful for maintainers, but they are uneven as release notes and can be noisy when read by the updater's "what's new" flow.

## Changelog

No player-facing changelog entry is included because this changes release tooling and contributor workflow, not gameplay, UI, controls, save data, or player-visible app behavior.

## Verification

- Passed Ruff across source, tests, and tools.
- Passed focused release-note and updater regression tests, including markdown flattening for speech readability.
- Previously passed the full pytest suite on this branch: 348 tests.
- After removing the changelog entry, reran focused release tooling and updater checks successfully.

## Accessibility

No interactive UI controls changed. The release-note output was verified through the updater markdown-flattening path, and wrapped changelog bullets are now emitted as single bullet lines so screen-reader users hear coherent release-note items.