### PR TITLE
Transmission Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,12 @@
   when it happens, and the idle goes quiet with it. Thanks to Darren Duff
   for the report.
 
+- **Adaptive cruise no longer revs the engine when you press the clutch to
+  shift.** With a manual gearbox, holding the clutch under cruise control used
+  to send the engine screaming toward the redline. Now cruise eases off the
+  moment the clutch goes in, the engine settles back toward idle, and the speed
+  is picked back up smoothly once you let the clutch out.
+
 - **The engine no longer re-cranks when you pick a trip back up.** Resuming a
   saved haul with the engine already running -- or coming back from a menu
   mid-drive -- used to replay the ignition sound as if you had just turned the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,13 @@
   instead of only in the F1 help, so you can weigh routes the same way
   the end-of-trip summary describes them. Thanks to a player suggestion.
 
+- **Switching between forward and reverse now takes a deliberate action.** In an
+  automatic, braking to a stop no longer slips straight into reverse, and
+  holding the accelerator to stop while reversing no longer flips you straight
+  back into forward. Come to a stop, then release the control and press it again
+  to change direction. On a controller, let the trigger return to neutral first,
+  then press it again.
+
 - **Online settings are now gathered in one place.** The Discord presence
   toggle moved from Settings, Gameplay to Settings, Online, alongside the
   drivers board and the new cloud backup options. And before you have set
@@ -364,6 +371,11 @@
   truck were still idling with the engine off. The shutdown is now heard
   when it happens, and the idle goes quiet with it. Thanks to Darren Duff
   for the report.
+
+- **Using the accelerator to brake in reverse no longer speeds you up.** In an
+  automatic, pressing the accelerator while rolling backward is meant to slow
+  and stop the truck, but at higher reverse speeds it could push you faster
+  instead. It now brakes reliably all the way to a stop.
 
 - **Adaptive cruise no longer revs the engine when you press the clutch to
   shift.** With a manual gearbox, holding the clutch under cruise control used

--- a/src/freight_fate/controller.py
+++ b/src/freight_fate/controller.py
@@ -498,6 +498,17 @@ class ControllerManager:
         return self._brake if self.active else 0.0
 
     @property
+    def throttle_target(self) -> float:
+        """Instantaneous trigger position, before smoothing. Press/release
+        detection (e.g. the reverse shift gesture) must read this so a quick
+        tap registers -- the smoothed reads above lag behind the trigger."""
+        return self._throttle_target if self.active else 0.0
+
+    @property
+    def brake_target(self) -> float:
+        return self._brake_target if self.active else 0.0
+
+    @property
     def clutch(self) -> float:
         return self._clutch if self.active else 0.0
 

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -123,6 +123,10 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
         self._lane_rumble_timer = 0.0
         self._lane_guidance_state = "center"
         self._reverse_cue_active = False
+        # Prev-frame accel/brake state, so a forward<->reverse shift needs a
+        # fresh press (release then press) rather than a held control.
+        self._reverse_brake_held = False
+        self._reverse_accel_held = False
         self._status_text = f"Press {self.ctx.control_hint('engine')} to start the engine."
 
     def _terse_speech(self) -> bool:

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -108,6 +108,7 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
         self._destination_exit_announced_key = ""
         self._cruise_mph: float | None = None
         self._cruise_throttle = 0.0
+        self._cruise_applied = 0.0
         self._acc_following = False
         self._acc_weather_gap_said = False
         self._acc_limit_capped = False

