### PR TITLE
feat(world): add Pacific Northwest cities and corridors

### DIFF
--- a/src/freight_fate/data/world_data/us/cities.json
+++ b/src/freight_fate/data/world_data/us/cities.json
@@ -2951,6 +2951,180 @@
       ],
       "lat": 41.4901,
       "lon": -71.3128
+    },
+    "Tacoma": {
+      "state": "Washington",
+      "region": "pacific_northwest",
+      "locations": [
+        {
+          "name": "Husky Terminal",
+          "type": "port_terminal",
+          "source_note": "Husky Terminal, Northwest Seaport Alliance container terminal, Port of Tacoma."
+        },
+        {
+          "name": "Washington United Terminals",
+          "type": "intermodal",
+          "source_note": "Washington United Terminals on the Blair Waterway, with on-dock Hyundai intermodal yard, Port of Tacoma."
+        },
+        {
+          "name": "Frederickson Distribution Center",
+          "type": "distribution",
+          "source_note": "Frederickson industrial/distribution area south of Tacoma (Amazon, IKEA and other DCs)."
+        }
+      ],
+      "lat": 47.2529,
+      "lon": -122.4443
+    },
+    "Everett": {
+      "state": "Washington",
+      "region": "pacific_northwest",
+      "locations": [
+        {
+          "name": "Port of Everett",
+          "type": "port",
+          "source_note": "Port of Everett seaport, the region's premier breakbulk facility and third-largest container port in Washington."
+        },
+        {
+          "name": "Boeing Everett Factory",
+          "type": "manufacturing_plant",
+          "source_note": "Boeing Everett widebody assembly plant, served by rail and I-5/US-2."
+        },
+        {
+          "name": "Mount Baker Terminal",
+          "type": "rail",
+          "source_note": "Port of Everett barge-to-rail facility handling oversized aerospace containers."
+        }
+      ],
+      "lat": 47.979,
+      "lon": -122.2021
+    },
+    "Olympia": {
+      "state": "Washington",
+      "region": "pacific_northwest",
+      "locations": [
+        {
+          "name": "Port of Olympia Marine Terminal",
+          "type": "port",
+          "source_note": "Port of Olympia deepwater marine terminal on Budd Inlet; timber and wind-energy breakbulk, on-dock rail."
+        },
+        {
+          "name": "Lacey Commerce Business Center",
+          "type": "distribution",
+          "source_note": "Light-industrial and warehouse/distribution space in Lacey, east of Olympia."
+        }
+      ],
+      "lat": 47.0379,
+      "lon": -122.9007
+    },
+    "Yakima": {
+      "state": "Washington",
+      "region": "pacific_northwest",
+      "locations": [
+        {
+          "name": "Washington Fruit & Produce",
+          "type": "food_processor",
+          "source_note": "Washington Fruit & Produce apple-packing plant with controlled-atmosphere storage on River Road, Yakima."
+        },
+        {
+          "name": "Price Cold Storage & Packing",
+          "type": "cold_storage",
+          "source_note": "Price Cold Storage & Packing apple/pear/cherry packing and cold storage, Yakima."
+        },
+        {
+          "name": "Yakima Fruit & Cold Storage",
+          "type": "cold_storage",
+          "source_note": "Yakima Fruit & Cold Storage Co., Central Washington tree-fruit storage and shipping."
+        }
+      ],
+      "lat": 46.6021,
+      "lon": -120.5059
+    },
+    "Medford": {
+      "state": "Oregon",
+      "region": "pacific_northwest",
+      "locations": [
+        {
+          "name": "Harry & David Distribution Center",
+          "type": "distribution",
+          "source_note": "Harry & David headquarters fulfillment/distribution operation, Medford."
+        },
+        {
+          "name": "Naumes Fruit Packing",
+          "type": "food_processor",
+          "source_note": "Naumes Inc., Medford-based pear and tree-fruit grower-packer-shipper."
+        },
+        {
+          "name": "FedEx Ground Terminal",
+          "type": "parcel_hub",
+          "source_note": "FedEx Ground trucking and ground-distribution terminal in the Medford/Central Point area."
+        }
+      ],
+      "lat": 42.3265,
+      "lon": -122.8756
+    },
+    "Roseburg": {
+      "state": "Oregon",
+      "region": "pacific_northwest",
+      "locations": [
+        {
+          "name": "Roseburg Forest Products Dillard Sawmill",
+          "type": "lumber_paper",
+          "source_note": "Roseburg Forest Products Dillard stud sawmill, one of the largest in North America."
+        },
+        {
+          "name": "Roseburg Forest Products Dillard MDF",
+          "type": "construction_materials_yard",
+          "source_note": "Roseburg Forest Products Dillard particleboard/MDF engineered-wood plant."
+        }
+      ],
+      "lat": 43.2165,
+      "lon": -123.3417
+    },
+    "Bellingham": {
+      "state": "Washington",
+      "region": "pacific_northwest",
+      "locations": [
+        {
+          "name": "Bellingham Shipping Terminal",
+          "type": "port_terminal",
+          "source_note": "Port of Bellingham shipping terminal handling breakbulk and clean-bulk cargo."
+        },
+        {
+          "name": "Bellingham Cold Storage",
+          "type": "cold_storage",
+          "source_note": "Bellingham Cold Storage, a major private deepwater cold-storage terminal (seafood and perishables)."
+        },
+        {
+          "name": "BP Cherry Point Refinery",
+          "type": "chemical_petroleum_terminal",
+          "source_note": "BP Cherry Point refinery north of Bellingham, the largest refinery in Washington."
+        }
+      ],
+      "lat": 48.7519,
+      "lon": -122.4787
+    },
+    "Pendleton": {
+      "state": "Oregon",
+      "region": "pacific_northwest",
+      "locations": [
+        {
+          "name": "United Grain Pendleton Elevator",
+          "type": "farm_elevator",
+          "source_note": "United Grain Corp. Pendleton grain elevator (former Grain Craft/PGG assets), Columbia Plateau wheat."
+        },
+        {
+          "name": "Pendleton Woolen Mills",
+          "type": "manufacturing_plant",
+          "source_note": "Pendleton Woolen Mills, historic wool textile mill in Pendleton."
+        },
+        {
+          "name": "Cubework Pendleton Warehouse",
+          "type": "warehouse",
+          "source_note": "Cubework flexible warehouse/distribution space, Pendleton."
+        }
+      ],
+      "lat": 45.6721,
+      "lon": -118.7886
     }
   }
 }

