### PR TITLE
feat(dispatch): repeat the market watch with Tab on the board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,9 @@
   seconds.
 
 ### Added
+- **Repeat the market watch on the dispatch board.** The board speaks which
+  freight is tight or loose when you open it; pressing Tab now repeats just that
+  market watch, so you can re-check it without leaving and reopening the board.
 - **State troopers can pull you over for speeding.** Routes now have patrol
   windows -- hotter on busy interstates, in construction, and in dense regions,
   cooler out on the plains, with a night DUI bump. Speed badly inside one and a

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -803,7 +803,8 @@ class JobBoardState(MenuState):
         "creates a local deadhead pickup drive from your terminal to "
         "the named origin facility. Jobs name their origin and "
         "destination facilities, and cargo depends on the facility "
-        "type. Escape returns to the terminal."
+        "type. Tab repeats the freight market watch. Escape returns to "
+        "the terminal."
     )
 
     def __init__(self, ctx, jobs: list[Job]) -> None:
@@ -844,6 +845,9 @@ class JobBoardState(MenuState):
 
         if event.type == pygame.KEYDOWN and event.key == pygame.K_F1 and self.jobs:
             self.ctx.push_state(JobDetailState(self.ctx, self, self.jobs[self.index]))
+            return
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_TAB:
+            self.ctx.say(self.ctx.profile.market.summary())
             return
         super().handle_event(event)
 

--- a/tests/test_dispatch_job_detail.py
+++ b/tests/test_dispatch_job_detail.py
@@ -45,6 +45,24 @@ def test_f1_on_dispatch_job_opens_structured_detail_view():
         app.shutdown()
 
 
+def test_tab_repeats_only_the_market_watch(monkeypatch):
+    from freight_fate.app import App
+
+    app = App()
+    try:
+        board = _job_board(app)
+        spoken = []
+        monkeypatch.setattr(app.ctx, "say", lambda text, interrupt=True: spoken.append(text))
+
+        board.handle_event(key_event(pygame.K_TAB))
+
+        # Exactly the market summary is spoken -- no job line, no HOS note.
+        assert spoken == [app.ctx.profile.market.summary()]
+        assert board.index == 0  # Tab does not move the selection
+    finally:
+        app.shutdown()
+
+
 def test_job_detail_lines_are_reviewable_before_accepting():
     from freight_fate.app import App
     from freight_fate.states.city import JobBoardState


### PR DESCRIPTION
## What changed and why

The dispatch board announces the freight market watch (which cargo is tight or loose) when you open it, but there was no way to hear it again -- you had to leave and reopen the board. This adds **Tab to repeat just the market watch**.

- `JobBoardState.handle_event` now handles Tab, speaking only `market.summary()` -- not the current job line or the HOS note.
- The board's F1 help mentions the Tab shortcut.

## What players will notice

On the dispatch board, pressing **Tab** re-speaks the market watch at any time, so you can re-check which freight is tight or loose without navigating away and back.

## Tests / checks run

- New test in `tests/test_dispatch_job_detail.py`: Tab speaks exactly the market summary (nothing else) and does not move the selection.
- `uv run pytest tests/test_dispatch_job_detail.py tests/test_pickup_loading.py`, `uv run ruff check` -- pass. Pre-commit hooks pass. Also verified manually in-game.

## Accessibility impact

This is a pure accessibility win: it makes information that was previously spoken only once repeatable on demand with a dedicated key, and the key is documented in the board's F1 help. No visual-only cues; spoken behavior only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
