### PR TITLE
fix(economy): hide unavailable pay advances

### DIFF
--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -140,10 +140,6 @@ class CityMenuState(MenuState):
             MenuItem(self._garage_label, self._garage,
                      help="Refuel and repair your truck at the terminal garage. "
                           "If cash is short, the garage does partial work."),
-            MenuItem(self._pay_advance_label, self._request_pay_advance,
-                     help="Draw cash against your next load when you are broke "
-                          "and cannot afford fuel. Repaid automatically out of "
-                          "your next delivery settlement."),
             MenuItem("Career stats", self._stats,
                      help="Hear your level, reputation, and lifetime numbers."),
             MenuItem("Truck status", self._truck_status,
@@ -163,6 +159,12 @@ class CityMenuState(MenuState):
             MenuItem("Quit to main menu", self._to_main_menu,
                      help="Save your career and return to the title menu."),
         ]
+        if self._pay_advance_available():
+            items.insert(3, MenuItem(
+                self._pay_advance_label, self._request_pay_advance,
+                help="Draw cash against your next load when you are broke "
+                     "and cannot afford fuel. Repaid automatically out of "
+                     "your next delivery settlement."))
         return items
 
     # -- actions -----------------------------------------------------------------
@@ -225,6 +227,10 @@ class CityMenuState(MenuState):
         if grant > 0:
             return f"Request pay advance: {grant:,.0f} dollars"
         return "Request pay advance"
+
+    def _pay_advance_available(self) -> bool:
+        p = self.ctx.profile
+        return pay_advance_grant(p.money, p.pay_advance) > 0
 
     def _request_pay_advance(self) -> None:
         p = self.ctx.profile

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -1935,11 +1935,12 @@ class RestStopState(MenuState):
                 "Save at this stop", self._save_here,
                 help="Save the active drive at this route POI without "
                      "leaving the road."))
-        items.append(MenuItem(
-            self._pay_advance_label, self._request_pay_advance,
-            help="Draw cash against this load when you are broke and cannot "
-                 "afford fuel. Repaid automatically out of your delivery "
-                 "settlement."))
+        if self._pay_advance_available():
+            items.append(MenuItem(
+                self._pay_advance_label, self._request_pay_advance,
+                help="Draw cash against this load when you are broke and cannot "
+                     "afford fuel. Repaid automatically out of your delivery "
+                     "settlement."))
         items.append(MenuItem("Back to the road", self.go_back))
         return items
 
@@ -1949,6 +1950,10 @@ class RestStopState(MenuState):
         if grant > 0:
             return f"Request pay advance: {grant:,.0f} dollars"
         return "Request pay advance"
+
+    def _pay_advance_available(self) -> bool:
+        p = self.ctx.profile
+        return pay_advance_grant(p.money, p.pay_advance) > 0
 
     def _request_pay_advance(self) -> None:
         p = self.ctx.profile

--- a/tests/test_pay_advance.py
+++ b/tests/test_pay_advance.py
@@ -9,6 +9,10 @@ from freight_fate.models.economy import (
 )
 
 
+def _menu_texts(items):
+    return [item.text for item in items]
+
+
 def test_no_advance_when_cash_is_healthy():
     assert pay_advance_grant(PAY_ADVANCE_ELIGIBLE_BELOW, 0.0) == 0.0
     assert pay_advance_grant(5000.0, 0.0) == 0.0
@@ -30,3 +34,89 @@ def test_advance_is_capped_by_the_outstanding_limit():
 def test_unavailable_reason_distinguishes_healthy_cash_from_the_limit():
     assert "cash is low" in pay_advance_unavailable_reason(5000.0, 0.0)
     assert "limit" in pay_advance_unavailable_reason(-50.0, PAY_ADVANCE_LIMIT)
+
+
+def test_terminal_pay_advance_option_only_appears_when_available():
+    from freight_fate.app import App
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.city import CityMenuState
+
+    app = App()
+    try:
+        app.ctx.profile = Profile(name="Advance Test", current_city="New York")
+        state = CityMenuState(app.ctx)
+
+        app.ctx.profile.money = PAY_ADVANCE_ELIGIBLE_BELOW
+        assert not any(
+            text.startswith("Request pay advance")
+            for text in _menu_texts(state.build_items())
+        )
+
+        app.ctx.profile.money = PAY_ADVANCE_ELIGIBLE_BELOW - 1.0
+        assert any(
+            text.startswith("Request pay advance")
+            for text in _menu_texts(state.build_items())
+        )
+
+        app.ctx.profile.pay_advance = PAY_ADVANCE_LIMIT
+        assert not any(
+            text.startswith("Request pay advance")
+            for text in _menu_texts(state.build_items())
+        )
+    finally:
+        app.shutdown()
+
+
+def test_rest_stop_pay_advance_option_only_appears_when_available():
+    from freight_fate.app import App
+    from freight_fate.models.jobs import CARGO_CATALOG, Job
+    from freight_fate.models.profile import Profile
+    from freight_fate.sim.trip import RoadStop
+    from freight_fate.states.driving import DrivingState, RestStopState
+
+    app = App()
+    try:
+        app.ctx.profile = Profile(name="Advance Test", current_city="New York")
+        job = Job(
+            CARGO_CATALOG["electronics"],
+            18,
+            "New York",
+            "JFK Air Cargo",
+            "Philadelphia",
+            78,
+            2500,
+            12,
+            origin_type="air_cargo",
+            destination_location="Philadelphia Distribution Center",
+            destination_type="retail_distribution",
+        )
+        route = app.ctx.world.route_from_cities(["New York", "Philadelphia"])
+        driving = DrivingState(app.ctx, job, route, phase="delivery")
+        stop = RoadStop(
+            "Example Service Plaza",
+            10.0,
+            "service_plaza",
+            ("park", "save"),
+            ("parking",),
+        )
+        state = RestStopState(app.ctx, driving, stop)
+
+        app.ctx.profile.money = PAY_ADVANCE_ELIGIBLE_BELOW
+        assert not any(
+            text.startswith("Request pay advance")
+            for text in _menu_texts(state.build_items())
+        )
+
+        app.ctx.profile.money = PAY_ADVANCE_ELIGIBLE_BELOW - 1.0
+        assert any(
+            text.startswith("Request pay advance")
+            for text in _menu_texts(state.build_items())
+        )
+
+        app.ctx.profile.pay_advance = PAY_ADVANCE_LIMIT
+        assert not any(
+            text.startswith("Request pay advance")
+            for text in _menu_texts(state.build_items())
+        )
+    finally:
+        app.shutdown()


### PR DESCRIPTION
## Summary

This keeps the existing pay-advance eligibility threshold intact and changes the menus so the request action only appears when the driver can actually receive an advance. Terminal and rest-stop menus now ask the shared economy rule whether the grant would be positive before adding the option.

## User impact

Drivers no longer tab or arrow to a pay-advance option that can only explain it is unavailable. When cash is low enough and the outstanding advance limit is not reached, the option still appears with the calculated grant amount.

## Accessibility impact

This reduces menu clutter for keyboard and screen-reader players by removing an unavailable action from normal navigation. No deeper UI accessibility testing was needed because the change only controls whether an existing menu item is included.

## Verification

- Passed focused pay-advance, settlement, smoke, and driving feature tests.
- Passed Ruff on the touched gameplay state and pay-advance test files.