### PR TITLE
feat(world): add Southern Plains cities and corridors

### DIFF
--- a/src/freight_fate/data/regions.py
+++ b/src/freight_fate/data/regions.py
@@ -75,7 +75,7 @@ STATE_REGION: dict[str, str] = {
     "Connecticut": "northeast",
     "New Jersey": "northeast",
     "Delaware": "northeast",
-    "Maryland": "northeast",
+    # Maryland is split by longitude in classify_region (western MD -> appalachia).
     "District of Columbia": "northeast",
     # Appalachia
     "West Virginia": "appalachia",
@@ -100,9 +100,9 @@ STATE_REGION: dict[str, str] = {
     "Alabama": "mid_south",
     "Mississippi": "mid_south",
     "Arkansas": "mid_south",
-    # Atlantic Southeast (Piedmont + southern Atlantic coastal plain)
-    "Virginia": "atlantic_southeast",
-    "North Carolina": "atlantic_southeast",
+    # Atlantic Southeast (Piedmont + southern Atlantic coastal plain).
+    # Virginia and North Carolina are split by longitude in classify_region
+    # (their western Blue Ridge / Great Valley -> appalachia).
     "South Carolina": "atlantic_southeast",
     "Georgia": "atlantic_southeast",
     # Gulf Coast
@@ -160,6 +160,18 @@ def classify_region(state: str, lat: float, lon: float) -> str:
     if state == "New York":
         # Western New York (Buffalo) is lake-effect Great Lakes country.
         return "great_lakes" if lon <= -78.0 else "northeast"
+    if state == "North Carolina":
+        # The western Blue Ridge (Asheville) is Appalachian; the Piedmont and
+        # coastal plain are the Atlantic Southeast.
+        return "appalachia" if lon <= -82.0 else "atlantic_southeast"
+    if state == "Virginia":
+        # West of the Blue Ridge -- the I-81 Great Valley (Roanoke, Harrisonburg,
+        # Winchester) -- is Appalachian; the Piedmont and Tidewater are not.
+        return "appalachia" if lon <= -78.0 else "atlantic_southeast"
+    if state == "Maryland":
+        # Western Maryland (Hagerstown, the Cumberland valley) is Appalachian;
+        # the rest is the Northeast corridor.
+        return "appalachia" if lon <= -77.5 else "northeast"
     try:
         return STATE_REGION[state]
     except KeyError:

--- a/src/freight_fate/data/world_data/us/cities.json
+++ b/src/freight_fate/data/world_data/us/cities.json
@@ -3377,6 +3377,114 @@
       ],
       "lat": 37.9514,
       "lon": -91.7713
+    },
+    "San Angelo": {
+      "state": "Texas",
+      "region": "southern_plains",
+      "locations": [
+        {
+          "name": "Ethicon Medical Devices",
+          "type": "manufacturing_plant",
+          "source_note": "Ethicon (Johnson & Johnson) suture and surgical-device plant, San Angelo."
+        },
+        {
+          "name": "San Angelo Oilfield Terminal",
+          "type": "chemical_petroleum_terminal",
+          "source_note": "Permian Basin oil-and-gas services and terminal serving the Concho Valley."
+        }
+      ],
+      "lat": 31.4638,
+      "lon": -100.437
+    },
+    "Lawton": {
+      "state": "Oklahoma",
+      "region": "southern_plains",
+      "locations": [
+        {
+          "name": "Goodyear Tire Plant",
+          "type": "manufacturing_plant",
+          "source_note": "Goodyear's largest global tire manufacturing plant, Lawton."
+        },
+        {
+          "name": "Republic Paperboard",
+          "type": "lumber_paper",
+          "source_note": "Republic Paperboard gypsum-board paper mill, Lawton."
+        }
+      ],
+      "lat": 34.6086,
+      "lon": -98.3903
+    },
+    "Salina": {
+      "state": "Kansas",
+      "region": "southern_plains",
+      "locations": [
+        {
+          "name": "Great Plains Manufacturing",
+          "type": "manufacturing_plant",
+          "source_note": "Great Plains Manufacturing / Kubota agricultural and compact-loader equipment plant, Salina."
+        },
+        {
+          "name": "Schwan's Food Plant",
+          "type": "food_processor",
+          "source_note": "Schwan's frozen-food manufacturing, Salina."
+        }
+      ],
+      "lat": 38.8403,
+      "lon": -97.6114
+    },
+    "Enid": {
+      "state": "Oklahoma",
+      "region": "southern_plains",
+      "locations": [
+        {
+          "name": "Enid Terminal Grain Elevators",
+          "type": "farm_elevator",
+          "source_note": "Enid terminal grain elevators (ADM, Cargill, Continental), among the largest grain-storage capacity in the US."
+        },
+        {
+          "name": "Enid Energy Terminal",
+          "type": "chemical_petroleum_terminal",
+          "source_note": "Oil-and-gas gathering and terminal serving the STACK play, Enid."
+        }
+      ],
+      "lat": 36.3956,
+      "lon": -97.8784
+    },
+    "Dodge City": {
+      "state": "Kansas",
+      "region": "southern_plains",
+      "locations": [
+        {
+          "name": "Cargill Meat Solutions",
+          "type": "food_processor",
+          "source_note": "Cargill Meat Solutions beef plant (~6,000 head/day, 1,400 acres), Dodge City."
+        },
+        {
+          "name": "National Beef Dodge City",
+          "type": "food_processor",
+          "source_note": "National Beef Packing plant, Dodge City."
+        }
+      ],
+      "lat": 37.7528,
+      "lon": -100.0171
+    },
+    "Garden City": {
+      "state": "Kansas",
+      "region": "southern_plains",
+      "locations": [
+        {
+          "name": "Tyson Fresh Meats",
+          "type": "food_processor",
+          "source_note": "Tyson Fresh Meats beef plant at Holcomb near Garden City (~6,000 head/day)."
+        },
+        {
+          "name": "Garden City Grain & Feed Terminal",
+          "type": "farm_elevator",
+          "source_note": "Grain and feedlot-supply shipping for the southwest Kansas cattle belt."
+        }
+      ],
+      "lat": 37.9717,
+      "lon": -100.8727
     }
   }
 }

