### PR TITLE
Abandon Job Confirmation Prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@
 
 ### Changed
 
+- **Abandoning a job now asks you to confirm.** Choosing Abandon job from the
+  pause menu opens a Yes or No prompt that starts on No, so you have to arrow
+  down to Yes to actually give up the load and pay the penalty. Choosing No
+  takes you straight back to the pause menu with the job intact.
 - **Cities that share a name now always say their state.** With two Jacksons,
   two Portlands, and three Springfields on the map, dispatch offers, route
   planning, GPS announcements, and delivery summaries now say "Jackson,

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -344,6 +344,7 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
 
 
 from .driving_menu_states import (  # noqa: E402,F401
+    AbandonJobConfirmationState,
     ArrivalState,
     DrivingStatusScreenState,
     DrivingStatusState,

--- a/src/freight_fate/states/driving_menu_states.py
+++ b/src/freight_fate/states/driving_menu_states.py
@@ -102,8 +102,7 @@ class DrivingStatusScreenState(MenuState):
         hours_used = d.trip.game_minutes / 60.0
         deadline = d.job.deadline_game_h - hours_used
         deadline_text = (
-            f"{deadline:.1f} hours before the deadline, "
-            f"due {_deadline_appointment(d)}"
+            f"{deadline:.1f} hours before the deadline, due {_deadline_appointment(d)}"
             if deadline >= 0
             else f"{-deadline:.1f} hours past the deadline"
         )
@@ -338,27 +337,8 @@ class PauseMenuState(MenuState):
         self.ctx.push_state(SettingsState(self.ctx))
 
     def _abandon(self) -> None:
-        from .city import CityMenuState
-
-        p = self.ctx.profile
-        p.money -= 500.0
-        p.career.reputation = max(0.0, p.career.reputation - 5.0)
-        p.truck_fuel_gal = self.driving.truck.fuel_gal
-        p.truck_damage_pct = self.driving.truck.damage_pct
-        # the hours spent on the failed run still happened: keep the world
-        # clock consistent with the HOS and fatigue already accrued
-        p.game_hours += self.driving.trip.game_minutes / 60.0
-        p.market.advance_to(p.market_day())
-        p.active_trip = None
-        p.pay_advance_used_for_load = False
-        self.ctx.save_profile()
-        self.ctx.say(
-            f"Job abandoned. You paid a five hundred dollar penalty and "
-            f"returned to {self.ctx.world.spoken_city(p.current_city)}.",
-            interrupt=True,
-        )
-        self.ctx.pop_state()  # close pause menu
-        self.ctx.replace_state(CityMenuState(self.ctx))
+        # Abandoning is destructive and one keystroke away, so confirm first.
+        self.ctx.push_state(AbandonJobConfirmationState(self.ctx, self.driving))
 
     def _quit_to_menu(self) -> None:
         from .main_menu import MainMenuState
@@ -373,6 +353,69 @@ class PauseMenuState(MenuState):
             interrupt=True,
         )
         self.ctx.reset_to(MainMenuState(self.ctx))
