### PR TITLE
Fix macOS packaged speech support

### DIFF
--- a/tests/test_build_release.py
+++ b/tests/test_build_release.py
@@ -1,0 +1,74 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_RELEASE_PATH = ROOT / "tools" / "build_release.py"
+spec = importlib.util.spec_from_file_location("build_release", BUILD_RELEASE_PATH)
+assert spec is not None
+assert spec.loader is not None
+build_release = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build_release)
+
+
+def test_prism_target_native_dir_uses_macos_app_runtime_layout(tmp_path):
+    build_dir = tmp_path / "FreightFate.app"
+
+    assert build_release.prism_target_native_dir(build_dir) == (
+        build_dir / "Contents" / "MacOS" / "prism" / "_native"
+    )
+
+
+def test_stage_prism_runtime_files_copies_native_library(tmp_path, monkeypatch):
+    source_dir = tmp_path / "site-packages" / "prism" / "_native"
+    source_dir.mkdir(parents=True)
+    (source_dir / "libprism.dylib").write_bytes(b"prism")
+    build_dir = tmp_path / "FreightFate.app"
+
+    monkeypatch.setattr(build_release, "prism_native_dir", lambda: source_dir)
+
+    build_release.stage_prism_runtime_files(build_dir)
+
+    target = build_dir / "Contents" / "MacOS" / "prism" / "_native" / "libprism.dylib"
+    assert target.read_bytes() == b"prism"
+
+
+def test_stage_prism_runtime_files_rejects_missing_native_library(tmp_path, monkeypatch):
+    source_dir = tmp_path / "site-packages" / "prism" / "_native"
+    source_dir.mkdir(parents=True)
+    (source_dir / "README.txt").write_text("not a native library", encoding="utf-8")
+    build_dir = tmp_path / "FreightFate.app"
+
+    monkeypatch.setattr(build_release, "prism_native_dir", lambda: source_dir)
+
+    with pytest.raises(RuntimeError, match="No Prism native libraries"):
+        build_release.stage_prism_runtime_files(build_dir)
+
+
+def test_smoke_check_keeps_save_data_out_of_app_bundle(tmp_path, monkeypatch):
+    build_dir = tmp_path / "FreightFate.app"
+    exe = build_dir / "Contents" / "MacOS" / build_release.APP_NAME
+    exe.parent.mkdir(parents=True)
+    exe.write_text("fake executable", encoding="utf-8")
+    observed = {}
+
+    def fake_run(cmd, check, cwd, env, timeout):
+        observed["cmd"] = cmd
+        observed["check"] = check
+        observed["cwd"] = cwd
+        observed["env"] = env
+        observed["timeout"] = timeout
+        assert Path(env["FREIGHT_FATE_DATA_DIR"]).is_dir()
+
+    monkeypatch.setattr(build_release.subprocess, "run", fake_run)
+
+    build_release.smoke_check(build_dir)
+
+    data_dir = Path(observed["env"]["FREIGHT_FATE_DATA_DIR"])
+    assert observed["cmd"] == [str(exe), "--smoke"]
+    assert observed["check"] is True
+    assert observed["cwd"] == exe.parent
+    assert observed["timeout"] == 120
+    assert observed["env"]["FREIGHT_FATE_NO_SPEECH"] == "1"
+    assert build_dir not in data_dir.parents

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -26,6 +26,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,6 +41,7 @@ SRC_DIR = ROOT / "src"
 PACKAGE_DIR = SRC_DIR / "freight_fate"
 SOUND_LIB_NATIVE_EXTS = {".dll", ".dylib", ".so"}
 SOUND_LIB_ARCH_DIR = "x64"
+PRISM_NATIVE_EXTS = {".dll", ".dylib", ".so"}
 
 
 def project_version() -> str:
@@ -88,6 +90,23 @@ def sound_lib_target_dir(build_dir: Path) -> Path:
     return build_dir / "sound_lib" / "lib"
 
 