--- a/src/freight_fate/data/world_data/us/cities.json
+++ b/src/freight_fate/data/world_data/us/cities.json
@@ -2022,9 +2022,20 @@
     "Roanoke": {
       "lat": 37.27097,
       "lon": -79.94143,
-      "region": "atlantic_southeast",
+      "region": "appalachia",
       "state": "Virginia",
-      "locations": []
+      "locations": [
+        {
+          "name": "Norfolk Southern Roanoke Rail Yard",
+          "type": "rail",
+          "source_note": "Norfolk Southern rail yard, a historic classification hub (former Norfolk & Western)."
+        },
+        {
+          "name": "Advance Auto Parts Distribution Center",
+          "type": "retail_distribution",
+          "source_note": "Advance Auto Parts distribution operation rooted in the Roanoke Valley."
+        }
+      ]
     },
     "Aurora": {
       "lat": 41.76058,
@@ -3125,6 +3136,124 @@
       ],
       "lat": 45.6721,
       "lon": -118.7886
+    },
+    "Asheville": {
+      "state": "North Carolina",
+      "region": "appalachia",
+      "locations": [
+        {
+          "name": "Pratt & Whitney Aerospace",
+          "type": "manufacturing_plant",
+          "source_note": "Pratt & Whitney turbine-airfoil plant in south Asheville (~1M sq ft)."
+        },
+        {
+          "name": "New Belgium Brewing Company",
+          "type": "food_processor",
+          "source_note": "New Belgium Brewing's East Coast brewery, Asheville River Arts District."
+        }
+      ],
+      "lat": 35.5951,
+      "lon": -82.5515
+    },
+    "Johnson City": {
+      "state": "Tennessee",
+      "region": "appalachia",
+      "locations": [
+        {
+          "name": "American Water Heater Company",
+          "type": "manufacturing_plant",
+          "source_note": "American Water Heater Company (A.O. Smith), residential/commercial water heaters, Johnson City."
+        },
+        {
+          "name": "Mullican Flooring",
+          "type": "lumber_paper",
+          "source_note": "Mullican Flooring, hardwood flooring manufacturer headquartered in Johnson City."
+        }
+      ],
+      "lat": 36.3134,
+      "lon": -82.3535
+    },
+    "Harrisonburg": {
+      "state": "Virginia",
+      "region": "appalachia",
+      "locations": [
+        {
+          "name": "Cargill Turkey Processing",
+          "type": "food_processor",
+          "source_note": "Cargill turkey processing and cooked-meats operation, Shenandoah Valley (~1,800 employees)."
+        },
+        {
+          "name": "Pilgrim's Pride Poultry Plant",
+          "type": "food_processor",
+          "source_note": "Pilgrim's Pride poultry processing, Harrisonburg."
+        },
+        {
+          "name": "Harrisonburg Feed Mill",
+          "type": "farm_elevator",
+          "source_note": "Poultry-industry feed mill serving the Shenandoah Valley grower network."
+        }
+      ],
+      "lat": 38.4496,
+      "lon": -78.8689
+    },
+    "Winchester": {
+      "state": "Virginia",
+      "region": "appalachia",
+      "locations": [
+        {
+          "name": "Rubbermaid Commercial Products",
+          "type": "distribution",
+          "source_note": "Rubbermaid Commercial Products distribution center, Stonewall Industrial Park off I-81 Exit 317."
+        },
+        {
+          "name": "HP Hood Dairy",
+          "type": "cold_storage",
+          "source_note": "HP Hood dairy plant and cold storage, Winchester."
+        },
+        {
+          "name": "Kraft Heinz Plant",
+          "type": "food_processor",
+          "source_note": "Kraft Heinz food-manufacturing plant, Winchester/Frederick County."
+        }
+      ],
+      "lat": 39.1857,
+      "lon": -78.1633
+    },
+    "Hagerstown": {
+      "state": "Maryland",
+      "region": "appalachia",
+      "locations": [
+        {
+          "name": "Volvo Group Powertrain Plant",
+          "type": "automotive_plant",
+          "source_note": "Volvo/Mack Trucks powertrain plant (engines, transmissions, axles), 1.5M sq ft, Hagerstown."
+        },
+        {
+          "name": "FedEx Ground Terminal",
+          "type": "parcel_hub",
+          "source_note": "FedEx Ground/FedEx Freight distribution at the I-70/I-81 logistics crossroads."
+        }
+      ],
+      "lat": 39.6418,
+      "lon": -77.72
+    },
+    "Beckley": {
+      "state": "West Virginia",
+      "region": "appalachia",
+      "locations": [
+        {
+          "name": "Beckley Coal Terminal",
+          "type": "mine_quarry",
+          "source_note": "Coal loadout/terminal on the Norfolk Southern line, southern West Virginia coalfields hub."
+        },
+        {
+          "name": "Raleigh County Distribution Center",
+          "type": "distribution",
+          "source_note": "Regional retail/distribution serving southern West Virginia at the I-64/I-77/US-19 junction."
+        }
+      ],
+      "lat": 37.7782,
+      "lon": -81.1882
     }
   }
 }