+
+
+class AbandonJobConfirmationState(MenuState):
+    """Yes/No guard in front of abandoning a job. Lands on "No" so giving up
+    the load takes a deliberate arrow to "Yes"."""
+
+    title = "Abandon job?"
+    intro_help = (
+        "Use up and down arrows to navigate, Enter to select. "
+        "Escape cancels and returns to the pause menu."
+    )
+
+    def __init__(self, ctx, driving: DrivingState) -> None:
+        super().__init__(ctx)
+        self.driving = driving
+
+    def announce_entry(self) -> None:
+        self.ctx.say(
+            f"{self.title} Abandoning gives up this load. You will pay a five "
+            "hundred dollar penalty, take a reputation hit, and return to "
+            f"{self.ctx.world.spoken_city(self.ctx.profile.current_city)}. "
+            f"{self.current_text()}"
+        )
+
+    def build_items(self) -> list[MenuItem]:
+        return [
+            MenuItem(
+                "No, keep driving",
+                self.go_back,
+                help="Return to the pause menu and keep this job.",
+            ),
+            MenuItem(
+                "Yes, abandon the job",
+                self._confirm,
+                help="Give up this job. Costs five hundred dollars and "
+                "reputation, and returns you to the origin city.",
+            ),
+        ]
+
+    def _confirm(self) -> None:
+        from .city import CityMenuState
+
+        p = self.ctx.profile
+        p.money -= 500.0
+        p.career.reputation = max(0.0, p.career.reputation - 5.0)
+        p.truck_fuel_gal = self.driving.truck.fuel_gal
+        p.truck_damage_pct = self.driving.truck.damage_pct
+        # the hours spent on the failed run still happened: keep the world
+        # clock consistent with the HOS and fatigue already accrued
+        p.game_hours += self.driving.trip.game_minutes / 60.0
+        p.market.advance_to(p.market_day())
+        p.active_trip = None
+        p.pay_advance_used_for_load = False
+        self.ctx.save_profile()
+        self.ctx.pop_state()  # close this confirmation
+        self.ctx.pop_state()  # close the pause menu
+        self.ctx.replace_state(CityMenuState(self.ctx))
+        # interrupt=True so this overrides any menu re-announcement during unwind
+        self.ctx.say(
+            f"Job abandoned. You paid a five hundred dollar penalty and "
+            f"returned to {self.ctx.world.spoken_city(p.current_city)}.",
+            interrupt=True,
+        )
 
 
 class FacilityArrivalState(MenuState):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -434,7 +434,11 @@ def test_upgrade_f1_help_explains_player_benefits():
 def test_pause_and_abandon_returns_to_city():
     from freight_fate.app import App
     from freight_fate.states.city import CityMenuState, PickupFacilityState, RouteSelectState
-    from freight_fate.states.driving import DrivingState, PauseMenuState
+    from freight_fate.states.driving import (
+        AbandonJobConfirmationState,
+        DrivingState,
+        PauseMenuState,
+    )
     from freight_fate.states.main_menu import MainMenuState, NameEntryState
 
     app = App()
@@ -475,8 +479,71 @@ def test_pause_and_abandon_returns_to_city():
         while pause.items[pause.index].text != "Abandon job":
             pause.handle_event(key_event(pygame.K_DOWN))
         pause.handle_event(key_event(pygame.K_RETURN))
+        # The abandon now needs a Yes/No confirmation that lands on No.
+        assert isinstance(app.state, AbandonJobConfirmationState)
+        confirm = app.state
+        assert confirm.items[confirm.index].text == "No, keep driving"
+        confirm.handle_event(key_event(pygame.K_DOWN))  # arrow to Yes
+        confirm.handle_event(key_event(pygame.K_RETURN))
         assert isinstance(app.state, CityMenuState)
         assert app.ctx.profile.money == money - 500.0
         assert app.ctx.profile.current_city == origin
+    finally:
+        app.shutdown()
+
+
+@pytest.mark.smoke
+def test_abandon_prompt_no_returns_to_pause_menu():
+    from freight_fate.app import App
+    from freight_fate.states.city import PickupFacilityState, RouteSelectState
+    from freight_fate.states.driving import (
+        AbandonJobConfirmationState,
+        DrivingState,
+        PauseMenuState,
+    )
+    from freight_fate.states.main_menu import MainMenuState, NameEntryState
+
+    app = App()
+    try:
+        app.push_state(MainMenuState(app.ctx))
+        while app.state.items[app.state.index].text != "New career":
+            app.state.handle_event(key_event(pygame.K_DOWN))
+        app.state.handle_event(key_event(pygame.K_RETURN))
+        assert isinstance(app.state, NameEntryState)
+        app.state.handle_event(key_event(pygame.K_RETURN))  # default name
+        app.state.handle_event(key_event(pygame.K_RETURN))  # default region
+        app.state.handle_event(key_event(pygame.K_RETURN))  # default home terminal
+        app.state.handle_event(key_event(pygame.K_RETURN))  # job board
+        board = app.state
+        while board.jobs[board.index].cargo.endorsement:  # skip locked teasers
+            board.handle_event(key_event(pygame.K_DOWN))
+        app.state.handle_event(key_event(pygame.K_RETURN))  # accept job
+        assert isinstance(app.state, DrivingState)
+        app.state.trip.position_mi = app.state.trip.total_miles
+        app.state.trip.finished = True
+        app.state.truck.velocity_mps = 0.0
+        app.state.update(1 / 60)
+        assert isinstance(app.state, PickupFacilityState)
+        app.state.handle_event(key_event(pygame.K_RETURN))  # check in at origin
+        app.state.handle_event(key_event(pygame.K_RETURN))  # load at dock
+        app.state.handle_event(key_event(pygame.K_RETURN))  # depart for destination
+        assert isinstance(app.state, RouteSelectState)
+        app.state.handle_event(key_event(pygame.K_RETURN))  # accept planned route
+        assert isinstance(app.state, DrivingState)
+
+        app.state.handle_event(key_event(pygame.K_ESCAPE))
+        assert isinstance(app.state, PauseMenuState)
+        pause = app.state
+        money = app.ctx.profile.money
+        active_trip = app.ctx.profile.active_trip
+        while pause.items[pause.index].text != "Abandon job":
+            pause.handle_event(key_event(pygame.K_DOWN))
+        pause.handle_event(key_event(pygame.K_RETURN))
+        assert isinstance(app.state, AbandonJobConfirmationState)
+        # Enter on the default "No" cancels and returns to the pause menu.
+        app.state.handle_event(key_event(pygame.K_RETURN))
+        assert app.state is pause
+        assert app.ctx.profile.money == money
+        assert app.ctx.profile.active_trip is active_trip
     finally:
         app.shutdown()

