### PR TITLE
fix(region): reclassify Erie and Evansville to fitting regions

### DIFF
--- a/src/freight_fate/data/regions.py
+++ b/src/freight_fate/data/regions.py
@@ -81,7 +81,7 @@ STATE_REGION: dict[str, str] = {
     "West Virginia": "appalachia",
     # Great Lakes / industrial Midwest
     "Ohio": "great_lakes",
-    "Indiana": "great_lakes",
+    # Indiana is split by latitude in classify_region (Evansville -> mid_south).
     "Illinois": "great_lakes",
     "Michigan": "great_lakes",
     "Wisconsin": "great_lakes",
@@ -147,8 +147,16 @@ def classify_region(state: str, lat: float, lon: float) -> str:
         # East Tennessee is Appalachian; middle and west are Mid-South.
         return "appalachia" if lon >= -85.0 else "mid_south"
     if state == "Pennsylvania":
+        # Erie sits on the Lake Erie shore -- lake-effect Great Lakes country,
+        # like Buffalo and Cleveland on either side -- not Appalachian.
+        if lat >= 42.0:
+            return "great_lakes"
         # Western Pennsylvania is Appalachian; the southeast is the Northeast.
         return "appalachia" if lon <= -78.0 else "northeast"
+    if state == "Indiana":
+        # Far-southern Indiana on the Ohio River (Evansville) is Mid-South;
+        # the rest of the state is the industrial Great Lakes Midwest.
+        return "mid_south" if lat <= 38.5 else "great_lakes"
     if state == "New York":
         # Western New York (Buffalo) is lake-effect Great Lakes country.
         return "great_lakes" if lon <= -78.0 else "northeast"

--- a/src/freight_fate/data/world_data/us/cities.json
+++ b/src/freight_fate/data/world_data/us/cities.json
@@ -2064,7 +2064,7 @@
     "Evansville": {
       "lat": 37.97476,
       "lon": -87.55585,
-      "region": "great_lakes",
+      "region": "mid_south",
       "state": "Indiana",
       "locations": []
     },
@@ -2402,7 +2402,7 @@
     },
     "Erie": {
       "state": "Pennsylvania",
-      "region": "appalachia",
+      "region": "great_lakes",
       "locations": [
         {
           "name": "Port of Erie",


### PR DESCRIPTION
## What changed and why

Two cities were deriving into geographically wrong regions:

- **Erie, PA** was `appalachia` — but it sits on the **Lake Erie shore between Buffalo and Cleveland** (both `great_lakes`), and is actually *west* of Buffalo. A lakefront city flanked by two Great Lakes cities shouldn't be Appalachian.
- **Evansville, IN** was `great_lakes` — but it's in the **far south of Indiana on the Ohio River**, ~300 mi from any Great Lake, surrounded by Louisville/Nashville/Clarksville. It reads `mid_south`.

Both came from the state-based classifier's coarse rules (all of western PA → appalachia; all of Indiana → great_lakes), which never got a deliberate call on these two expansion-era cities.

## The fix

Two targeted carve-outs in `classify_region`:
- **Pennsylvania:** `lat >= 42.0` → `great_lakes` (the Lake Erie shore — matches **only Erie**; Pittsburgh at 40.44 etc. stay `appalachia`).
- **Indiana:** split by latitude, `lat <= 38.5` → `mid_south` (matches **only Evansville**; Indianapolis/Fort Wayne/South Bend stay `great_lakes`). Indiana's now-redundant `STATE_REGION` entry removed to match the other split-states.

Stored regions re-synced so `stored == classify_region` stays green.

## Save compatibility

**Save-safe.** Region is derived from world data at runtime and is **never stored in a save** (saves reference cities by name). `legs.json` is unchanged, so no in-progress trip's route is affected. Confirmed by re-deriving all 202 cities and asserting **exactly Erie and Evansville** change.

## Tests / checks

- `tests/test_regions.py` (incl. the `stored == derived` guard) passes; full suite passes; ruff clean; `world_data` in sync. Pre-commit hooks pass.

## Player-facing

Erie now appears under **Great Lakes** and Evansville under **Mid-South** in the terminal picker, and each picks up its correct region's weather flavor, fuel price, and hazard table. No gameplay mechanics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
