### PR TITLE
fix(license): use 2024-2026 copyright year range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
 
 <https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Required Notice: Copyright (c) 2026 Joshua Tubbs (Orinks)
+Required Notice: Copyright (c) 2024-2026 Joshua Tubbs (Orinks)
 
 ## Acceptance
 


### PR DESCRIPTION
## What changed and why

Updates the LICENSE Required Notice to "Copyright (c) 2024-2026 Joshua Tubbs (Orinks)". The repo was first published November 30, 2024 and is still maintained, so the conventional range form is correct. Same fix is already on dev (dfb47ce).

## What players will notice

Nothing in-game; this only touches the legal notice in the LICENSE file.

## Tests run

None needed -- text-only change to LICENSE.

## Accessibility impact

None; no spoken or UI text touched.

## Changelog

- [x] Not player-facing: commit carries [skip changelog].

🤖 Generated with [Claude Code](https://claude.com/claude-code)