### PR TITLE
fix: restore main CI metric navigation coverage

### DIFF
--- a/src/freight_fate/sim/trip.py
+++ b/src/freight_fate/sim/trip.py
@@ -180,6 +180,9 @@ class NavigationCue:
     at_mi: float
     text: str
     near_text: str = ""
+    # Speed carried unformatted so display code can render it in the player's
+    # chosen units. Only traffic cues set this; others leave it None.
+    speed_mph: float | None = None
 
 
 class Trip:
@@ -187,12 +190,16 @@ class Trip:
 
     def __init__(self, route: Route, truck: TruckState, weather: WeatherSystem,
                  time_scale: float = 20.0, seed: int | None = None,
-                 start_hour: float = 12.0) -> None:
+                 start_hour: float = 12.0, imperial: bool = True) -> None:
         self.route = route
         self.truck = truck
         self.weather = weather
         self.time_scale = time_scale
         self.start_hour = start_hour   # clock hour of day at departure
+        # Spoken/listed navigation distances follow the player's unit choice.
+        # Backing field set before cues are built below; the property setter
+        # re-renders baked cues if the player changes units mid-trip.
+        self._imperial = imperial
         self.position_mi = 0.0
         self.game_minutes = 0.0
         self.finished = False
@@ -218,6 +225,39 @@ class Trip:
         self._inspection_check_mi = 10.0
         self._traffic_warning_mi = 1.0
         self._announced_enforcement: set[str] = set()
+
+    @property
+    def imperial(self) -> bool:
+        return self._imperial
+
+    @imperial.setter
+    def imperial(self, value: bool) -> None:
+        if value == self._imperial:
+            return
+        self._imperial = value
+        # Re-render baked cue distances (onramp, continue, rest stop) so a
+        # mid-trip unit change updates guidance already laid out on the route.
+        # Cue keys are distance-independent, so announcement de-duplication
+        # carries over unchanged.
+        self.navigation_cues = self._build_navigation_cues()
+
+    def _distance_text(self, miles: float) -> str:
+        """Spoken distance in the player's units (miles or kilometers)."""
+        if self.imperial:
+            return f"{miles:.0f} miles"
+        return f"{miles * 1.609344:.0f} kilometers"
+
+    def _gap_text(self, miles: float) -> str:
+        """Short following-gap distance (one decimal) in the player's units."""
+        if self.imperial:
+            return f"{miles:.1f} miles"
+        return f"{miles * 1.609344:.1f} kilometers"
+
+    def _speed_value(self, mph: float) -> str:
+        """Bare speed-limit number in the player's units (no unit word)."""
+        if self.imperial:
+            return f"{mph:.0f}"
+        return f"{mph * 1.609344:.0f}"
 
     # -- layout -----------------------------------------------------------------
 
@@ -269,15 +309,15 @@ class Trip:
                     start + 0.05,
                     f"merge onto {shield} toward {toward}",
                     f"Merge onto {shield} toward {toward}; "
-                    f"{segment_miles:.0f} miles.",
+                    f"{self._distance_text(segment_miles)}.",
                 ))
             elif segment_miles >= 40.0:
                 cues.append(NavigationCue(
                     f"continue:{i}",
                     "continue",
                     start + 0.1,
-                    f"Continue on {leg.highway} for {segment_miles:.0f} miles "
-                    f"toward {toward}.",
+                    f"Continue on {leg.highway} for "
+                    f"{self._distance_text(segment_miles)} toward {toward}.",
                 ))
             if i > 0 and self.route.legs[i - 1].highway != leg.highway:
                 cues.append(NavigationCue(
@@ -349,7 +389,8 @@ class Trip:
                     "rest_stop",
                     start + offset,
                     f"{stop.label} ahead{at_part}",
-                    f"{stop.label.capitalize()}{at_part} ahead in 1 mile; "
+                    f"{stop.label.capitalize()}{at_part} ahead in "
+                    f"{'1 mile' if self.imperial else self._distance_text(1.0)}; "
                     f"{stop.parking_label}; press X to take the exit.",
                 ))
         for i, lead in enumerate(self.traffic_leads):
