### PR TITLE
fix(economy): reserve pay advances for broke drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@
 - **Dispatcher pay advances (no more soft lock).** A broke driver who can no
   longer afford fuel can now draw a cash advance against the next load -- from
   the terminal hub or any in-trip rest stop -- and it is repaid automatically
-  out of the next delivery settlement. The advance is offered only while cash
-  is low and is capped, so it stays a recovery line rather than free money. A
-  negative balance is no longer a dead end.
+  out of the next delivery settlement. The advance is offered only when cash is
+  nearly gone and is capped, so it stays a recovery line rather than free
+  money. A negative balance is no longer a dead end.
 - **Discord Rich Presence (optional).** When Discord is running, your profile
   can show broad game activity -- the main menu, the terminal, driving a route,
   resting, or delivering -- with high-level route and cargo context. Only

--- a/src/freight_fate/models/economy.py
+++ b/src/freight_fate/models/economy.py
@@ -33,7 +33,7 @@ REST_COST = 35.0               # flat cost of a rest stop visit (food, parking)
 # driver fuel money against a load in transit.
 PAY_ADVANCE_LIMIT = 1500.0          # most you can owe at once
 PAY_ADVANCE_GRANT = 500.0           # cash per request
-PAY_ADVANCE_ELIGIBLE_BELOW = 400.0  # only offered when nearly broke
+PAY_ADVANCE_ELIGIBLE_BELOW = 10.0   # only offered at single-digit cash or worse
 
 
 def pay_advance_grant(money: float, outstanding: float) -> float:

--- a/tests/test_pay_advance.py
+++ b/tests/test_pay_advance.py
@@ -11,12 +11,15 @@ from freight_fate.models.economy import (
 
 def test_no_advance_when_cash_is_healthy():
     assert pay_advance_grant(PAY_ADVANCE_ELIGIBLE_BELOW, 0.0) == 0.0
+    assert pay_advance_grant(10.0, 0.0) == 0.0
+    assert pay_advance_grant(400.0, 0.0) == 0.0
     assert pay_advance_grant(5000.0, 0.0) == 0.0
 
 
 def test_advance_available_when_broke():
     assert pay_advance_grant(-300.0, 0.0) == PAY_ADVANCE_GRANT
     assert pay_advance_grant(0.0, 0.0) == PAY_ADVANCE_GRANT
+    assert pay_advance_grant(9.99, 0.0) == PAY_ADVANCE_GRANT
 
 
 def test_advance_is_capped_by_the_outstanding_limit():


### PR DESCRIPTION
## Summary
- Tighten pay-advance eligibility from low cash to single-digit cash or worse.
- Keep the advance grant, cap, and repayment behavior unchanged.
- Update tests and changelog wording to match the narrower recovery-only behavior.

## Verification
- Passed focused pay-advance and settlement tests.
- Passed Ruff on the touched economy/test files.
- Accessibility impact: no UI mechanics changed beyond when the existing menu action becomes available; spoken unavailable messaging still explains why no advance is available.