--- a/src/freight_fate/states/driving_controls.py
+++ b/src/freight_fate/states/driving_controls.py
@@ -101,8 +101,10 @@ class DrivingControlsMixin:
         objective_help = self._objective_help()
         self.ctx.say(
             "Hold Up arrow to accelerate, Down arrow to brake. "
-            "When stopped in automatic, hold Down arrow to reverse slowly; "
-            "touch Up arrow to brake and return to forward. "
+            "In automatic, brake to a stop, then release the Down arrow and "
+            "press it again to shift into reverse and back slowly. While "
+            "reversing, hold the Up arrow to brake to a stop, then release it "
+            "and press again to shift back into forward. "
             "Hold B for the emergency brake, the hardest possible stop. "
             "K sets adaptive cruise at your current speed; bad weather "
             "increases the following gap, sharp posted-limit drops make it "
@@ -147,7 +149,11 @@ class DrivingControlsMixin:
             "The A button shifts up a gear and the X button shifts down, while "
             "you hold the left bumper for the clutch. "
             if manual
-            else ""
+            else "In automatic, brake to a stop, then let the left trigger "
+            "return to neutral and press it again to shift into reverse and "
+            "back slowly. While reversing, hold the right trigger to brake to a "
+            "stop, then let it return to neutral and press again to shift back "
+            "into forward. "
         )
         self.ctx.say(
             "Right trigger is the gas, left trigger the brake; press the left "

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -457,6 +457,7 @@ class DrivingEventMixin:
             return
         self._cruise_mph = t.speed_mph
         self._cruise_throttle = t.throttle
+        self._cruise_applied = t.throttle
         self._acc_following = False
         self._acc_weather_gap_said = False
         self._acc_limit_capped = False
@@ -485,6 +486,7 @@ class DrivingEventMixin:
     def _cancel_cruise(self) -> None:
         self._cruise_mph = None
         self._cruise_throttle = 0.0
+        self._cruise_applied = 0.0
         self._acc_following = False
         self._acc_weather_gap_said = False
         self._acc_limit_capped = False
@@ -533,7 +535,9 @@ class DrivingEventMixin:
             probe += ACC_LIMIT_LOOKAHEAD_STEP_MI
         return lowest_limit, lowest_reason
 
-    def _update_cruise(self, dt: float, braking: bool, accelerating: bool) -> None:
+    def _update_cruise(
+        self, dt: float, braking: bool, accelerating: bool, clutch_disengaged: bool
+    ) -> None:
         """Hold speed when clear, and follow slower modeled traffic when present."""
         if self._cruise_mph is None:
             return
@@ -544,6 +548,14 @@ class DrivingEventMixin:
             return
         if accelerating:
             return  # manual override; cruise resumes when the key lifts
+        if clutch_disengaged:
+            # Clutch in / mid-shift: driveline is open, so any applied throttle
+            # only free-revs the engine. Cut throttle to idle and hold the
+            # integrator; the applied throttle ramps back up from zero once the
+            # clutch engages again.
+            t.throttle = 0.0
+            self._cruise_applied = 0.0
+            return
         target_mph = self._cruise_mph
         # Predictive ACC: never carry the driver past the posted limit. With real
         # OSM limits baked per leg, a held set speed would otherwise sail through
@@ -583,7 +595,15 @@ class DrivingEventMixin:
         self._acc_following = following
         error = target_mph - t.speed_mph
         self._cruise_throttle = max(0.0, min(1.0, self._cruise_throttle + error * 0.08 * dt))
-        t.throttle = self._cruise_throttle
+        # Ramp the applied throttle up to the held integrator value rather than
+        # snapping, so cruise eases back in after a clutch release; drops (traffic
+        # or a lower limit) still apply immediately. On a steady frame the applied
+        # throttle already equals _cruise_throttle, so this holds as before.
+        if self._cruise_throttle > self._cruise_applied:
+            self._cruise_applied = min(self._cruise_throttle, self._cruise_applied + dt * 2.2)
+        else:
+            self._cruise_applied = self._cruise_throttle
+        t.throttle = self._cruise_applied
         if (following or limit_capped) and error < -2.0:
             weather_brake = 0.45 if self.weather.effects.grip < 0.7 else 0.65
             t.brake = max(t.brake, min(weather_brake, abs(error) / 30.0))

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -87,8 +87,9 @@ class DrivingUpdateMixin:
         if pad_on:
             clutch_val = max(clutch_val, pad.clutch)
         t.transmission.clutch = clutch_val if not t.transmission.automatic else 0.0
+        clutch_disengaged = t.transmission.clutch > 0.5 or t.transmission.shifting
         self._update_lane(keys, dt)
-        self._update_cruise(dt, braking, accelerating)
+        self._update_cruise(dt, braking, accelerating, clutch_disengaged)
 
         if t.transmission.automatic and t.engine_on:
             new_gear = t.auto_shift()

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -30,10 +30,16 @@ class DrivingUpdateMixin:
         key_down = keys[pygame.K_DOWN]
         accelerating = key_up or pad_throttle > 0.05
         braking_key = key_down or pad_brake > 0.05
-        backing = self._update_reverse_controls(accelerating, braking_key)
+        # The shift gesture keys off a fresh press, so it reads the trigger's
+        # instantaneous position rather than the smoothed accelerate/brake
+        # values above -- otherwise the smoothing lag swallows a quick tap and
+        # the release-then-press never registers as neutral in between.
+        accel_held = key_up or (pad.throttle_target if pad_on else 0.0) > 0.05
+        brake_held = key_down or (pad.brake_target if pad_on else 0.0) > 0.05
+        backing = self._update_reverse_controls(accelerating, braking_key, accel_held, brake_held)
         if accelerating and not backing and t.air_brakes_holding:
             self._maybe_say_air_brake_lockout()
-        if key_up and not backing:
+        if key_up and not backing and not t.transmission.in_reverse:
             if t.engine_brake:
                 t.engine_brake = False
                 self.ctx.say_event("Engine brake off.", interrupt=False)
@@ -42,7 +48,7 @@ class DrivingUpdateMixin:
             t.throttle = min(0.45, t.throttle + ramp)
         else:
             t.throttle = max(0.0, t.throttle - ramp * 2)
-        if pad_throttle > 0.05 and not backing:
+        if pad_throttle > 0.05 and not backing and not t.transmission.in_reverse:
             if t.engine_brake:
                 t.engine_brake = False
                 self.ctx.say_event("Engine brake off.", interrupt=False)
@@ -269,14 +275,38 @@ class DrivingUpdateMixin:
             # flickers across it every cycle and re-announces back to back.
             self._air_ready_said = False
 
-    def _update_reverse_controls(self, accelerating: bool, braking_key: bool) -> bool:
-        """Return True when the current key state means backing up."""
+    def _update_reverse_controls(
+        self,
+        accelerating: bool,
+        braking_key: bool,
+        accel_held: bool | None = None,
+        brake_held: bool | None = None,
+    ) -> bool:
+        """Return True when the current key state means backing up.
+
+        ``accel_held``/``brake_held`` are the instantaneous (unsmoothed) press
+        states used for the shift-gesture edge detection; they default to the
+        ramped ``accelerating``/``braking_key`` for the keyboard, where the two
+        are the same.
+        """
         t = self.truck
         tr = t.transmission
+        if accel_held is None:
+            accel_held = accelerating
+        if brake_held is None:
+            brake_held = braking_key
+        # A direction change needs a fresh press (rising edge): braking or
+        # accelerating to a stop and holding the control no longer flips gears --
+        # the player must release and press again. For a controller this is the
+        # trigger returning to neutral and being pressed once more.
+        brake_edge = brake_held and not self._reverse_brake_held
+        accel_edge = accel_held and not self._reverse_accel_held
+        self._reverse_brake_held = brake_held
+        self._reverse_accel_held = accel_held
         if not tr.automatic:
             return tr.in_reverse and braking_key and not accelerating
         if tr.in_reverse:
-            if accelerating and abs(t.velocity_mps) < 0.3:
+            if accel_edge and abs(t.velocity_mps) < 0.3:
                 tr.gear = 1
                 tr._shift_timer = 0.0
                 self.ctx.audio.play("vehicle/gear_shift", volume=0.55)
@@ -284,7 +314,7 @@ class DrivingUpdateMixin:
                 self.ctx.say_event("Forward gear selected.", interrupt=False)
                 return False
             return braking_key and not accelerating
-        if braking_key and not accelerating and t.speed_mph < 0.5:
+        if brake_edge and not accel_held and t.speed_mph < 0.5:
             tr.gear = REVERSE
             tr._shift_timer = 0.0
             self._cancel_cruise()

--- a/tests/test_driving_cruise_weather.py
+++ b/tests/test_driving_cruise_weather.py
@@ -47,6 +47,59 @@ def test_cruise_control_holds_the_set_speed(monkeypatch):
         app.shutdown()
 
 
+def test_cruise_does_not_rev_engine_when_clutch_is_depressed(monkeypatch):
+    from freight_fate.app import App
+
+    class Keys:
+        pressed = set()
+
+        def __getitem__(self, key):
+            return key in self.pressed
+
+    keys = Keys()
+    monkeypatch.setattr(pygame.key, "get_pressed", lambda: keys)
+
+    app = App()
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        driving.trip.zones = []
+        open_limits(driving)
+        t = driving.truck
+        driving.handle_event(key_event(pygame.K_e))  # engine on
+        t.cargo_kg = 0.0
+        t.grade = 0.0
+        t.transmission.automatic = False  # the bug is manual-only
+        t.transmission.gear = 10
+        t.velocity_mps = 26.8  # ~60 mph
+        t.throttle = 0.35
+        driving.handle_event(key_event(pygame.K_k))  # engage cruise
+        # Let cruise settle to its holding throttle with the clutch out.
+        for _ in range(30):
+            driving.update(1 / 60)
+        held_throttle = driving._cruise_throttle
+        assert held_throttle > 0.05
+        assert t.rpm < t.specs.max_rpm * 0.9
+
+        # Depress the clutch to shift: throttle must cut to idle, not free-rev.
+        keys.pressed = {pygame.K_LSHIFT}
+        for _ in range(30):  # ~0.5 s clutch in
+            driving.update(1 / 60)
+            assert t.throttle == 0.0
+        assert driving._cruise_mph is not None  # cruise stays engaged
+        assert t.rpm < t.specs.max_rpm * 0.6  # engine settled toward idle
+
+        # Release the clutch: cruise ramps the throttle back up toward the hold.
+        keys.pressed = set()
+        driving.update(1 / 60)
+        assert t.throttle > 0.0
+        for _ in range(30):
+            driving.update(1 / 60)
+        assert t.throttle > held_throttle * 0.5
+    finally:
+        app.shutdown()
+
+
 @pytest.mark.smoke
 def test_cruise_set_point_adjusts_with_plus_and_minus():
     from freight_fate.app import App

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -135,6 +135,91 @@ def test_automatic_reverse_selection_is_spoken(monkeypatch):
         app.shutdown()
 
 
+def test_automatic_held_brake_does_not_engage_reverse(monkeypatch):
+    """Braking to a stop and holding must not slip into reverse; only a fresh
+    press (release, then press again) engages it."""
+    from freight_fate.app import App
+
+    app = App()
+    monkeypatch.setattr(app.ctx.audio, "play", lambda *a, **k: None)
+    monkeypatch.setattr(app.ctx, "say_event", lambda *a, **k: None)
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        driving.truck.velocity_mps = 0.0
+        # Brake was already held coming into this frame, as after braking to
+        # a stop -- no rising edge, so reverse must not engage.
+        driving._reverse_brake_held = True
+        assert not driving._update_reverse_controls(accelerating=False, braking_key=True)
+        assert not driving.truck.transmission.in_reverse
+        # Release the brake, then a fresh press engages reverse.
+        assert not driving._update_reverse_controls(accelerating=False, braking_key=False)
+        assert driving._update_reverse_controls(accelerating=False, braking_key=True)
+        assert driving.truck.transmission.in_reverse
+    finally:
+        app.shutdown()
+
+
+def test_automatic_held_accelerator_does_not_flip_out_of_reverse(monkeypatch):
+    """Holding the accelerator to brake a reverse roll to a stop must not flip
+    to forward; a fresh press is required."""
+    from freight_fate.app import App
+    from freight_fate.sim.transmission import REVERSE
+
+    app = App()
+    monkeypatch.setattr(app.ctx.audio, "play", lambda *a, **k: None)
+    monkeypatch.setattr(app.ctx, "say_event", lambda *a, **k: None)
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        tr = driving.truck.transmission
+        tr.gear = REVERSE
+        driving.truck.velocity_mps = 0.0
+        # Accelerator was held while it braked the reverse roll to a stop.
+        driving._reverse_accel_held = True
+        assert not driving._update_reverse_controls(accelerating=True, braking_key=False)
+        assert tr.in_reverse
+        # Release, then a fresh press flips to forward.
+        driving._update_reverse_controls(accelerating=False, braking_key=False)
+        driving._update_reverse_controls(accelerating=True, braking_key=False)
+        assert not tr.in_reverse
+    finally:
+        app.shutdown()
+
+
+def test_accelerator_does_not_thrust_while_braking_in_reverse(monkeypatch):
+    """Pressing the accelerator to brake a backward roll must never command
+    reverse thrust -- throttle stays down while the service brake engages."""
+    from freight_fate.app import App
+    from freight_fate.sim.transmission import REVERSE
+
+    class Keys:
+        def __getitem__(self, key):
+            return key == pygame.K_UP
+
+    app = App()
+    monkeypatch.setattr(pygame.key, "get_pressed", lambda: Keys())
+    monkeypatch.setattr(app.ctx.audio, "play", lambda *a, **k: None)
+    monkeypatch.setattr(app.ctx, "say_event", lambda *a, **k: None)
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        t = driving.truck
+        t.transmission.gear = REVERSE
+        t.velocity_mps = -3.0
+        t.throttle = 0.5
+        # Accelerator already held, so this is not a fresh press: no gear flip.
+        driving._reverse_accel_held = True
+
+        driving.update(1 / 60)
+
+        assert t.transmission.in_reverse
+        assert t.throttle < 0.5  # decays toward 0 rather than ramping up
+        assert t.brake > 0.0  # the service brake is what arrests the roll
+    finally:
+        app.shutdown()
+
+
 def test_driving_f1_describes_safe_shutdown_and_destination_parking(monkeypatch):
     from freight_fate.app import App
 


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for branch targets,
     test commands, and accessibility expectations. -->

## What changed and why

##### Manual Transmission

* Shifting with adaptive cruise on now properly releases the throttle back to idle

##### Automatic transmission

* Service brakes no longer fight acceleration and deceleration in reverse
* Shifts from reverse to forward, and forward now require an explicit action from the player
    * Keyboard: When stopped, lift finger from brake and depress to shift into reverse. To shift into forward, come to a stop, lift finger from accelerator and depress
    * Controller: Fully lift finger from trigger after a stop, depress to shift and set out

## What players or maintainers will notice

These changes aim to make the driving experience smoother and a bit more realistic. In manual, the player could unknowingly accrue damage to their truck when shifting because the cruise control throttle would never release when the clutch was activated, causing revs to reach red line while a shift was in progress. Now, this should not occur unless the player is letting their revs hang near red line. The automatic shifting from reverse to forward and vise versa felt buggy. Turns out, it kind of was. This should see things be a lot smoother, and players can stop at ease without worrying about an unwanted shift into reverse and being launched backward.

## Tests and checks run

all

<!-- e.g. uv run pytest, uv run ruff check src tests tools,
     plus any manual spoken-text or keyboard checks. -->

## Accessibility impact

neutral

<!-- Every gameplay path must stay usable by keyboard and screen reader.
     Say how you checked spoken text or keyboard flow, or why this change
     has no accessibility impact. -->

## Changelog

CI requires a `CHANGELOG.md` entry when user-facing paths (such as `src/`
or `docs/`) change. Check one:

- [ ] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.