@@ -357,8 +398,9 @@ class Trip:
                 f"traffic:{i}:{lead.at_mi:.1f}",
                 "traffic",
                 lead.at_mi,
-                f"{lead.reason} at {lead.speed_mph:.0f} miles per hour",
+                lead.reason,
                 f"Traffic slowing ahead; target speed {lead.speed_mph:.0f}.",
+                speed_mph=lead.speed_mph,
             ))
         cues.sort(key=lambda cue: cue.at_mi)
         return cues
@@ -608,7 +650,13 @@ class Trip:
         if cue.kind == "interchange":
             return f"Next exit in {ahead_text}: {cue.text}."
         if cue.kind == "traffic":
-            return f"Traffic in {ahead_text}: {cue.text}."
+            speed = ""
+            if cue.speed_mph is not None:
+                speed = " at " + (
+                    f"{cue.speed_mph:.0f} miles per hour" if imperial
+                    else f"{cue.speed_mph * 1.609344:.0f} kilometers per hour"
+                )
+            return f"Traffic in {ahead_text}: {cue.text}{speed}."
         if cue.kind == "toll":
             return f"Toll point in {ahead_text}: {cue.text}."
         return f"Next guidance in {ahead_text}: {cue.text}."
@@ -627,7 +675,7 @@ class Trip:
         if cue is None:
             return "No listed highway exit ahead before the destination."
         ahead = max(0.0, cue.at_mi - self.position_mi)
-        return f"Next listed exit in {ahead:.0f} miles: {cue.text}."
+        return f"Next listed exit in {self._distance_text(ahead)}: {cue.text}."
 
     def next_exit_cue(self) -> NavigationCue | None:
         for cue in self.navigation_cues:
@@ -734,8 +782,8 @@ class Trip:
                 self._announced_zone_warnings.add(key)
                 self._emit(
                     TripEventKind.GPS_CUE,
-                    f"In {ahead:.0f} miles, {zone.reason} ahead. "
-                    f"Speed limit {zone.limit_mph:.0f}.",
+                    f"In {self._distance_text(ahead)}, {zone.reason} ahead. "
+                    f"Speed limit {self._speed_value(zone.limit_mph)}.",
                     zone=zone,
                 )
         zone = self._active_zone_at(self.position_mi)
@@ -744,14 +792,15 @@ class Trip:
                 if zone.reason == "construction":
                     self._construction_zone_grace_start[_zone_key(zone)] = zone.start_mi
                 self._emit(TripEventKind.ZONE_ENTER,
-                           f"{zone.reason} ahead. Speed limit {zone.limit_mph:.0f}.",
+                           f"{zone.reason} ahead. "
+                           f"Speed limit {self._speed_value(zone.limit_mph)}.",
                            zone=zone)
             elif self._active_zone is not None:
                 self._construction_zone_grace_start.pop(
                     _zone_key(self._active_zone), None)
                 self._emit(TripEventKind.ZONE_EXIT,
                            f"End of {self._active_zone.reason} zone. "
-                           f"Speed limit {BASE_SPEED_LIMIT_MPH:.0f}.")
+                           f"Speed limit {self._speed_value(BASE_SPEED_LIMIT_MPH)}.")
             self._active_zone = zone
 
     def _check_stops(self) -> None:
@@ -761,7 +810,8 @@ class Trip:
                 self._announced_stops.add(stop.name)
                 exit_part = f" at {stop.exit_label}" if stop.exit_label else ""
                 self._emit(TripEventKind.STOP_AHEAD,
-                           f"{stop.spoken_name}{exit_part} in {ahead:.0f} miles. "
+                           f"{stop.spoken_name}{exit_part} in "
+                           f"{self._distance_text(ahead)}. "
                            f"{stop.parking_text}. "
                            "Press X to take the exit for it.",
                            stop=stop)
@@ -788,9 +838,12 @@ class Trip:
                 key = f"{cue.key}:advance"
                 if 0 < ahead <= 2.0 and key not in self._announced_navigation:
                     self._announced_navigation.add(key)
