### PR TITLE
feat(time): real US time zones over the compressed career clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added
+
+- **The map now has real time zones, and your clock changes as you cross
+  them.** Drive west out of Tennessee on I-40 and you will hear "You are
+  crossing into Central Time. Set your clock back one hour; it is now 2:15
+  PM." Every spoken clock -- rest stops, sleep, city arrivals, the driving
+  status screens -- now reads the local time where your truck is, and the
+  clock readouts name the zone, like "2:15 PM Central Time". Delivery
+  deadlines are also quoted the way a real receiver would say them: in the
+  destination's local time, like "deliver by 6 PM Central Time tomorrow", on
+  the dispatch job details and in the driving deadline readouts. Hours of
+  service, deadlines, and pay are untouched; only what the wall clock says
+  changes. Boundaries follow the real lines, including split states like
+  Tennessee, Kentucky, Indiana, the Florida panhandle, and far west Texas.
+
 ### Changed
 
 - **Cities that share a name now always say their state.** With two Jacksons,

--- a/src/freight_fate/music.py
+++ b/src/freight_fate/music.py
@@ -59,7 +59,12 @@ _TRACKS_BY_KEY = {track.key: track for track in ALL_MUSIC_TRACKS}
 
 
 def _profile_is_night(profile) -> bool:
-    """True when the loaded career's clock currently reads night."""
+    """True when the loaded career's clock currently reads night.
+
+    Reads the absolute career clock, not the current city's local time: menu
+    music is chosen before the world data (and with it the city's time zone)
+    is loaded, and a bed picked up to three hours off local dusk is cosmetic.
+    """
     if profile is None:
         return False
     hour = (getattr(profile, "game_hours", 0.0) or 0.0) % 24.0