--- a/tests/test_trip_resume.py
+++ b/tests/test_trip_resume.py
@@ -184,7 +184,7 @@ def test_delivery_clears_the_saved_trip():
 def test_abandoning_clears_the_saved_trip():
     from freight_fate.app import App
     from freight_fate.states.city import CityMenuState
-    from freight_fate.states.driving import PauseMenuState
+    from freight_fate.states.driving import AbandonJobConfirmationState, PauseMenuState
 
     app = App()
     try:
@@ -197,6 +197,9 @@ def test_abandoning_clears_the_saved_trip():
         while pause.items[pause.index].text != "Abandon job":
             pause.handle_event(key_event(pygame.K_DOWN))
         pause.handle_event(key_event(pygame.K_RETURN))
+        assert isinstance(app.state, AbandonJobConfirmationState)
+        app.state.handle_event(key_event(pygame.K_DOWN))  # arrow to Yes
+        app.state.handle_event(key_event(pygame.K_RETURN))
         assert isinstance(app.state, CityMenuState)
         assert app.ctx.profile.active_trip is None
     finally:
@@ -209,7 +212,7 @@ def test_abandoning_keeps_the_hours_spent_driving():
     departure time, while HOS and fatigue kept the accrued hours."""
     from freight_fate.app import App
     from freight_fate.states.city import CityMenuState
-    from freight_fate.states.driving import PauseMenuState
+    from freight_fate.states.driving import AbandonJobConfirmationState, PauseMenuState
 
     app = App()
     try:
@@ -224,6 +227,9 @@ def test_abandoning_keeps_the_hours_spent_driving():
         while pause.items[pause.index].text != "Abandon job":
             pause.handle_event(key_event(pygame.K_DOWN))
         pause.handle_event(key_event(pygame.K_RETURN))
+        assert isinstance(app.state, AbandonJobConfirmationState)
+        app.state.handle_event(key_event(pygame.K_DOWN))  # arrow to Yes
+        app.state.handle_event(key_event(pygame.K_RETURN))
         assert isinstance(app.state, CityMenuState)
         assert app.ctx.profile.game_hours == pytest.approx(before + spent)
     finally:


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for branch targets,
     test commands, and accessibility expectations. -->

## What changed and why

Adds a confirmation prompt to the "Abandon job" option from the pause menu to prevent accidental presses.

## What players or maintainers will notice

You now land on a yes / no prompt with the no option being the default, which simply takes you back to the pause menu. The yes option abandons the job.

## Tests and checks run

all

<!-- e.g. uv run pytest, uv run ruff check src tests tools,
     plus any manual spoken-text or keyboard checks. -->

## Accessibility impact

<!-- Every gameplay path must stay usable by keyboard and screen reader.
     Say how you checked spoken text or keyboard flow, or why this change
     has no accessibility impact. -->

## Changelog

CI requires a `CHANGELOG.md` entry when user-facing paths (such as `src/`
or `docs/`) change. Check one:

- [ ] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.
