### PR TITLE
Fix speed limit announcement when pressing V

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
+### Fixed
 
+When pressing V, if you selected to use the metric system, speed limits are in KM/h
 ### Added
 - **Bigger freight map.** The playable network grows to 194 cities and
   438 routed legs, adding many more regional hubs, shorter connector lanes,

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -703,7 +703,7 @@ class DrivingState(State):
         source = "Live conditions" if self.weather.live else "Currently"
         parts = [f"It is {time_of_day(self.trip.current_hour)}.",
                  f"{source} {self.weather.describe()}.",
-                 f"Safe speed about {self.weather.effects.safe_speed_mph:.0f}."]
+                f"Safe speed about {(self.weather.effects.safe_speed_mph if self.ctx.settings.imperial_units else self.weather.effects.safe_speed_mph * 1.609):.0f}."]
         if not self.weather.live:
             ahead = ", then ".join(k.value for k in self.weather.forecast(2))
             parts.append(f"Ahead: {ahead}.")


### PR DESCRIPTION
when pressing V, the speed limit is mentioned in KM/h if you are on the metric system 