--- a/src/freight_fate/data/world_data/us/cities.json
+++ b/src/freight_fate/data/world_data/us/cities.json
@@ -3254,6 +3254,129 @@
       ],
       "lat": 37.7782,
       "lon": -81.1882
+    },
+    "Columbia, Missouri": {
+      "state": "Missouri",
+      "region": "heartland",
+      "locations": [
+        {
+          "name": "3M Columbia Plant",
+          "type": "manufacturing_plant",
+          "source_note": "3M plant making medical filtration/diagnostic products and stethoscopes, Columbia."
+        },
+        {
+          "name": "Kraft Heinz Oscar Mayer Plant",
+          "type": "food_processor",
+          "source_note": "Kraft Heinz Oscar Mayer plant, 24/7 hot dog production, Columbia."
+        },
+        {
+          "name": "Buske Logistics Distribution Center",
+          "type": "distribution",
+          "source_note": "Third-party logistics/distribution center on the I-70 corridor between St. Louis and Kansas City."
+        }
+      ],
+      "lat": 38.9517,
+      "lon": -92.3341
+    },
+    "Sioux City": {
+      "state": "Iowa",
+      "region": "heartland",
+      "locations": [
+        {
+          "name": "Seaboard Triumph Foods",
+          "type": "food_processor",
+          "source_note": "Seaboard Triumph Foods fresh pork plant (~20,000 hogs/day), Bridgeport West Industrial Park, Sioux City."
+        },
+        {
+          "name": "CF Industries Port Neal",
+          "type": "chemical_petroleum_terminal",
+          "source_note": "CF Industries Port Neal nitrogen-fertilizer complex on the Missouri River south of Sioux City."
+        },
+        {
+          "name": "Sioux City Grain Terminal",
+          "type": "farm_elevator",
+          "source_note": "Grain and ethanol shipping terminal serving the upper-Midwest ag belt."
+        }
+      ],
+      "lat": 42.4999,
+      "lon": -96.4003
+    },
+    "Grand Island": {
+      "state": "Nebraska",
+      "region": "heartland",
+      "locations": [
+        {
+          "name": "JBS Grand Island Beef Plant",
+          "type": "food_processor",
+          "source_note": "JBS USA beef processing plant, central Nebraska cattle country, exporting to 30+ countries."
+        },
+        {
+          "name": "Case IH Grand Island Plant",
+          "type": "manufacturing_plant",
+          "source_note": "CNH/Case IH plant building Axial-Flow combines and hay & forage equipment, Grand Island."
+        },
+        {
+          "name": "Hornady Manufacturing",
+          "type": "manufacturing_plant",
+          "source_note": "Hornady Manufacturing, family-owned ammunition maker headquartered in Grand Island."
+        }
+      ],
+      "lat": 40.9264,
+      "lon": -98.342
+    },
+    "North Platte": {
+      "state": "Nebraska",
+      "region": "heartland",
+      "locations": [
+        {
+          "name": "Union Pacific Bailey Yard",
+          "type": "rail",
+          "source_note": "Union Pacific Bailey Yard, the world's largest railroad classification yard (~2,850 acres, 10,000 cars/day)."
+        },
+        {
+          "name": "North Platte Grain Terminal",
+          "type": "farm_elevator",
+          "source_note": "Grain and feedlot-supply shipping serving western Nebraska."
+        }
+      ],
+      "lat": 41.1239,
+      "lon": -100.7654
+    },
+    "Joplin": {
+      "state": "Missouri",
+      "region": "heartland",
+      "locations": [
+        {
+          "name": "CFI Freight Terminal",
+          "type": "cross_dock",
+          "source_note": "Contract Freighters, Inc. (CFI) truckload carrier terminal, headquartered in Joplin since 1951."
+        },
+        {
+          "name": "Eagle Picher Technologies",
+          "type": "manufacturing_plant",
+          "source_note": "Eagle Picher Technologies battery and defense-electronics manufacturing, Joplin."
+        }
+      ],
+      "lat": 37.0842,
+      "lon": -94.5133
+    },
+    "Rolla": {
+      "state": "Missouri",
+      "region": "heartland",
+      "locations": [
+        {
+          "name": "Royal Canin Pet Food Plant",
+          "type": "food_processor",
+          "source_note": "Royal Canin (Mars) pet food manufacturing plant, Rolla."
+        },
+        {
+          "name": "Brewer Science",
+          "type": "manufacturing_plant",
+          "source_note": "Brewer Science microelectronic-materials manufacturing and shipping campus, Rolla."
+        }
+      ],
+      "lat": 37.9514,
+      "lon": -91.7713
     }
   }
 }