+                    speed = (f" at {cue.speed_mph:.0f} miles per hour"
+                             if cue.speed_mph is not None else "")
                     self._emit(
                         TripEventKind.GPS_CUE,
-                        f"Traffic slowing ahead in {ahead:.0f} miles; {cue.text}.",
+                        f"Traffic slowing ahead in {self._distance_text(ahead)}; "
+                        f"{cue.text}{speed}.",
                         cue=cue,
                     )
                 continue
@@ -808,10 +861,7 @@ class Trip:
             )
             if 0 < ahead <= lookahead and advance_key not in self._announced_navigation:
                 self._announced_navigation.add(advance_key)
-                if cue.kind == "maneuver":
-                    message = f"In {ahead:.0f} miles, {cue.text}."
-                else:
-                    message = f"In {ahead:.0f} miles, {cue.text}."
+                message = f"In {self._distance_text(ahead)}, {cue.text}."
                 self._emit(TripEventKind.GPS_CUE, message, cue=cue)
             if -0.1 <= ahead <= 0.1 and near_key not in self._announced_navigation:
                 self._announced_navigation.add(near_key)
@@ -893,7 +943,7 @@ class Trip:
             self._emit(
                 TripEventKind.HAZARD,
                 f"Brake now! {context.lead.reason.capitalize()} "
-                f"{context.gap_mi:.1f} miles ahead.",
+                f"{self._gap_text(context.gap_mi)} ahead.",
                 deadline_s=2.5,
                 traffic=context,
             )

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -130,7 +130,8 @@ class DrivingState(State):
         trip_start_hour = profile.game_hours % 24.0 if start_hour is None else start_hour
         self.trip = Trip(route, self.truck, self.weather,
                          time_scale=ctx.settings.time_scale, seed=self.trip_seed,
-                         start_hour=trip_start_hour)
+                         start_hour=trip_start_hour,
+                         imperial=ctx.settings.imperial_units)
         self.lane = LaneKeeping(seed=self.trip_seed)
         self._day_music_sequence = select_drive_music_sequence(
             self.route, self.trip_seed, 12.0, self.weather.current)
@@ -772,6 +773,9 @@ class DrivingState(State):
             elif t.fuel_gal <= 0:
                 self._handle_out_of_fuel()
 
+        # Keep the trip's spoken-distance units in step with a live settings
+        # change; the setter only re-renders cues when the choice actually flips.
+        self.trip.imperial = self.ctx.settings.imperial_units
         pos_before = self.trip.position_mi
         for event in self.trip.update(dt):
             self._handle_trip_event(event)
@@ -2237,11 +2241,13 @@ class DrivingStatusScreenState(MenuState):
     def _map_lines(self) -> list[str]:
         d = self.driving
         route = d.route
+        settings = self.ctx.settings
         lines = [
             f"Route: {' to '.join(route.cities)}",
             f"Highways: {_join_phrase(route.highways)}",
-            f"Progress: {d.trip.position_mi:.0f} miles driven, {d.trip.remaining_miles:.0f} miles remaining",
-            f"Guidance: {d.trip.next_navigation_context()}",
+            f"Progress: {settings.distance_text(d.trip.position_mi)} driven, "
+            f"{settings.distance_text(d.trip.remaining_miles)} remaining",
+            f"Guidance: {d.trip.next_navigation_context(settings.imperial_units)}",
         ]
         upcoming = [
             stop
@@ -2252,7 +2258,7 @@ class DrivingStatusScreenState(MenuState):
             for stop in upcoming:
                 ahead = max(0.0, stop.at_mi - d.trip.position_mi)
                 lines.append(
-                    f"Stop in {ahead:.0f} miles: {stop.spoken_name}; "
+                    f"Stop in {settings.distance_text(ahead)}: {stop.spoken_name}; "
                     f"{_poi_offers_text(stop)}."
                 )
         else:
@@ -2263,7 +2269,10 @@ class DrivingStatusScreenState(MenuState):
         ][:4]
         for cue in next_cues:
             ahead = max(0.0, cue.at_mi - d.trip.position_mi)