--- a/src/freight_fate/sim/timezones.py
+++ b/src/freight_fate/sim/timezones.py
@@ -1,0 +1,234 @@
+"""United States time zones and the local wall clock.
+
+The career clock (``profile.game_hours``) and the trip clock
+(``Trip.current_hour``) are a single absolute timeline defined as Eastern
+Time; time compression only changes how fast that timeline advances. A time
+zone is a pure display layer over it: the local wall clock at any place is
+the absolute clock plus that place's fixed offset. Nothing that measures
+durations -- hours of service, deadlines, seasons, market days -- ever
+shifts; only what the player hears spoken as "the time" does.
+
+Zones are derived offline and deterministically from coordinates the world
+data already carries (cities and baked route points both have lat/lon plus a
+state). Whole states resolve through a table; the states a zone boundary
+splits (Tennessee, Kentucky, Indiana, the Florida panhandle, west Texas, and
+friends) use curated longitude/latitude rules that track the real boundary at
+game fidelity. Daylight saving time is deliberately not modeled: the career
+calendar is abstract, and fixed standard offsets keep the spoken clock
+predictable for screen reader players.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .hos import clock_text
+
+
+@dataclass(frozen=True)
+class TimeZone:
+    key: str
+    name: str  # spoken: "Central Time"
+    offset_h: float  # hours relative to Eastern, the game's reference clock
+
+
+EASTERN = TimeZone("eastern", "Eastern Time", 0.0)
+CENTRAL = TimeZone("central", "Central Time", -1.0)
+MOUNTAIN = TimeZone("mountain", "Mountain Time", -2.0)
+PACIFIC = TimeZone("pacific", "Pacific Time", -3.0)
+ALASKA = TimeZone("alaska", "Alaska Time", -4.0)
+HAWAII = TimeZone("hawaii", "Hawaii Time", -5.0)
+
+ZONES: dict[str, TimeZone] = {
+    zone.key: zone for zone in (EASTERN, CENTRAL, MOUNTAIN, PACIFIC, ALASKA, HAWAII)
+}
+
+# States that sit entirely inside one zone, keyed by the full state name the
+# world data uses. Arizona skips daylight saving in reality; with no DST in
+# the model it is plain Mountain here.
+_STATE_ZONES: dict[str, TimeZone] = {
+    "Connecticut": EASTERN,
+    "Delaware": EASTERN,
+    "District of Columbia": EASTERN,
+    "Georgia": EASTERN,
+    "Maine": EASTERN,
+    "Maryland": EASTERN,
+    "Massachusetts": EASTERN,
+    "New Hampshire": EASTERN,
+    "New Jersey": EASTERN,
+    "New York": EASTERN,
+    "North Carolina": EASTERN,
+    "Ohio": EASTERN,
+    "Pennsylvania": EASTERN,
+    "Rhode Island": EASTERN,
+    "South Carolina": EASTERN,
+    "Vermont": EASTERN,
+    "Virginia": EASTERN,
+    "West Virginia": EASTERN,
+    "Alabama": CENTRAL,
+    "Arkansas": CENTRAL,
+    "Illinois": CENTRAL,
+    "Iowa": CENTRAL,
+    "Louisiana": CENTRAL,
+    "Minnesota": CENTRAL,
+    "Mississippi": CENTRAL,
+    "Missouri": CENTRAL,
+    "Oklahoma": CENTRAL,
+    "Wisconsin": CENTRAL,
+    "Arizona": MOUNTAIN,
+    "Colorado": MOUNTAIN,
+    "Montana": MOUNTAIN,
+    "New Mexico": MOUNTAIN,
+    "Utah": MOUNTAIN,
+    "Wyoming": MOUNTAIN,
+    "California": PACIFIC,
+    "Washington": PACIFIC,
+    "Alaska": ALASKA,
+    "Hawaii": HAWAII,
+}
+
+
+def _florida(lat: float, lon: float) -> TimeZone:
+    # The panhandle west of the Apalachicola River keeps Central time.
+    return CENTRAL if lon < -85.1 else EASTERN
+
+
+def _indiana(lat: float, lon: float) -> TimeZone:
+    # The Gary and Evansville corners follow Chicago; the rest is Eastern.
+    return CENTRAL if lon < -87.25 else EASTERN
+
+
+def _kentucky(lat: float, lon: float) -> TimeZone:
+    # Western Kentucky (Bowling Green, Paducah) is Central; Louisville and
+    # Lexington are Eastern.
+    return CENTRAL if lon < -86.0 else EASTERN
+
+
+def _tennessee(lat: float, lon: float) -> TimeZone:
+    # East Tennessee (Knoxville, Chattanooga) is Eastern; the boundary runs
+    # just west of Chattanooga, so Nashville and Memphis are Central.
+    return CENTRAL if lon < -85.5 else EASTERN
+
+
+def _michigan(lat: float, lon: float) -> TimeZone:
+    # Four western Upper Peninsula counties border Wisconsin's clock.
+    return CENTRAL if lon < -89.5 and lat > 45.5 else EASTERN
+
+
+def _north_dakota(lat: float, lon: float) -> TimeZone:
+    # The southwest corner below the Missouri River is Mountain.
+    return MOUNTAIN if lon < -102.25 and lat < 47.5 else CENTRAL
+
+
+def _south_dakota(lat: float, lon: float) -> TimeZone:
+    # West River (Rapid City) is Mountain; Pierre and eastward are Central.
+    return MOUNTAIN if lon < -101.0 else CENTRAL
+
+
+def _nebraska(lat: float, lon: float) -> TimeZone:
+    # The panhandle from about Ogallala west is Mountain.
+    return MOUNTAIN if lon < -101.4 else CENTRAL
+
+
+def _kansas(lat: float, lon: float) -> TimeZone:
+    # The four westernmost border counties (Goodland) are Mountain.
+    return MOUNTAIN if lon < -101.5 else CENTRAL
+
+
+def _texas(lat: float, lon: float) -> TimeZone:
+    # Only El Paso and Hudspeth counties, in the far western wedge.
+    return MOUNTAIN if lon < -104.9 else CENTRAL
+
+
+def _idaho(lat: float, lon: float) -> TimeZone:
+    # The panhandle north of the Salmon River follows Spokane's clock.
+    return PACIFIC if lat > 45.5 else MOUNTAIN
+
+
+def _oregon(lat: float, lon: float) -> TimeZone:
+    # Ontario and most of Malheur County, on the Boise side of the desert.
+    return MOUNTAIN if lon > -117.3 and lat < 44.5 else PACIFIC
+
+
+def _nevada(lat: float, lon: float) -> TimeZone:
+    # The West Wendover sliver on the Utah line runs on Mountain time.
+    return MOUNTAIN if lon > -114.1 else PACIFIC
+
+
+_SPLIT_STATE_ZONES = {
+    "Florida": _florida,
+    "Indiana": _indiana,
+    "Kentucky": _kentucky,
+    "Tennessee": _tennessee,
+    "Michigan": _michigan,
+    "North Dakota": _north_dakota,
+    "South Dakota": _south_dakota,
+    "Nebraska": _nebraska,
+    "Kansas": _kansas,
+    "Texas": _texas,
+    "Idaho": _idaho,
+    "Oregon": _oregon,
+    "Nevada": _nevada,
+}
+
+
+def zone_for(lat: float, lon: float, state: str = "") -> TimeZone:
+    """The time zone at a coordinate, using the state when one is known.
+
+    With no usable state, rough boundary meridians decide -- good enough for
+    the open road between known places. Missing geometry (0, 0) resolves to
+    Eastern, the reference zone, so a synthetic or incomplete leg keeps the
+    clock it always had.
+    """
+    split = _SPLIT_STATE_ZONES.get(state)
+    if split is not None:
+        return split(lat, lon)
+    zone = _STATE_ZONES.get(state)
+    if zone is not None:
+        return zone
+    if lat == 0.0 and lon == 0.0:
+        return EASTERN
+    if lon >= -85.5:
+        return EASTERN
+    if lon >= -102.0:
+        return CENTRAL
+    if lon >= -114.5:
+        return MOUNTAIN
+    return PACIFIC
+
+
+def city_zone(city) -> TimeZone:
+    """The zone a City (or anything with lat, lon, and state) lives in."""
+    return zone_for(city.lat, city.lon, city.state)
+
+
+def to_local(game_hours: float, zone: TimeZone) -> float:
+    """Absolute (Eastern-reference) hours shifted onto a zone's wall clock.
+
+    Not wrapped to a day: callers doing clock math keep the full timeline,
+    and ``clock_text`` wraps for speech on its own.
+    """
+    return game_hours + zone.offset_h
+
+
+def local_clock_text(game_hours: float, zone: TimeZone, *, with_zone: bool = False) -> str:
+    """Spoken local wall clock, optionally naming the zone: '2:15 PM Central Time'."""
+    text = clock_text(to_local(game_hours, zone))
+    return f"{text} {zone.name}" if with_zone else text
+
+
+def appointment_text(now_game_hours: float, hours_from_now: float, zone: TimeZone) -> str:
+    """A future moment as a local appointment: '6 PM Central Time tomorrow'.
+
+    The day qualifier counts local midnights between now and the moment, so
+    "tomorrow" means what a driver parked at the receiver would mean by it.
+    """
+    local_now = to_local(now_game_hours, zone)
+    local_due = local_now + max(0.0, hours_from_now)
+    days_ahead = int(local_due // 24.0) - int(local_now // 24.0)
+    base = f"{clock_text(local_due)} {zone.name}"
+    if days_ahead <= 0:
+        return base
+    if days_ahead == 1:
+        return f"{base} tomorrow"
+    return f"{base} in {days_ahead} days"

--- a/src/freight_fate/sim/trip.py
+++ b/src/freight_fate/sim/trip.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import random
 
 from ..data.world import Leg, Route, get_world
-from .hos import is_night
+from .hos import clock_text, is_night
+from .timezones import appointment_text, city_zone, zone_for
 from .trip_models import *
 from .trip_route_helpers import *
 from .vehicle import TruckState
@@ -62,6 +63,8 @@ class Trip:
         self._events: list[TripEvent] = []
         self._leg_starts = self._compute_leg_starts()
         self._city_mileposts = list(self._leg_starts) + [self.total_miles]
+        self.start_timezone, self.timezone_crossings = self._compute_timezone_crossings()
+        self._current_timezone = self.start_timezone
         self.stops = self._place_stops()
         self.traffic_leads = self._place_traffic()
         self.navigation_cues = self._build_navigation_cues()
@@ -128,6 +131,101 @@ class Trip:
             starts.append(acc)
             acc += leg.miles
         return starts
+
+    def _timezone_samples(self) -> list[tuple[float, TimeZone]]:
+        """(trip mile, zone) along the route, from city and route-point geometry.
+
+        City endpoints are sampled too, so a leg with no baked geometry still
+        lands its clock change somewhere between two cities in different zones.
+        """
+        world = get_world()
+        samples: list[tuple[float, TimeZone]] = []
+        for i, (start, leg) in enumerate(zip(self._leg_starts, self.route.legs, strict=True)):
+            forward = self.route.cities[i] == leg.a
+            city = world.cities.get(self.route.cities[i])
+            if city is not None and (city.lat or city.lon):
+                samples.append((start, city_zone(city)))
+            for pt in leg.route_points:
+                offset = _stop_offset_for_direction(pt.at_mi, leg.miles, forward)
+                zone = zone_for(pt.lat, pt.lon, _leg_state_at(leg, pt.at_mi))
+                samples.append((start + offset, zone))
+        last = world.cities.get(self.route.cities[-1])
+        if last is not None and (last.lat or last.lon):
+            samples.append((self.total_miles, city_zone(last)))
+        samples.sort(key=lambda s: s[0])
+        return samples
+
+    def _compute_timezone_crossings(self) -> tuple[TimeZone, list[TimezoneCrossing]]:
+        """Start zone plus the deduped clock-change mileposts for the route.
+
+        A flip that reverts within ``TIMEZONE_DWELL_MI`` is a road hugging the
+        boundary, not a crossing, and is dropped -- same idea as the state
+        crossing sanitizer.
+        """
+        samples = self._timezone_samples()
+        if not samples:
+            return zone_for(0.0, 0.0), []
+        current = samples[0][1]
+        start = current
+        crossings: list[TimezoneCrossing] = []
+        for i, (mile, zone) in enumerate(samples):
+            if zone.key == current.key:
+                continue
+            settled = True
+            for later_mile, later_zone in samples[i + 1 :]:
+                if later_mile - mile > TIMEZONE_DWELL_MI:
+                    break
+                if later_zone.key == current.key:
+                    settled = False
+                    break
+            if settled:
+                crossings.append(TimezoneCrossing(mile, current, zone))
+                current = zone
+        return start, crossings
+
+    def timezone_at(self, mile: float) -> TimeZone:
+        """The time zone in effect at a trip milepost."""
+        zone = self.start_timezone
+        for crossing in self.timezone_crossings:
+            if crossing.at_mi <= mile:
+                zone = crossing.to_zone
+            else:
+                break
+        return zone
+
+    @property
+    def current_timezone(self) -> TimeZone:
+        return self.timezone_at(self.position_mi)
+
+    @property
+    def destination_timezone(self) -> TimeZone:
+        return self.timezone_at(self.total_miles)
+
+    @property
+    def local_hour(self) -> float:
+        """The wall clock where the truck is right now; what the player hears.
+
+        ``current_hour`` stays on the absolute (Eastern-reference) timeline
+        for durations and deadlines; only speech and day/night feel go local.
+        """
+        return (self.current_hour + self.current_timezone.offset_h) % 24.0
+
+    @property
+    def local_start_hour(self) -> float:
+        """The local wall clock at departure, for day/night placement."""
+        return (self.start_hour + self.start_timezone.offset_h) % 24.0
+
+    def deadline_clock_text(self, deadline_game_h: float, zone: TimeZone | None = None) -> str:
+        """The delivery appointment as a receiver would quote it: the wall
+        clock in the destination's zone, e.g. '6 PM Central Time tomorrow'.
+
+        ``zone`` overrides where the appointment is read -- a pickup drive's
+        trip ends at the origin facility, so its caller passes the delivery
+        city's zone instead of this trip's endpoint.
+        """
+        now = self.start_hour + self.game_minutes / 60.0
+        remaining = deadline_game_h - self.game_minutes / 60.0
+        return appointment_text(now, remaining, zone or self.destination_timezone)
 
     def _place_stops(self) -> list[RoadStop]:
         out: list[RoadStop] = []
@@ -290,7 +388,7 @@ class Trip:
         return cues
 
     def _place_zones(self) -> list[Zone]:
-        night = is_night(self.start_hour)
+        night = is_night(self.local_start_hour)
         zones: list[Zone] = []
         total = self.route.miles
         n = max(0, int(total / 150))
@@ -333,7 +431,7 @@ class Trip:
             base *= 1.3
         elif region in _COLD_PATROL_REGIONS:
             base *= 0.7
-        if is_night(self.start_hour):
+        if is_night(self.local_start_hour):
             base *= 1.15
         return base
 
@@ -381,7 +479,7 @@ class Trip:
             bad_weather_bias += (0.9 - effects.grip) * 0.45
         if effects.visibility_mi < 3.0:
             bad_weather_bias += (3.0 - effects.visibility_mi) * 0.05
-        night = is_night(self.start_hour)
+        night = is_night(self.local_start_hour)
         for start, leg in zip(self._leg_starts, self.route.legs, strict=True):
             if leg.miles < 70.0:
                 continue
@@ -680,6 +778,7 @@ class Trip:
             if i and self.position_mi >= start:
                 self._announced_cities.add(i)
         self._active_zone = self._active_zone_at(self.position_mi)
+        self._current_timezone = self.timezone_at(self.position_mi)
 
     def restore_toll_charges(self, charges: list[dict]) -> None:
         """Restore settlement toll expenses from an active-drive snapshot."""
@@ -740,6 +839,7 @@ class Trip:
         self._check_navigation_cues()
         self._check_tolls()
         self._check_cities()
+        self._check_timezone()
         if moved_mi > 0.0:
             self._check_hazards(moved_mi)
             self._check_conditions_speed(moved_mi)
@@ -798,6 +898,28 @@ class Trip:
                     f"Speed limit {self._speed_value(resumed)}.",
                 )
             self._active_zone = zone
+
+    def _check_timezone(self) -> None:
+        """Announce a clock change the moment the truck passes a zone boundary.
+
+        The message carries the new local time, so it is composed here at
+        crossing time rather than baked into a static cue at trip start.
+        """
+        zone = self.timezone_at(self.position_mi)
+        if zone.key == self._current_timezone.key:
+            return
+        previous = self._current_timezone
+        self._current_timezone = zone
+        hours = abs(zone.offset_h - previous.offset_h)
+        amount = "one hour" if hours == 1.0 else f"{hours:.0f} hours"
+        direction = "back" if zone.offset_h < previous.offset_h else "forward"
+        self._emit(
+            TripEventKind.TIMEZONE_CROSSING,
+            f"You are crossing into {zone.name}. Set your clock {direction} "
+            f"{amount}; it is now {clock_text(self.local_hour)}.",
+            from_zone=previous,
+            to_zone=zone,
+        )
 
     def _check_speed_limit(self) -> None:
         """Announce a changed posted limit on the open road (signs at a region
@@ -948,7 +1070,7 @@ class Trip:
         """
         vis = self.weather.effects.visibility_mi
         risk = 0.25 + (0.25 if vis < 2 else 0.0)
-        if is_night(self.current_hour):
+        if is_night(self.local_hour):
             risk += NIGHT_HAZARD_BONUS
         return risk * self.hazard_scale
 
@@ -979,7 +1101,7 @@ class Trip:
                 self.current_region,
                 self.weather.current,
                 self.terrain_at(self.position_mi),
-                self.current_hour,
+                self.local_hour,
             )
             if not choices:
                 return

--- a/src/freight_fate/sim/trip_models.py
+++ b/src/freight_fate/sim/trip_models.py
@@ -9,6 +9,7 @@ from enum import Enum
 
 from ..data.world import STOP_TYPE_LABELS, Leg, TollEvent
 from .hos import is_night, time_of_day
+from .timezones import TimeZone
 from .vehicle import TruckState
 from .weather import WeatherKind, WeatherSystem
 
@@ -132,6 +133,10 @@ FACILITY_GATE_LIMIT_MPH = 15.0
 DESTINATION_APPROACH_ZONE_MI = 3.0
 FACILITY_GATE_ZONE_MI = 0.5
 NIGHT_HAZARD_BONUS = 0.10  # extra hazard risk after dark
+# A zone flip that flips back within this distance is boundary noise from a
+# road hugging the line (the state-crossing dwell filter's lesson), not a
+# crossing the driver should reset a watch for.
+TIMEZONE_DWELL_MI = 10.0
 NIGHT_TRAFFIC_KEEP = 0.4  # chance a traffic zone still forms at night
 TRAFFIC_LOOKAHEAD_MI = 2.5
 TRAFFIC_WARNING_GAP_S = 2.2
@@ -347,6 +352,7 @@ class TripEventKind(Enum):
     INSPECTION = "inspection"
     GPS_CUE = "gps_cue"
     STATE_CROSSING = "state_crossing"
+    TIMEZONE_CROSSING = "timezone_crossing"
     CHECKPOINT = "checkpoint"
     TOLL_CHARGED = "toll_charged"
     ARRIVED = "arrived"
@@ -357,6 +363,15 @@ class TripEvent:
     kind: TripEventKind
     message: str
     data: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TimezoneCrossing:
+    """The trip milepost where the route passes into another time zone."""
+
+    at_mi: float
+    from_zone: TimeZone
+    to_zone: TimeZone
 
 
 @dataclass

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -14,6 +14,7 @@ from ..models.jobs import Job, JobBoard, job_from_payload, job_payload, normaliz
 from ..models.trucks import TRUCK_CATALOG
 from ..music import select_menu_music_sequence
 from ..sim.hos import clock_text, time_of_day
+from ..sim.timezones import city_zone, to_local
 from .base import MenuItem, MenuState
 from .career_stats import CareerStatsState, fully_rested
 from .city_dispatch import (
@@ -287,7 +288,8 @@ class CityMenuState(MenuState):
 
         p = self.ctx.profile
         city = self.ctx.world.city(p.current_city)
-        hour = p.game_hours % 24.0
+        zone = city_zone(city)
+        hour = to_local(p.game_hours, zone) % 24.0
         day = p.market_day() + 1
         desc, live = None, False
         provider = self.ctx.real_weather_provider()
@@ -309,7 +311,7 @@ class CityMenuState(MenuState):
             desc = WeatherSystem(city.region, seed=seed, game_hours=season_hours).describe()
         source = "Live weather" if live else "Weather"
         self.ctx.say(
-            f"It is {clock_text(hour)}, {time_of_day(hour)}, "
+            f"It is {clock_text(hour)} {zone.name}, {time_of_day(hour)}, "
             f"{date_text(season_hours)}, in {season(season_hours)}, "
             f"day {day} of your career. "
             f"{source} in {city.name}: {desc}."
@@ -334,7 +336,8 @@ class CityMenuState(MenuState):
         p.market.advance_to(p.market_day())
         self.ctx.save_profile()
         self.ctx.audio.play("ui/notify")
-        hour = p.game_hours % 24.0
+        zone = city_zone(self.ctx.world.city(p.current_city))
+        hour = to_local(p.game_hours, zone) % 24.0
         self.ctx.say(
             f"You slept 10 hours and woke rested. It is "
             f"{clock_text(hour)}, {time_of_day(hour)}. "

--- a/src/freight_fate/states/city_dispatch.py
+++ b/src/freight_fate/states/city_dispatch.py
@@ -15,6 +15,7 @@ from ..models.jobs import (
 )
 from ..music import select_menu_music_sequence
 from ..sim.hos import LIMITS
+from ..sim.timezones import appointment_text, city_zone
 from ..sim.vehicle import TruckState
 from .base import MenuItem, MenuState
 
@@ -319,7 +320,11 @@ class JobDetailState(MenuState):
             f"Distance: {job.distance_mi:.0f} miles.",
             f"Pay: {job.pay:,.0f} dollars.",
             f"Dollars per mile: {dollars_per_mile:.2f}.",
-            f"Deadline: {job.deadline_game_h:.0f} hours.",
+            # The appointment reads in the receiver's local time, the way real
+            # dispatch quotes it. "About" because the clock starts at pickup
+            # departure, after check-in and loading.
+            f"Deadline: {job.deadline_game_h:.0f} hours; deliver by about "
+            f"{appointment_text(p.game_hours, job.deadline_game_h, city_zone(world.city(job.destination)))}.",
             f"Equipment: {job.equipment_text()}.",
         ]
         locked = job.locked_reason(p.career.endorsements, p.career.level)

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -65,7 +65,7 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
         self._day_music_index = 0
         self._night_music_index = 0
         self._music_elapsed_s = 0.0
-        self._music_night = is_night(trip_start_hour)
+        self._music_night = is_night(self.trip.local_start_hour)
         self.tutorial = Tutorial(ctx) if not profile.tutorial_done else None
 
         self.hos = profile.hos  # shift clock lives on the profile
@@ -241,7 +241,7 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
         self.ctx.audio.set_weather(self.weather.effects.sound)
         self.ctx.audio.set_wind(self.weather.effects.wind)
         mode = "automatic" if self.truck.transmission.automatic else "manual"
-        now = clock_text(self.trip.current_hour)
+        now = clock_text(self.trip.local_hour)
         if self.resumed:
             hours_used = self.trip.game_minutes / 60.0
             drive_name = "pickup drive" if self.phase == DRIVE_PHASE_PICKUP else "loaded delivery"

--- a/src/freight_fate/states/driving_controls.py
+++ b/src/freight_fate/states/driving_controls.py
@@ -427,7 +427,8 @@ class DrivingControlsMixin:
             f"Air brakes: {self._air_status_text(detailed=True)}",
             f"Weather: {self.weather.describe(self.ctx.settings.imperial_units)}",
             f"Calendar: {self._calendar_phrase() or 'unknown'}",
-            f"Clock: {clock_text(self.trip.current_hour)} ({time_of_day(self.trip.current_hour)})",
+            f"Clock: {clock_text(self.trip.local_hour)} {self.trip.current_timezone.name} "
+            f"({time_of_day(self.trip.local_hour)})",
         ]
         if self._cruise_mph is not None:
             lines.insert(
@@ -505,7 +506,7 @@ class DrivingControlsMixin:
     def _clock_phrase(self) -> str:
         """'It is 5:33 AM, March 21, spring.' -- the time plus the calendar."""
         cal = self._calendar_phrase()
-        base = f"It is {clock_text(self.trip.current_hour)}"
+        base = f"It is {clock_text(self.trip.local_hour)} {self.trip.current_timezone.name}"
         return f"{base}, {cal}." if cal else f"{base}."
 
     def _speak_clock(self) -> None:
@@ -537,9 +538,11 @@ class DrivingControlsMixin:
                 if eta < remaining
                 else "You are running behind. Keep your speed up."
             )
+            appointment = _deadline_appointment(self)
             self.ctx.say(
                 f"{now} {hours_used:.1f} hours on the road. "
-                f"{remaining:.1f} hours until the deadline. "
+                f"{remaining:.1f} hours until the deadline; "
+                f"delivery is due by {appointment}. "
                 f"Estimated time to arrival {eta:.1f} hours {basis}. "
                 f"{verdict} {hos_part}"
             )
@@ -629,7 +632,7 @@ class DrivingControlsMixin:
         source = "Live conditions" if self.weather.live else "Currently"
         safe_speed = self.ctx.settings.speed_text(self.weather.effects.safe_speed_mph)
         parts = [
-            f"It is {time_of_day(self.trip.current_hour)}.",
+            f"It is {time_of_day(self.trip.local_hour)}.",
             f"{source} {self.weather.describe()}.",
             f"Safe speed about {safe_speed}.",
         ]

--- a/src/freight_fate/states/driving_core.py
+++ b/src/freight_fate/states/driving_core.py
@@ -36,6 +36,7 @@ from ..music import (
 from ..sim import hos
 from ..sim.hos import HosClock, clock_text, is_night, time_of_day
 from ..sim.lane import LaneKeeping
+from ..sim.timezones import city_zone
 from ..sim.transmission import REVERSE
 from ..sim.trip import RoadStop, Trip, TripEventKind
 from ..sim.vehicle import KG_PER_TON, G, TruckState
@@ -115,6 +116,10 @@ def _route_event_sound(event) -> str | None:
     if kind == TripEventKind.TOLL_CHARGED:
         return "events/toll_charged"
     if kind in {TripEventKind.STATE_CROSSING, TripEventKind.CHECKPOINT}:
+        return "events/state_crossing"
+    if kind == TripEventKind.TIMEZONE_CROSSING:
+        # A boundary marker like a state line; reuse its earcon until the
+        # sound pack gains a dedicated one.
         return "events/state_crossing"
     if kind == TripEventKind.ZONE_ENTER:
         zone = event.data.get("zone")
@@ -281,10 +286,22 @@ def _advance_rest_clock(driving: DrivingState, minutes: float) -> None:
     driving.weather.update(minutes)
 
 
+def _deadline_appointment(driving: DrivingState) -> str:
+    """The delivery appointment in the receiving city's local time.
+
+    Anchored on the job's destination, not the current trip's endpoint: a
+    pickup drive ends at the origin facility, possibly in another zone.
+    """
+    zone = city_zone(driving.ctx.world.city(driving.job.destination))
+    return driving.trip.deadline_clock_text(driving.job.deadline_game_h, zone)
+
+
 def _deadline_text(driving: DrivingState) -> str:
     remaining = driving.job.deadline_game_h - driving.trip.game_minutes / 60.0
     if remaining > 0:
-        return f"{remaining:.1f} hours left to deliver."
+        # The appointment reads in the receiver's local time, the way a real
+        # dispatcher quotes it -- the zone name keeps it unambiguous mid-route.
+        return f"{remaining:.1f} hours left to deliver; that is {_deadline_appointment(driving)}."
     return f"You are now {-remaining:.1f} hours past the deadline."
 
 
@@ -296,7 +313,7 @@ def _perform_shoulder_sleep(driving: DrivingState, anchor_mi: float) -> str:
     p.fatigue = hos.rest_shoulder(p.fatigue)
     parts = [
         f"You sleep poorly on the shoulder, woken again and again by "
-        f"passing trucks. It is {clock_text(driving.trip.current_hour)}. "
+        f"passing trucks. It is {clock_text(driving.trip.local_hour)}. "
         f"Hours of service reset, but you are still tired."
     ]
     if hos.shoulder_fine_due(driving.trip_seed, anchor_mi):

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -185,7 +185,7 @@ class DrivingEventMixin:
         self.truck.brake = 1.0
         self.truck.set_parking_brake()
         can_sleep = "sleep" in stop.actions
-        if can_sleep and hos.parking_is_full(self.trip_seed, stop.at_mi, self.trip.current_hour):
+        if can_sleep and hos.parking_is_full(self.trip_seed, stop.at_mi, self.trip.local_hour):
             self.ctx.push_state(ParkingFullState(self.ctx, self, stop))
             return
         self.ctx.push_state(RestStopState(self.ctx, self, stop))
@@ -796,8 +796,9 @@ class DrivingEventMixin:
             f"Remaining: {remaining}",
             f"Weather: {self.weather.current.value}",
             f"Date: {self._calendar_phrase() or 'unknown'}",
-            f"Clock: {clock_text(self.trip.current_hour)} "
-            f"({time_of_day(self.trip.current_hour)})   "
+            f"Clock: {clock_text(self.trip.local_hour)} "
+            f"{self.trip.current_timezone.name} "
+            f"({time_of_day(self.trip.local_hour)})   "
             f"Fatigue: {self.ctx.profile.fatigue:.0f}%",
             "",
             self._status_text,

--- a/src/freight_fate/states/driving_menu_states.py
+++ b/src/freight_fate/states/driving_menu_states.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F403,F405
 from __future__ import annotations
 
+from ..sim.timezones import to_local
 from .driving_core import *
 from .driving_rest_states import ShoulderSleepConfirmationState
 
@@ -101,7 +102,8 @@ class DrivingStatusScreenState(MenuState):
         hours_used = d.trip.game_minutes / 60.0
         deadline = d.job.deadline_game_h - hours_used
         deadline_text = (
-            f"{deadline:.1f} hours before the deadline"
+            f"{deadline:.1f} hours before the deadline, "
+            f"due {_deadline_appointment(d)}"
             if deadline >= 0
             else f"{-deadline:.1f} hours past the deadline"
         )
@@ -115,7 +117,8 @@ class DrivingStatusScreenState(MenuState):
             f"Transmission: {'automatic' if t.transmission.automatic else 'manual'}, {d._gear_text()}",
             f"Fatigue: {profile.fatigue:.0f} percent",
             f"Hours: {d.hos.summary(self.ctx.settings.hos_mode).rstrip('.')}",
-            f"Time: {clock_text(d.trip.current_hour)}, {deadline_text}",
+            f"Time: {clock_text(d.trip.local_hour)} {d.trip.current_timezone.name}, "
+            f"{deadline_text}",
         ]
 
     def _map_lines(self) -> list[str]:
@@ -271,7 +274,7 @@ class PauseMenuState(MenuState):
             f"{FIELD_REPAIR_DAMAGE_PCT:.0f} percent damage for "
             f"{cost:,.0f} dollars. You have {p.money:,.0f} dollars. "
             f"The repair took an hour and a half: it is "
-            f"{clock_text(d.trip.current_hour)}. {_deadline_text(d)}"
+            f"{clock_text(d.trip.local_hour)}. {_deadline_text(d)}"
         )
 
     def _emergency_shoulder_sleep(self) -> None:
@@ -540,7 +543,8 @@ class ArrivalState(MenuState):
             0,
             (
                 f"Bobtailed empty to {job.spoken_destination} in {hours:.1f} hours. "
-                f"It is {clock_text(p.game_hours)}. No load and no pay, but you are "
+                f"It is {clock_text(to_local(p.game_hours, d.trip.destination_timezone))}. "
+                f"No load and no pay, but you are "
                 f"parked at {self.terminal.name} and can shop the {job.spoken_destination} "
                 f"dispatch board. Fuel {d.truck.fuel_fraction * 100:.0f} percent."
             ),
@@ -616,7 +620,7 @@ class ArrivalState(MenuState):
                 f"Delivered {job.weight_tons:.0f} tons of {job.cargo.label} to "
                 f"{job.spoken_destination} in {hours:.1f} hours, "
                 f"{'on time' if on_time else 'late'}. "
-                f"It is {clock_text(p.game_hours)}. "
+                f"It is {clock_text(to_local(p.game_hours, d.trip.destination_timezone))}. "
                 f"Gross pay {gross_pay:,.0f} dollars. "
                 f"Carrier-paid or reimbursed charges {carrier_charges:,.0f} dollars: "
                 f"tolls {toll_expense:,.0f}, accessorials "
@@ -674,7 +678,7 @@ class ArrivalState(MenuState):
             f"Delivered {job.weight_tons:.0f} tons of {job.cargo.label} "
             f"to {job.spoken_destination}.",
             f"Trip time: {hours:.1f} hours, {timing.lower()}.",
-            f"It is {clock_text(p.game_hours)}.",
+            f"It is {clock_text(to_local(p.game_hours, d.trip.destination_timezone))}.",
             f"Parked at {self.terminal.name} for the {job.spoken_destination} service area.",
             f"Gross pay: {gross_pay:,.0f} dollars.",
             f"Carrier-paid or reimbursed charges: {carrier_charges:,.0f} "
@@ -766,7 +770,9 @@ class ArrivalState(MenuState):
         }
         if origin in route66 and dest in route66:
             ids.append("route66_run")
-        arrival_hour = self.driving.trip.current_hour
+        # Wall-clock badge conditions ("by Daybreak", "Midnight Freight") read
+        # the destination's local clock, matching what the player just heard.
+        arrival_hour = self.driving.trip.local_hour
         # Plain "deliver into this city" badges (titles claim nothing extra).
         simple_arrival = {
             "phoenix_az_us": "phoenix_arrival",

--- a/src/freight_fate/states/driving_rest_states.py
+++ b/src/freight_fate/states/driving_rest_states.py
@@ -174,7 +174,7 @@ class RestStopState(MenuState):
             parts.append(f"{self.stop.parking_text}.")
         parts.extend(
             [
-                f"It is {clock_text(self.driving.trip.current_hour)}.",
+                f"It is {clock_text(self.driving.trip.local_hour)}.",
                 self.current_text(),
             ]
         )
@@ -381,7 +381,7 @@ class RestStopState(MenuState):
         self.ctx.audio.play("ui/notify")
         self.ctx.say(
             f"You took a 30-minute break. "
-            f"It is {clock_text(d.trip.current_hour)}. "
+            f"It is {clock_text(d.trip.local_hour)}. "
             f"Your break requirement is reset and you feel a little "
             f"fresher. {_deadline_text(d)}"
         )
@@ -397,7 +397,7 @@ class RestStopState(MenuState):
         self.ctx.audio.play("ui/notify")
         self.ctx.say(
             f"You took a short food and coffee break. "
-            f"It is {clock_text(d.trip.current_hour)}. "
+            f"It is {clock_text(d.trip.local_hour)}. "
             f"{_deadline_text(d)}"
         )
 
@@ -428,7 +428,7 @@ class RestStopState(MenuState):
         )
         self.ctx.say(
             f"You slept {hours} hours in the sleeper berth. "
-            f"It is {clock_text(d.trip.current_hour)}. {status} {_deadline_text(d)}"
+            f"It is {clock_text(d.trip.local_hour)}. {status} {_deadline_text(d)}"
         )
         self.ctx.award_achievement("slept_on_route")
         self.refresh()
@@ -444,7 +444,7 @@ class RestStopState(MenuState):
         self.ctx.audio.play("ui/notify")
         self.ctx.say(
             f"You slept 10 hours and woke rested. "
-            f"It is {clock_text(d.trip.current_hour)}. "
+            f"It is {clock_text(d.trip.local_hour)}. "
             f"Hours of service reset. {_deadline_text(d)}"
         )
         self.ctx.award_achievement("slept_on_route")
@@ -464,7 +464,7 @@ class RestStopState(MenuState):
         self.ctx.audio.play("ui/notify")
         self.ctx.say(
             f"You bed down in the cramped lot, off to the side. "
-            f"It is {clock_text(d.trip.current_hour)}. Hours of service "
+            f"It is {clock_text(d.trip.local_hour)}. Hours of service "
             f"reset, but the rest was poor and you wake still tired. "
             f"{_deadline_text(d)}"
         )
@@ -490,7 +490,7 @@ class RestStopState(MenuState):
         self.ctx.audio.play("ui/notify")
         self.ctx.say(
             f"Truck repaired for {cost:,.0f} dollars. "
-            f"It is {clock_text(d.trip.current_hour)}. "
+            f"It is {clock_text(d.trip.local_hour)}. "
             f"You have {p.money:,.0f} dollars. {_deadline_text(d)}"
         )
         self.ctx.award_achievement("garage_repair")
@@ -514,7 +514,7 @@ class RestStopState(MenuState):
             f"Roadside assistance patched the truck to "
             f"{d.truck.damage_pct:.0f} percent damage for "
             f"{cost:,.0f} dollars. It is "
-            f"{clock_text(d.trip.current_hour)}. {_deadline_text(d)}"
+            f"{clock_text(d.trip.local_hour)}. {_deadline_text(d)}"
         )
 
     def _inspect(self) -> None:
@@ -524,7 +524,7 @@ class RestStopState(MenuState):
         self.ctx.audio.play("ui/notify")
         self.ctx.say(
             f"Inspection check-in complete at {self.stop.spoken_name}. "
-            f"It is {clock_text(d.trip.current_hour)}. "
+            f"It is {clock_text(d.trip.local_hour)}. "
             f"{_deadline_text(d)}"
         )
         self.ctx.award_achievement("inspection")
@@ -573,7 +573,7 @@ class ParkingFullState(MenuState):
         self.ctx.audio.set_ambient("poi/rest_stop_night")
         self.ctx.say(
             f"The truck parking at {self.stop.spoken_name} is full tonight. "
-            f"It is {clock_text(self.driving.trip.current_hour)}. "
+            f"It is {clock_text(self.driving.trip.local_hour)}. "
             f"{self.current_text()}"
         )
 

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -315,7 +315,7 @@ class DrivingUpdateMixin:
             mode
         )
 
-        night = is_night(self.trip.current_hour)
+        night = is_night(self.trip.local_hour)
         if moving:
             p.fatigue = min(100.0, p.fatigue + hos.fatigue_rate_per_min(night) * gm)
         fatigue = p.fatigue
@@ -447,7 +447,7 @@ class DrivingUpdateMixin:
             # Harsh, continuous pad buzz while over the rumble strip; refreshed
             # each frame, it stops on its own once steered back off.
             self.ctx.controller.rumble.rumble_strip(rumble)
-        night = is_night(self.trip.current_hour)
+        night = is_night(self.trip.local_hour)
         if night:
             audio.set_ambient("ambient/night")
         else:

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -1,0 +1,276 @@
+"""Time zones: coordinate-to-zone derivation, the local wall clock, trip
+boundary crossings with their spoken clock change, and delivery appointments
+quoted in the destination's local time."""
+
+from __future__ import annotations
+
+import pygame
+import pytest
+
+from freight_fate.data.world_models import Leg, Route, RoutePoint, StateMileage
+from freight_fate.sim import Trip, TruckState, WeatherSystem
+from freight_fate.sim.timezones import (
+    CENTRAL,
+    EASTERN,
+    MOUNTAIN,
+    PACIFIC,
+    appointment_text,
+    local_clock_text,
+    to_local,
+    zone_for,
+)
+from freight_fate.sim.trip_models import TripEventKind
+
+# --- zone derivation ----------------------------------------------------------
+
+
+def test_whole_states_resolve_from_the_table():
+    assert zone_for(33.75, -84.39, "Georgia") is EASTERN  # Atlanta
+    assert zone_for(41.88, -87.63, "Illinois") is CENTRAL  # Chicago
+    assert zone_for(39.74, -104.99, "Colorado") is MOUNTAIN  # Denver
+    assert zone_for(47.61, -122.33, "Washington") is PACIFIC  # Seattle
+
+
+@pytest.mark.parametrize(
+    "place, lat, lon, state, expected",
+    [
+        ("Knoxville", 35.96, -83.92, "Tennessee", EASTERN),
+        ("Chattanooga", 35.05, -85.31, "Tennessee", EASTERN),
+        ("Nashville", 36.16, -86.78, "Tennessee", CENTRAL),
+        ("Memphis", 35.15, -90.05, "Tennessee", CENTRAL),
+        ("Miami", 25.76, -80.19, "Florida", EASTERN),
+        ("Pensacola", 30.42, -87.22, "Florida", CENTRAL),
+        ("Louisville", 38.25, -85.76, "Kentucky", EASTERN),
+        ("Bowling Green", 36.99, -86.44, "Kentucky", CENTRAL),
+        ("Indianapolis", 39.77, -86.16, "Indiana", EASTERN),
+        ("Evansville", 37.97, -87.57, "Indiana", CENTRAL),
+        ("Dallas", 32.78, -96.80, "Texas", CENTRAL),
+        ("El Paso", 31.76, -106.49, "Texas", MOUNTAIN),
+        ("Sioux Falls", 43.55, -96.73, "South Dakota", CENTRAL),
+        ("Rapid City", 44.08, -103.23, "South Dakota", MOUNTAIN),
+        ("Boise", 43.62, -116.20, "Idaho", MOUNTAIN),
+        ("Coeur d'Alene", 47.68, -116.78, "Idaho", PACIFIC),
+        ("Portland", 45.52, -122.68, "Oregon", PACIFIC),
+        ("Ontario", 44.03, -116.96, "Oregon", MOUNTAIN),
+    ],
+)
+def test_split_states_follow_the_real_boundary(place, lat, lon, state, expected):
+    assert zone_for(lat, lon, state) is expected, place
+
+
+def test_unknown_state_falls_back_to_longitude():
+    assert zone_for(40.0, -75.0) is EASTERN
+    assert zone_for(40.0, -95.0) is CENTRAL
+    assert zone_for(40.0, -108.0) is MOUNTAIN
+    assert zone_for(40.0, -120.0) is PACIFIC
+
+
+def test_missing_geometry_keeps_the_reference_clock():
+    # Synthetic legs and incomplete data carry (0, 0); the clock must not move.
+    assert zone_for(0.0, 0.0) is EASTERN
+    assert zone_for(0.0, 0.0, "Atlantis") is EASTERN
+
+
+def test_every_world_city_resolves_to_a_conus_zone(world):
+    for key, city in world.cities.items():
+        zone = zone_for(city.lat, city.lon, city.state)
+        assert zone in (EASTERN, CENTRAL, MOUNTAIN, PACIFIC), (key, city.state)
+
+
+# --- the local wall clock -------------------------------------------------------
+
+
+def test_local_clock_wraps_backwards_across_midnight():
+    # 1 AM on the Eastern reference clock is 10 PM Pacific the night before.
+    assert to_local(1.0, PACIFIC) == -2.0
+    assert local_clock_text(1.0, PACIFIC) == "10 PM"
+
+
+def test_local_clock_can_name_its_zone():
+    assert local_clock_text(12.0, CENTRAL, with_zone=True) == "11 AM Central Time"
+
+
+# --- appointments ---------------------------------------------------------------
+
+
+def test_appointment_same_local_day():
+    assert appointment_text(6.0, 4.0, EASTERN) == "10 AM Eastern Time"
+
+
+def test_appointment_tomorrow_counts_local_midnights():
+    assert appointment_text(20.0, 10.0, EASTERN) == "6 AM Eastern Time tomorrow"
+
+
+def test_appointment_days_ahead():
+    assert appointment_text(6.0, 44.0, EASTERN) == "2 AM Eastern Time in 2 days"
+
+
+def test_appointment_tomorrow_judged_in_the_destination_zone():
+    # 10 PM on the reference clock is 9 PM Central; five hours later is past
+    # the receiver's midnight even though it is not past Eastern's.
+    assert appointment_text(22.0, 5.0, CENTRAL) == "2 AM Central Time tomorrow"
+
+
+# --- trip crossings -------------------------------------------------------------
+
+
+def _tennessee_leg() -> Leg:
+    """A stylized east-to-middle Tennessee leg: Eastern until the boundary at
+    the halfway point, Central beyond it. Kept under 70 miles so the trip
+    places no traffic or patrols for the synthetic endpoint cities."""
+    return Leg(
+        "A",
+        "B",
+        60.0,
+        "I-40",
+        "hills",
+        (),
+        state_miles=(StateMileage("Tennessee", 60.0),),
+        route_points=(
+            RoutePoint(0.0, 35.96, -83.92),
+            RoutePoint(20.0, 35.90, -85.00),
+            RoutePoint(30.0, 36.00, -85.80),
+            RoutePoint(40.0, 36.10, -86.30),
+            RoutePoint(60.0, 36.16, -86.78),
+        ),
+    )
+
+
+def _trip(route: Route, start_hour: float = 12.0) -> Trip:
+    return Trip(route, TruckState(), WeatherSystem("mid_south", seed=1), seed=2, start_hour=start_hour)
+
+
+def test_trip_finds_the_boundary_from_route_geometry():
+    trip = _trip(Route(["A", "B"], [_tennessee_leg()]))
+    assert trip.start_timezone is EASTERN
+    assert trip.destination_timezone is CENTRAL
+    assert [(c.at_mi, c.to_zone.key) for c in trip.timezone_crossings] == [(30.0, "central")]
+    assert trip.timezone_at(20.0) is EASTERN
+    assert trip.timezone_at(35.0) is CENTRAL
+
+
+def test_trip_reversed_route_mirrors_the_boundary():
+    trip = _trip(Route(["B", "A"], [_tennessee_leg()]))
+    assert trip.start_timezone is CENTRAL
+    assert trip.destination_timezone is EASTERN
+    # The crossing lands on the first sampled point inside the new zone, so
+    # driving the same leg the other way quantizes to the next sample over.
+    assert [(c.at_mi, c.to_zone.key) for c in trip.timezone_crossings] == [(40.0, "eastern")]
+
+
+def test_crossing_announces_the_new_local_clock_once():
+    trip = _trip(Route(["A", "B"], [_tennessee_leg()]), start_hour=12.0)
+    trip.position_mi = 35.0
+    trip._check_timezone()
+    events = [e for e in trip._events if e.kind == TripEventKind.TIMEZONE_CROSSING]
+    assert len(events) == 1
+    message = events[0].message
+    assert "Central Time" in message
+    assert "back" in message
+    assert "11 AM" in message  # noon Eastern reference is 11 AM Central
+    trip._check_timezone()
+    assert len([e for e in trip._events if e.kind == TripEventKind.TIMEZONE_CROSSING]) == 1
+
+
+def test_crossing_east_says_set_the_clock_forward():
+    trip = _trip(Route(["B", "A"], [_tennessee_leg()]), start_hour=12.0)
+    trip.position_mi = 45.0
+    trip._check_timezone()
+    events = [e for e in trip._events if e.kind == TripEventKind.TIMEZONE_CROSSING]
+    assert len(events) == 1
+    assert "Eastern Time" in events[0].message
+    assert "forward" in events[0].message
+
+
+def test_local_hour_follows_the_truck_across_the_boundary():
+    trip = _trip(Route(["A", "B"], [_tennessee_leg()]), start_hour=12.0)
+    assert trip.local_hour == 12.0
+    trip.position_mi = 35.0
+    assert trip.local_hour == 11.0
+
+
+def test_restore_past_the_boundary_does_not_reannounce(world):
+    # restore() walks real corridor data, so use a real route: resuming a
+    # save from beyond the boundary must adopt the zone silently.
+    route = world.route_options("Atlanta", "Dallas")[0]
+    trip = Trip(route, TruckState(), WeatherSystem("atlantic_southeast", seed=1), seed=2)
+    first = next(c for c in trip.timezone_crossings if c.to_zone is CENTRAL)
+    trip.restore(position_mi=first.at_mi + 5.0, game_minutes=120.0)
+    trip._check_timezone()
+    assert [e for e in trip._events if e.kind == TripEventKind.TIMEZONE_CROSSING] == []
+    assert trip.current_timezone is CENTRAL
+
+
+def test_boundary_zigzag_is_not_a_crossing():
+    # A road that pokes over the line and comes back within the dwell window
+    # (the I-84-on-the-Columbia lesson) must not move the clock at all.
+    leg = Leg(
+        "A",
+        "B",
+        60.0,
+        "I-40",
+        "hills",
+        (),
+        state_miles=(StateMileage("Tennessee", 60.0),),
+        route_points=(
+            RoutePoint(0.0, 35.96, -83.92),
+            RoutePoint(25.0, 35.90, -85.60),  # briefly over the line
+            RoutePoint(30.0, 35.90, -85.20),  # and straight back
+            RoutePoint(60.0, 35.96, -84.50),
+        ),
+    )
+    trip = _trip(Route(["A", "B"], [leg]))
+    assert trip.timezone_crossings == []
+    assert trip.destination_timezone is EASTERN
+
+
+# --- destination-local deadlines --------------------------------------------------
+
+
+def test_deadline_reads_in_the_destination_zone():
+    trip = _trip(Route(["A", "B"], [_tennessee_leg()]), start_hour=12.0)
+    assert trip.deadline_clock_text(10.0) == "9 PM Central Time"
+    assert trip.deadline_clock_text(20.0) == "7 AM Central Time tomorrow"
+
+
+def test_deadline_clock_is_anchored_at_trip_start():
+    trip = _trip(Route(["A", "B"], [_tennessee_leg()]), start_hour=12.0)
+    before = trip.deadline_clock_text(10.0)
+    trip.game_minutes = 180.0  # three hours of driving later...
+    assert trip.deadline_clock_text(10.0) == before  # ...the appointment holds
+
+
+# --- real world data ---------------------------------------------------------------
+
+
+def test_atlanta_to_dallas_crosses_into_central(world):
+    route = world.route_options("Atlanta", "Dallas")[0]
+    trip = Trip(route, TruckState(), WeatherSystem("atlantic_southeast", seed=1), seed=2)
+    assert trip.start_timezone is EASTERN
+    assert trip.destination_timezone is CENTRAL
+    keys = [(c.from_zone.key, c.to_zone.key) for c in trip.timezone_crossings]
+    assert ("eastern", "central") in keys
+
+
+def test_dispatch_detail_quotes_the_local_appointment():
+    from freight_fate.app import App
+    from freight_fate.models.jobs import JobBoard
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.city import JobBoardState
+
+    app = App()
+    try:
+        app.ctx.profile = Profile(name="Zones", current_city="Buffalo")
+        jobs = JobBoard(app.ctx.world, seed=7).offers(
+            "Buffalo", {"refrigerated", "heavy_haul", "high_value"}, level=5
+        )
+        board = JobBoardState(app.ctx, jobs)
+        app.push_state(board)
+        board.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_F1, mod=0, unicode="")
+        )
+        joined = " ".join(app.state.lines())
+        assert "deliver by about" in joined
+        assert "Time" in joined  # the zone is always named on the appointment
+    finally:
+        app.shutdown()