+def prism_native_dir() -> Path:
+    """Locate Prism's native speech library directory."""
+    spec = importlib.util.find_spec("prism")
+    if not spec or not spec.submodule_search_locations:
+        raise RuntimeError("prism is not installed; cannot build packaged speech support")
+    native_dir = Path(next(iter(spec.submodule_search_locations))) / "_native"
+    if not native_dir.exists():
+        raise RuntimeError(f"Prism native library directory was not found: {native_dir}")
+    return native_dir
+
+
+def prism_target_native_dir(build_dir: Path) -> Path:
+    if build_dir.suffix == ".app":
+        return build_dir / "Contents" / "MacOS" / "prism" / "_native"
+    return build_dir / "prism" / "_native"
+
+
 def mirror_sound_lib_flat_files_to_arch_dir(target_dir: Path) -> None:
     """Support sound_lib loaders that still search sound_lib/lib/x64."""
     flat_files = [path for path in target_dir.iterdir() if path.is_file()]
@@ -128,6 +147,23 @@ def stage_sound_lib_runtime_files(build_dir: Path) -> None:
     ]
     if not native_files:
         raise RuntimeError(f"No sound_lib native libraries were staged under {target_dir}")
+
+
+def stage_prism_runtime_files(build_dir: Path) -> None:
+    source_dir = prism_native_dir()
+    target_dir = prism_target_native_dir(build_dir)
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_dir, target_dir)
+
+    native_files = [
+        path
+        for path in target_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() in PRISM_NATIVE_EXTS
+    ]
+    if not native_files:
+        raise RuntimeError(f"No Prism native libraries were staged under {target_dir}")
 
 
 def build_nuitka_command(entry: Path) -> list[str]:
@@ -196,6 +232,7 @@ def run_nuitka() -> Path:
         shutil.rmtree(build_dir)
     DIST.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source_dir, build_dir)
+    stage_prism_runtime_files(build_dir)
     stage_sound_lib_runtime_files(build_dir)
     return build_dir
 
@@ -244,7 +281,9 @@ def smoke_check(build_dir: Path) -> None:
         "SDL_AUDIODRIVER": "dummy",
         "FREIGHT_FATE_NO_SPEECH": "1",
     }
-    subprocess.run([str(exe), "--smoke"], check=True, cwd=exe.parent, env=env, timeout=120)
+    with tempfile.TemporaryDirectory(prefix="freight-fate-smoke-") as data_dir:
+        env["FREIGHT_FATE_DATA_DIR"] = data_dir
+        subprocess.run([str(exe), "--smoke"], check=True, cwd=exe.parent, env=env, timeout=120)
     print("Smoke check passed: the frozen build boots and renders.")
 
 


### PR DESCRIPTION
## Summary

Fix macOS release builds so packaged speech can initialize in the frozen app.

Nuitka was compiling Prism's Python modules, but the app bundle did not include Prism's native runtime library at `prism/_native/libprism.dylib`. When the packaged game started, Prism could not load its native library, `Speech()` caught the failure, and the game continued silently.

This PR explicitly stages Prism's native runtime files into the packaged app alongside the existing `sound_lib` native staging. It also keeps the release smoke check from writing settings into the signed `.app` bundle by setting `FREIGHT_FATE_DATA_DIR` to a temporary directory during smoke runs.

## Changes

- Stage `prism/_native` into standalone/app builds and fail the build if no native Prism library is copied.
- Keep existing `sound_lib` staging behavior unchanged.
- Isolate release smoke-check save data outside the app bundle.
- Add build-release regression tests for Prism staging and smoke-check data isolation.

## Validation

- `uv run ruff check src tests tools`
- `uv run pytest tests/ -v --cov=src/freight_fate --cov-report=xml`
- `uv run python tools/build_release.py --tag macos-speech-test`
- `codesign --verify --deep --strict --verbose=2 dist/FreightFate.app`
- Confirmed `dist/FreightFate.app/Contents/MacOS/prism/_native/libprism.dylib` exists in the built app.