--- a/tests/test_route_coverage_tool.py
+++ b/tests/test_route_coverage_tool.py
@@ -25,7 +25,7 @@ def test_route_coverage_report_is_machine_readable():
     assert report["metadata_contract"]["legacy_full_graph_available_for_old_saves"] is True
     assert report["metadata_contract"]["placeholder_pois_do_not_count_for_dispatch"]
     assert "source-backed truck-stop coverage" in report["current_batch_notes"][0]
-    assert report["totals"]["legs"] == 461
+    assert report["totals"]["legs"] == 472
     assert report["totals"]["playable"] == report["totals"]["legs"]
     assert report["missing_playable"] == []
     assert report["totals"]["route_points"] == report["totals"]["legs"]

--- a/tests/test_route_coverage_tool.py
+++ b/tests/test_route_coverage_tool.py
@@ -25,7 +25,7 @@ def test_route_coverage_report_is_machine_readable():
     assert report["metadata_contract"]["legacy_full_graph_available_for_old_saves"] is True
     assert report["metadata_contract"]["placeholder_pois_do_not_count_for_dispatch"]
     assert "source-backed truck-stop coverage" in report["current_batch_notes"][0]
-    assert report["totals"]["legs"] == 449
+    assert report["totals"]["legs"] == 461
     assert report["totals"]["playable"] == report["totals"]["legs"]
     assert report["missing_playable"] == []
     assert report["totals"]["route_points"] == report["totals"]["legs"]

--- a/tests/test_route_coverage_tool.py
+++ b/tests/test_route_coverage_tool.py
@@ -25,7 +25,7 @@ def test_route_coverage_report_is_machine_readable():
     assert report["metadata_contract"]["legacy_full_graph_available_for_old_saves"] is True
     assert report["metadata_contract"]["placeholder_pois_do_not_count_for_dispatch"]
     assert "source-backed truck-stop coverage" in report["current_batch_notes"][0]
-    assert report["totals"]["legs"] == 472
+    assert report["totals"]["legs"] == 484
     assert report["totals"]["playable"] == report["totals"]["legs"]
     assert report["missing_playable"] == []
     assert report["totals"]["route_points"] == report["totals"]["legs"]


### PR DESCRIPTION
Region-coverage batch (stacked on #36 Appalachia + #37 Heartland — merge those first; this diff resolves to southern-plains-only once they land).

## What
Fills the sparse Southern Plains:
- **San Angelo TX** — the empty Abilene–Midland triangle
- **Lawton OK** (I-44) — Goodyear's largest global tire plant + Fort Sill
- **Salina KS** — central Kansas I-70/I-135 crossroads
- **Enid OK** — one of the largest grain-storage hubs in the US
- **Dodge City + Garden City KS** — the southwest Kansas "Golden Triangle" beef belt (Cargill, National Beef, Tyson), paired ~50 mi apart for a real local run

ORS `driving-hgv` corridors with real miles, real facilities, real truck stops (curated plains Love's/Pilot).

## Checks
Full suite / ruff / coverage green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
