### PR TITLE
ci: pin macOS release builds to macos-15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,11 @@ jobs:
         include:
           - os: windows-latest
             label: Windows
-          - os: macos-latest
+          # Pinned: macos-latest migrates to macOS 26 from 2026-06-15
+          # (actions/runner-images#14167). v1.8.0 shipped from macOS 15;
+          # revalidate the Nuitka app build and ad-hoc codesign on the new
+          # image before unpinning.
+          - os: macos-15
             label: macOS
           - os: ubuntu-latest
             label: Linux


### PR DESCRIPTION
## What changed and why

Pins the macOS release-build runner from `macos-latest` to `macos-15`. GitHub begins migrating the `macos-latest` label to macOS 26 on 2026-06-15 (actions/runner-images#14167 — the v1.8.0 build run carried this annotation). v1.8.0 shipped from macOS 15, so this keeps the Nuitka `--mode=app` build and ad-hoc codesign environment unchanged until a dry-run build validates the new image. Same pin is already on dev (cf8b63d); this PR applies it to main because scheduled nightly runs execute the workflow definition from the default branch.

## What players will notice

Nothing. Build infrastructure only; the macOS app keeps building exactly as it did for 1.8.0.

## Tests run

None needed beyond CI — workflow-only change. Validation plan for unpinning: `workflow_dispatch` with `dry_run` on a `macos-26` matrix entry before adopting the new image.

## Accessibility impact

None — no user-facing or spoken content touched.

## Changelog

- [x] Nothing player-facing: commit carries `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