--- a/tests/test_route_coverage_tool.py
+++ b/tests/test_route_coverage_tool.py
@@ -25,7 +25,7 @@ def test_route_coverage_report_is_machine_readable():
     assert report["metadata_contract"]["legacy_full_graph_available_for_old_saves"] is True
     assert report["metadata_contract"]["placeholder_pois_do_not_count_for_dispatch"]
     assert "source-backed truck-stop coverage" in report["current_batch_notes"][0]
-    assert report["totals"]["legs"] == 437
+    assert report["totals"]["legs"] == 449
     assert report["totals"]["playable"] == report["totals"]["legs"]
     assert report["missing_playable"] == []
     assert report["totals"]["route_points"] == report["totals"]["legs"]


### PR DESCRIPTION
## What changed and why

The Pacific Northwest was one of the sparsest regions on the map — **6 cities with a ~128-mile median hop**, so a player there had no short runs (Seattle's shortest possible dispatch was 181 mi to Portland). This is the first region batch of the map-coverage effort: fill sparse regions with real freight metros so the future local/regional/long-haul job tiers have short and medium runs everywhere.

Adds **8 new PNW cities** and their corridors:

| City | Fills |
|------|-------|
| Tacoma, WA | Port of Tacoma; Seattle local run (~34) |
| Everett, WA | I-5 north; Seattle local run (~28) |
| Olympia, WA | I-5 capital; Tacoma ~31 |
| Yakima, WA | central WA (I-82/I-90) |
| Medford, OR | southern I-5 |
| Roseburg, OR | steps the long Medford–Eugene I-5 hop into ~60-mi runs |
| Bellingham, WA | northern I-5 / border (Canada-ready) |
| Pendleton, OR | the empty I-84 corridor |

## Data quality (real-world, verified)

- **Corridors:** all legs routed with the ORS `driving-hgv` truck profile (geometry, elevation, grades, state crossings), real truck miles adopted.
- **Facilities:** each new city carries **real, web-verified named facilities** — Port of Tacoma / Husky Terminal / Washington United Terminals, Port of Everett / Boeing Everett Factory, BP Cherry Point Refinery / Bellingham Cold Storage, Washington Fruit & Produce, Harry & David / Naumes, Roseburg Forest Products Dillard, United Grain Pendleton / Pendleton Woolen Mills, etc. — plus the standard template fill-ins for market completeness, exactly like the original cities (e.g. Seattle: 2 real + template).
- **Truck stops:** real named stops on every non-urban leg (Overpass-harvested Pilot/Love's/Flying J, plus hand-curated **Seven Feathers** at Canyonville and the **Yreka/Redding Pilots** on the rural I-5 stretches). The two short urban hops (Everett–Seattle 28, Tacoma–Olympia 31) are intentionally stopless.

## Result

**202 cities / 449 legs, all playable.** Coverage report green (`playable == legs`).

## Tests / checks run

- `uv run pytest` (full suite), `uv run ruff check src tests tools`, `uv run python -m compileall`, `tools/index_world.py --check` — all pass. Coverage test bumped 437 → 449. Pre-commit hooks pass.

## Accessibility impact

None mechanically — this is world data. Player-facing benefit: PNW dispatches now include short local and regional runs (and real facility/stop names in the spoken dispatch/route text) instead of only long hauls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
