### PR TITLE
fix(speech): stop speech with Control in menus and help reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 ### Fixed
 
+- **Control now stops speech in menus too, not just while driving.** Left or
+  Right Control already silenced the driving event voice; it now also stops the
+  current speech in every menu and in the how-to-play reader, so a long readout
+  -- job details, cargo loading, a full help page -- can be cut short with the
+  same key everywhere.
 - **Dispatch, garage, and driving tools feel clearer.** F1 on a dispatch job now opens a
   reviewable job-detail view with line-by-line facts, long-haul pay has a stronger
   floor, drive-start speech is shorter in terse mode, the horn loops while held,

--- a/src/freight_fate/app.py
+++ b/src/freight_fate/app.py
@@ -105,6 +105,16 @@ class GameContext:
     def stop_event_speech(self) -> None:
         _stop_event_speech(self.speech)
 
+    def stop_speech(self) -> None:
+        """Silence all in-progress speech on both channels (main and event).
+
+        Menus and readers speak through the main channel, so the driving-only
+        ``stop_event_speech`` does not quiet them. This silences everything so a
+        single key works as a "stop talking" everywhere in the game.
+        """
+        _stop_main_speech(self.speech)
+        _stop_event_speech(self.speech)
+
     # -- state stack ------------------------------------------------------------
 
     def push_state(self, state: State) -> None:

--- a/src/freight_fate/states/base.py
+++ b/src/freight_fate/states/base.py
@@ -80,7 +80,10 @@ class MenuState(State):
     """A vertically navigated, fully spoken menu."""
 
     title = "Menu"
-    intro_help = "Use up and down arrows to navigate, Enter to select, Escape to go back."
+    intro_help = (
+        "Use up and down arrows to navigate, Enter to select, Escape to go back. "
+        "Left or Right Control stops the current speech."
+    )
     open_sound_key = "ui/menu_open"
 
     def __init__(self, ctx: GameContext) -> None:
@@ -164,6 +167,8 @@ class MenuState(State):
             self.go_back()
         elif key == pygame.K_F1:
             self.ctx.say(self.current_help())
+        elif key in (pygame.K_LCTRL, pygame.K_RCTRL):
+            self.ctx.stop_speech()
         elif event.unicode and event.unicode.isalnum():
             self._first_letter_jump(event.unicode.lower())
 

--- a/src/freight_fate/states/main_menu_help.py
+++ b/src/freight_fate/states/main_menu_help.py
@@ -297,7 +297,8 @@ class HelpState(State):
     def enter(self) -> None:
         self.ctx.say(
             "How to play. Left and Right arrows change pages. Up and Down arrows "
-            "read line by line. Enter reads the whole page. Escape goes back. " + self._page_title()
+            "read line by line. Enter reads the whole page. Left or Right Control "
+            "stops the current speech. Escape goes back. " + self._page_title()
         )
 
     def _page_title(self) -> str:
@@ -311,6 +312,8 @@ class HelpState(State):
         if event.key == pygame.K_ESCAPE:
             self.ctx.audio.play("ui/menu_back")
             self.ctx.pop_state()
+        elif event.key in (pygame.K_LCTRL, pygame.K_RCTRL):
+            self.ctx.stop_speech()
         elif event.key in (pygame.K_RIGHT, pygame.K_PAGEDOWN):
             self.page = (self.page + 1) % len(HELP_PAGES)
             self.line = -1

--- a/tests/test_menu_stop_speech.py
+++ b/tests/test_menu_stop_speech.py
@@ -1,0 +1,67 @@
+"""Left or Right Control silences speech in menus and the help reader.
+
+The driving screen already stops its event voice with Control; menus and the
+how-to-play reader speak on the main channel, so they need the same key to quiet
+a long readout (job details, cargo loading, a whole help page).
+"""
+
+from types import SimpleNamespace
+
+import pygame
+
+from freight_fate.states.base import MenuItem, MenuState
+
+
+class _Menu(MenuState):
+    def build_items(self):
+        return [MenuItem("One", lambda: None), MenuItem("Two", lambda: None)]
+
+
+def _keydown(key):
+    return SimpleNamespace(type=pygame.KEYDOWN, key=key, unicode="")
+
+
+def _menu_with_stop(calls):
+    ctx = SimpleNamespace(
+        settings=SimpleNamespace(announce_menu_position=True),
+        stop_speech=lambda: calls.append("stop"),
+    )
+    m = _Menu(ctx)
+    m.refresh()  # populate items without a real ctx
+    return m
+
+
+def test_left_and_right_control_stop_speech_in_menus():
+    calls = []
+    m = _menu_with_stop(calls)
+    m.handle_event(_keydown(pygame.K_LCTRL))
+    m.handle_event(_keydown(pygame.K_RCTRL))
+    assert calls == ["stop", "stop"]
+
+
+def test_control_stops_speech_in_the_help_reader():
+    from freight_fate.states.main_menu_help import HelpState
+
+    calls = []
+    ctx = SimpleNamespace(stop_speech=lambda: calls.append("stop"))
+    state = HelpState(ctx, start_page=0)
+    state.handle_event(_keydown(pygame.K_LCTRL))
+    assert calls == ["stop"]
+
+
+def test_stop_speech_silences_both_channels():
+    from freight_fate.app import GameContext
+
+    stopped = []
+    speech = SimpleNamespace(
+        stop_main=lambda: stopped.append("main"),
+        stop_event=lambda: stopped.append("event"),
+    )
+    ctx = object.__new__(GameContext)
+    ctx.speech = speech
+    ctx.stop_speech()
+    assert stopped == ["main", "event"]
+
+
+def test_menu_intro_help_documents_the_stop_key():
+    assert "Control stops the current speech" in MenuState.intro_help


### PR DESCRIPTION
## What changed and why

Left or Right Control already stopped the driving **event** voice, but menus and the how-to-play reader speak on the **main** channel, so pressing Control there did nothing. A long readout -- job details, **cargo loading**, a full help page -- could not be cut short.

This adds `GameContext.stop_speech()` (silences both channels) and wires Control to it in the shared `MenuState` base class and the `HelpState` reader, so the same key now stops speech everywhere in the game.

## What players/maintainers will notice

- In any menu (and the how-to-play reader), **Left or Right Control now stops the current speech**, matching how it already works while driving.
- The stop key is documented in the menu intro help (F1) and the help reader intro.

## Tests / checks run

- New `tests/test_menu_stop_speech.py` covers the menu key, the help-reader key, and that `stop_speech()` quiets both channels.
- `uv run pytest` (focused: menu/controls/speech/driving suites), `uv run ruff check src tests tools`, `uv run python -m compileall src tests tools` -- all pass. pre-commit hooks pass.

## Accessibility impact

Directly improves screen-reader UX: a verbose menu readout (e.g. the cargo loading screen) can now be silenced instantly with a familiar key, instead of forcing the player to wait it out. No visual-only cues introduced; spoken behavior only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)