### PR DESCRIPTION
## What changed and why

A player reported that the absence of time zones was messing with his head on long hauls. The map now has real US time zones layered over the existing compressed career clock. The career clock stays a single absolute timeline (defined as Eastern Time), so time compression is untouched; a time zone is a pure display offset over it. Zones derive at runtime from coordinates the world data already carries -- city lat/lon/state and baked route points -- with curated boundary rules for split states (Tennessee, Kentucky, Indiana, the Florida panhandle, far west Texas, the Dakotas, Idaho, Oregon, and more). No world-data regen, no new dependencies, and no daylight saving time by design.

## What players or maintainers will notice

- Crossing a zone boundary plays the state-line earcon and announces, for example: "You are crossing into Central Time. Set your clock back one hour; it is now 2:15 PM." A dwell filter keeps boundary-hugging roads from flapping the clock.
- Every spoken clock (rest stops, sleep, city arrivals, status screens) reads the local time where the truck is, and clock readouts name the zone, like "2:15 PM Central Time".
- Delivery deadlines are also quoted the way a receiver would say them: in the destination's local time ("deliver by 6 PM Central Time tomorrow") on job details and driving readouts, anchored on the job destination even during a pickup drive.
- Day/night ambience, night music, fatigue, wildlife windows, and the overnight parking crunch follow the local sun. Hours of service, deadlines, seasons, market days, and pay are unchanged (real HOS runs on home-terminal time, so this is also the realistic call).
- Old saves shift their spoken time by up to three hours once, since the career clock now formally means Eastern; durations and money are unaffected.

## Tests and checks run

- `uv run pytest` -- full suite, 966 passed, including 39 new tests in `tests/test_timezones.py` (zone derivation incl. split states, local clock wrap, trip crossings both directions, dwell filter, save-resume silence, destination-local deadlines, real Atlanta-to-Dallas route, dispatch detail wording).
- `uv run ruff check src tests tools`
- `uv run python -m compileall src tests tools`

## Accessibility impact

All new information is spoken, never visual-only: the crossing announcement goes out on the driving event channel, names the zone in full ("Central Time"), states the clock adjustment in plain words ("set your clock back one hour"), and gives the new local time immediately so a screen reader player never has to infer it. Deadline appointments always name their zone so times stay unambiguous mid-route. No keyboard flow changed. Spoken wording is exercised directly by the new tests.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)