-            lines.append(f"Map point in {ahead:.0f} miles: {cue.text}.")
+            speed = (f" at {settings.speed_text(cue.speed_mph)}"
+                     if cue.speed_mph is not None else "")
+            lines.append(
+                f"Map point in {settings.distance_text(ahead)}: {cue.text}{speed}.")
         if route.estimated_tolls > 0:
             lines.append(
                 f"Estimated carrier-paid toll exposure: {route.estimated_tolls:,.0f} dollars."
@@ -2545,6 +2554,7 @@ class ArrivalState(MenuState):
         self.driving = driving
         self.summary_parts: list[str] = []
         self._achievement_messages: list[str] = []
+        self._announcements: list[str] = []
         self.summary_lines: list[str] = []
         self.terminal = ctx.world.home_terminal(driving.job.destination)
         self._settle()
@@ -2571,6 +2581,8 @@ class ArrivalState(MenuState):
             self.summary_parts.append(
                 f"The empty run added {trip_damage:.0f} percent truck damage. "
                 "Visit the garage when you can.")
+        # The arrival screen and announcement read summary_lines, not parts.
+        self.summary_lines = list(self.summary_parts)
 
     def _settle(self) -> None:
         d = self.driving

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -398,6 +398,7 @@ def test_engine_shutdown_is_blocked_at_highway_speed(monkeypatch):
 
 def test_metric_status_lines_do_not_mix_mph_and_miles(monkeypatch):
     from freight_fate.app import App
+    from freight_fate.sim.trip import NavigationCue
 
     app = App()
     monkeypatch.setattr(app.ctx, "say", lambda text, interrupt=True: None)
@@ -407,11 +408,22 @@ def test_metric_status_lines_do_not_mix_mph_and_miles(monkeypatch):
         quiet_trip(driving)
         driving.truck.velocity_mps = 26.8
         driving._cruise_mph = 60.0
-        driving.trip.traffic_leads = []
+        # Force a known traffic cue ahead so the route line always renders the
+        # traffic speed. The speed used to be baked into the cue text as mph at
+        # build time, so it leaked imperial units in metric mode -- but only when
+        # a traffic lead randomly landed in range, which made this test flaky.
+        driving.trip.navigation_cues = [
+            NavigationCue("traffic:test", "traffic",
+                          driving.trip.position_mi + 5.0,
+                          "traffic queue ahead", speed_mph=50.0),
+        ]
 
         lines = driving.status_lines()
 
         assert any("kilometers per hour" in line for line in lines)
+        # 50 mph rendered in metric, not "miles per hour".
+        assert any("traffic queue ahead at 80 kilometers per hour" in line
+                   for line in lines)
         assert not any(" mph" in line for line in lines)
         assert not any(" miles" in line for line in lines)
     finally:

--- a/tests/test_interchanges.py
+++ b/tests/test_interchanges.py
@@ -321,3 +321,77 @@ def test_spoken_phrase_keeps_unrelated_destinations():
     ix = Interchange(at_mi=5.0, exit_ref="7", via="US 1 North",
                      destinations=("Trenton", "New York"), source="x")
     assert ix.spoken_phrase == "exit 7 for US-1 North toward Trenton and New York"
+
+
+# --- metric navigation distances --------------------------------------------
+
+def test_metric_navigation_cues_use_kilometers(world):
+    route = world.route_options("Chicago", "Indianapolis")[0]
+    metric = Trip(route, TruckState(), WeatherSystem("great_lakes", seed=1),
+                  seed=2, imperial=False)
+    blob = " ".join(f"{c.text} {c.near_text}" for c in metric.navigation_cues)
+    assert "kilometers" in blob
+    assert "mile" not in blob
+
+    # The default (imperial) trip keeps miles, so existing drives are unchanged.
+    imperial = Trip(route, TruckState(), WeatherSystem("great_lakes", seed=1),
+                    seed=2)
+    blob_i = " ".join(f"{c.text} {c.near_text}" for c in imperial.navigation_cues)
+    assert "miles" in blob_i
+
+
+def test_metric_drive_speaks_distances_in_kilometers(world):
+    from freight_fate.sim.trip import TripEventKind
+
+    route = world.route_options("Chicago", "Indianapolis")[0]
+    truck = TruckState()
+    truck.transmission.automatic = True
+    truck.start_engine()
+    trip = Trip(route, truck, WeatherSystem("great_lakes", seed=1),
+                seed=2, imperial=False)
+    truck.throttle = 0.85
+    nav: list[str] = []
+    for _ in range(60 * 60 * 12):
+        truck.auto_shift()
+        truck.update(1 / 60)
+        for ev in trip.update(1 / 60):
+            if ev.kind in (TripEventKind.GPS_CUE, TripEventKind.STOP_AHEAD):
+                nav.append(ev.message)
+        if trip.finished:
+            break
+    assert nav, "expected navigation announcements on a long metric drive"
+    blob = " ".join(nav)
+    assert "kilometers" in blob
+    assert "mile" not in blob
+
+
+def test_unit_toggle_rerenders_baked_navigation_cues(world):
+    route = world.route_options("Chicago", "Indianapolis")[0]
+    trip = Trip(route, TruckState(), WeatherSystem("great_lakes", seed=1), seed=2)
+
+    def cue_blob() -> str:
+        return " ".join(f"{c.text} {c.near_text}" for c in trip.navigation_cues)
+
+    assert "miles" in cue_blob() and "kilometers" not in cue_blob()
+    # Switching units mid-trip re-renders the distances already on the route.
+    trip.imperial = False
+    assert "kilometers" in cue_blob() and "mile" not in cue_blob()
+    trip.imperial = True
+    assert "miles" in cue_blob() and "kilometers" not in cue_blob()
+
+
+def test_metric_zone_warning_uses_metric_speed_limit(world):
+    from freight_fate.sim.trip import TripEventKind, Zone
+
+    route = world.route_options("Chicago", "Indianapolis")[0]
+    trip = Trip(route, TruckState(), WeatherSystem("great_lakes", seed=1),
+                seed=2, imperial=False)
+    trip.zones = [Zone(5.0, 10.0, 45.0, "construction")]
+    trip._announced_zone_warnings.clear()
+    trip.position_mi = 4.0  # within the 2-mile warning lookahead of the zone
+
+    msgs = [ev.message for ev in trip.update(0.0)
+            if ev.kind == TripEventKind.GPS_CUE]
+    blob = " ".join(msgs)
+    assert "Speed limit 72" in blob   # 45 mph rendered as 72 km/h
+    assert "Speed limit 45" not in blob

--- a/tests/test_job_progression.py
+++ b/tests/test_job_progression.py
@@ -73,11 +73,17 @@ def test_bobtail_relocates_to_a_nearby_city_without_pay():
         # a bobtail run survives save/resume as a bobtail run
         assert DrivingState.from_snapshot(app.ctx, driving.snapshot()).job.bobtail
 
-        ArrivalState(app.ctx, driving)
+        # Push the state so enter() runs -- this is the path that crashed when
+        # the bobtail settle left _announcements unset and summary_lines empty.
+        app.ctx.push_state(ArrivalState(app.ctx, driving))
+        arrival = app.state
 
         assert p.current_city == "Cheyenne"   # relocated to the new hub
         assert p.money == money_before        # no pay for an empty run
         assert p.career.deliveries == 0       # not counted as a delivery
+        # The repositioned arrival screen carries its summary.
+        assert arrival.summary_lines
+        assert any("Cheyenne" in line for line in arrival.summary_lines)
     finally:
         app.shutdown()
 


### PR DESCRIPTION
## Summary
- Backport the dev metric navigation/deadhead arrival fix needed by main CI.
- Keep the stable changelog unchanged while carrying the product and regression-test changes.

## Verification
- Passed local Ruff check for src, tests, and tools.
- Passed full local pytest suite.
- Opening as draft to run CI before promoting to main.