### PR TITLE
Fixed Job Dispatch Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@
   new as -- or newer than -- the latest nightly, so once those changes ship in
   a stable build you converge back onto stable instead of being left on an
   equivalent nightly.
+  
+  **Fixed** a bug in which pressing F1 on the "Back to terminal" entry on the dispatch board would crash the game.
 
 ### Changed
 - **Hours-of-service rules are more realistic.** Realistic mode now tracks the

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -842,7 +842,11 @@ class JobBoardState(MenuState):
     def handle_event(self, event) -> None:
         import pygame
 
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_F1 and self.jobs:
+        if (
+            event.type == pygame.KEYDOWN
+            and event.key == pygame.K_F1
+            and self.index < len(self.jobs)
+        ):
             self.ctx.push_state(JobDetailState(self.ctx, self, self.jobs[self.index]))
             return
         super().handle_event(event)

--- a/tests/test_dispatch_job_detail.py
+++ b/tests/test_dispatch_job_detail.py
@@ -119,6 +119,28 @@ def test_locked_job_detail_does_not_sound_accept_available():
         app.shutdown()
 
 
+def test_f1_on_back_item_does_not_crash():
+    from freight_fate.app import App
+    from freight_fate.states.city import JobBoardState, JobDetailState
+
+    app = App()
+    try:
+        board = _job_board(app)
+        # Move to the trailing "Back to terminal" item (past the last job).
+        board.handle_event(key_event(pygame.K_END))
+        assert board.index == len(board.jobs)
+        assert board.items[board.index].text == "Back to terminal"
+
+        # F1 here must not index off the end of the jobs list.
+        board.handle_event(key_event(pygame.K_F1))
+
+        assert app.state is board
+        assert isinstance(app.state, JobBoardState)
+        assert not isinstance(app.state, JobDetailState)
+    finally:
+        app.shutdown()
+
+
 def test_job_detail_accept_command_accepts_and_escape_returns():
     from freight_fate.app import App
     from freight_fate.states.city import JobBoardState, PickupFacilityState


### PR DESCRIPTION
Fixed a bug in which pressing F1 on the `Back to terminal' entry on the job dispatch board would crash the game.