### PR TITLE
feat(jobs): skip dispatch hauls under 25 miles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 ### Fixed
 
+- **The dispatch board no longer offers trivially short hauls.** Because each
+  city stands for a whole freight area, a job to a neighbor under 25 miles was a
+  pointless across-town hop; the board now skips those destinations and fills
+  from real routes instead.
 - **Trucks into New York now take the George Washington Bridge, not the Holland
   Tunnel.** New York freight now routes to the Hunts Point market in the Bronx
   over the GWB on I-95 -- the Hudson crossing a full-height rig can legally use

--- a/src/freight_fate/models/jobs.py
+++ b/src/freight_fate/models/jobs.py
@@ -395,6 +395,11 @@ def make_reposition_job(world: World, origin: str, destination: str) -> Job | No
     )
 
 
+# Shortest job the dispatch board will offer. Cities stand for whole freight
+# areas, so a haul below this is a trivial across-town hop (e.g. New York to
+# Newark at 11 miles) rather than a real dispatch.
+MIN_JOB_DISTANCE_MI = 25.0
+
 # Career-arc distance caps: short regional hops while learning the ropes,
 # cross-country hauls unlocking as a progression reward around level 4-5.
 LEVEL_DISTANCE_CAPS = {1: 300.0, 2: 450.0, 3: 650.0, 4: 850.0, 5: 1200.0}
@@ -695,7 +700,7 @@ class JobBoard:
     ) -> list[Job]:
         jobs: list[Job] = []
         city_obj = self.world.cities[city]
-        candidates = self._candidates(city)
+        candidates = [c for c in self._candidates(city) if c[1] >= MIN_JOB_DISTANCE_MI]
         cap = self.distance_cap(level)
         reachable = [c for c in candidates if c[1] <= cap]
         if not reachable and candidates:

--- a/tests/test_job_progression.py
+++ b/tests/test_job_progression.py
@@ -6,6 +6,7 @@ from freight_fate.models.jobs import (
     FACILITY_CARGO,
     LEVEL_DISTANCE_CAPS,
     LONG_HAUL_MILES,
+    MIN_JOB_DISTANCE_MI,
     JobBoard,
     minimum_pay_for_level,
 )
@@ -146,6 +147,34 @@ def test_destination_weighting_prefers_near_cities(world):
             near += job.destination == "Milwaukee"
             far += job.destination == "New York"
     assert near > far
+
+
+def test_board_never_offers_a_haul_below_the_minimum(world):
+    # Cities stand for whole freight areas, so trivial across-town hops are not
+    # offered as dispatches, no matter how close two cities sit on the map.
+    for city in ["New York", "Philadelphia", "Los Angeles", "Dallas", "Norfolk"]:
+        for seed in range(20):
+            for level in (1, 6):
+                for job in JobBoard(world, seed=seed).offers(city, set(), level=level):
+                    assert job.distance_mi >= MIN_JOB_DISTANCE_MI, (
+                        f"{job.origin} -> {job.destination} is only {job.distance_mi:.0f} mi"
+                    )
+
+
+@pytest.mark.parametrize(
+    ("city", "too_close"),
+    [
+        ("Norfolk", "Virginia Beach"),  # 18 mi
+        ("Bridgeport", "New Haven"),  # 21 mi
+    ],
+)
+def test_close_neighbors_are_not_dispatched(world, city, too_close):
+    # The nearest neighbor sits under the minimum, so it must never be offered,
+    # yet the board still fills from farther destinations.
+    for seed in range(30):
+        jobs = JobBoard(world, seed=seed).offers(city, set(), level=1)
+        assert jobs
+        assert all(job.destination != too_close for job in jobs)
 
 
 def test_remote_terminal_still_gets_a_full_board(world):


### PR DESCRIPTION
## What changed and why

Each city in Freight-Fate stands for a whole freight area, so a dispatch to a neighbor under ~25 road miles is a trivial across-town hop rather than a real haul (and the pay/deadline floors then have to paper over it). This adds a minimum job distance to the dispatch board so those hops are never offered.

- New constant `MIN_JOB_DISTANCE_MI = 25.0` in `models/jobs.py`.
- One filter at the candidate source in `JobBoard.offers()`, so it covers both the normal path and the remote-terminal fallback:
  ```python
  candidates = [c for c in self._candidates(city) if c[1] >= MIN_JOB_DISTANCE_MI]
  ```

## What players/maintainers will notice

- The board no longer offers ultra-short hauls. On current `dev` only two pairs are affected -- Norfolk↔Virginia Beach (18 mi) and Bridgeport↔New Haven (21 mi) -- so day-to-day play is unchanged, but the guard matters more as the city network grows and close neighbors become common.
- Boards for those origin cities still fill normally from farther destinations.

## Tests / checks run

- New tests in `tests/test_job_progression.py`: no board offers a haul under the minimum, and the two sub-25-mile neighbors are never dispatched while the board stays full.
- `uv run pytest` (full suite), `uv run ruff check src tests tools`, `uv run python -m compileall src tests tools` -- all pass. Pre-commit hooks pass.

## Accessibility impact

None -- this is dispatch-generation logic only; no speech, UI, or keyboard changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)