### PR TITLE
Controller fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,6 +330,21 @@
   open road, not on a two-minute crawl at yard speeds. Thanks to a player
   report.
 
+- **Reconnecting a controller no longer crashes the game or leaves it
+  half-working.** Unplugging a pad -- or having it change to another device and
+  come back over Bluetooth -- could crash the game outright, or bring the
+  controller back with the triggers and bumpers dead so you could steer but not
+  brake. The game now recovers from the hot-plug instead of crashing, and
+  fully re-acquires the controller when it returns -- even when the system hands
+  it back under a new identity -- so braking, throttle, and the bumpers work
+  again right away.
+
+- **Controller toggle actions no longer fire twice.** On some controllers --
+  notably the Xbox Elite -- setting or releasing the parking brake, or starting
+  or shutting down the engine, could trigger twice from a single press, so the
+  action immediately undid itself. Each button press now counts once, even when
+  the controller reports itself to the system more than once.
+
 - **Construction zones no longer stack or chain together.** Slow zones were
   placed independently, so a construction zone could land inside another
   one, or two could start back to back with no open road between. Zones now

--- a/src/freight_fate/app.py
+++ b/src/freight_fate/app.py
@@ -374,13 +374,13 @@ class App:
     def _dispatch_controller(self, event: pygame.event.Event) -> None:
         """Feed a controller event to the manager, then to the active state.
 
-        The manager updates its cached axis/modifier/hot-plug state first;
-        only button presses are then handed to the state, which routes them
-        to the same methods keyboard events already call.
+        The manager updates its cached axis/modifier/hot-plug state first and
+        reports whether the event is an accepted button press for the bound
+        controller; only those reach the state, so a duplicate from a pad that
+        enumerates twice can never fire an action a second time.
         """
-        self.controller.process_event(event)
-        button_event = event.type in (pygame.CONTROLLERBUTTONDOWN, pygame.CONTROLLERBUTTONUP)
-        if button_event and self.controller.active and self.state is not None:
+        forward = self.controller.process_event(event)
+        if forward and self.controller.active and self.state is not None:
             self.state.handle_controller(event, self.controller)
 
     # -- main loop ------------------------------------------------------------
@@ -399,7 +399,23 @@ class App:
         try:
             while self.running:
                 dt = self.clock.tick(FPS) / 1000.0
-                for event in pygame.event.get():
+                try:
+                    events = pygame.event.get()
+                except Exception:
+                    # A controller hot-plug (notably a Bluetooth resume) can make
+                    # SDL's internal instance-id map inconsistent, and pygame's
+                    # controller layer then raises out of the C event pump
+                    # (KeyError surfacing as SystemError). Losing this batch of
+                    # events is survivable; crashing the game is not.
+                    log.exception(
+                        "pygame.event.get() failed (frame %d; controller %s); skipping this batch",
+                        frames,
+                        "connected" if self.controller.connected else "disconnected",
+                    )
+                    with contextlib.suppress(Exception):
+                        pygame.event.pump()
+                    continue
+                for event in events:
                     if event.type == pygame.WINDOWFOCUSGAINED:
                         # Switching screen readers happens outside the game;
                         # re-check speech the moment the player comes back.

--- a/src/freight_fate/controller.py
+++ b/src/freight_fate/controller.py
@@ -106,6 +106,17 @@ class ControllerManager:
         self._instance_id: int | None = None
         self._name = ""
         self._disconnected = False  # latched until the app consumes it
+        # A freshly opened pad reports a device id from ``Controller.id`` that a
+        # hot-plug can leave stale (the events then arrive under a different id).
+        # We treat the opened id as provisional and adopt the id of the first
+        # real event we see, so the binding always matches the live event stream.
+        self._id_pending = False
+        # Buttons currently held, so a duplicate press (some pads/drivers deliver
+        # a button twice) fires its action only once, on the genuine transition.
+        self._buttons_down: set[int] = set()
+        # Last "foreign" instance id we logged a dropped event for, so a stream
+        # of events from a stale/other pad logs once rather than every frame.
+        self._logged_mismatch_id: int | None = None
         # Haptics live in their own pygame-free engine; we only supply the
         # guarded device send/stop and drive it once per frame in tick().
         self.rumble = RumbleEngine(send=self._device_rumble, stop=self._device_stop_rumble)
@@ -175,22 +186,100 @@ class ControllerManager:
         with contextlib.suppress(Exception):  # pragma: no cover - driver dependent
             self._controller.stop_rumble()
 
+    # Controls SDL surfaces on a fully mapped pad; a reconnect that drops these
+    # is the signature of the "dead triggers/shoulders" fault, so we check them.
+    _ESSENTIAL_MAPPINGS = ("lefttrigger", "righttrigger", "leftshoulder", "rightshoulder")
+
+    def _open_index(self, index: int) -> bool:
+        """Bind the GameController at ``index``; return True on success."""
+        if self._sdl is None or not self._sdl.is_controller(index):
+            return False
+        try:
+            self._controller = self._sdl.Controller(index)
+        except Exception:  # pragma: no cover - driver dependent
+            log.debug("Could not open controller at slot %d", index, exc_info=True)
+            return False
+        self._instance_id = self._controller.id
+        # Provisional: the first real event's instance id is authoritative (see
+        # _id_pending), which self-heals a stale id left by a hot-plug.
+        self._id_pending = True
+        try:
+            self._name = self._sdl.name_forindex(index) or "controller"
+        except Exception:  # pragma: no cover
+            self._name = "controller"
+        log.info("Controller connected: %s (instance %s)", self._name, self._instance_id)
+        self._log_capabilities(index)
+        return True
+
     def _open_first(self) -> None:
         if self._sdl is None:
             return
         for index in range(self._sdl.get_count()):
-            if self._sdl.is_controller(index):
-                try:
-                    self._controller = self._sdl.Controller(index)
-                except Exception:  # pragma: no cover - driver dependent
-                    continue
-                self._instance_id = self._controller.id
-                try:
-                    self._name = self._sdl.name_forindex(index) or "controller"
-                except Exception:  # pragma: no cover
-                    self._name = "controller"
-                log.info("Controller connected: %s", self._name)
+            if self._open_index(index):
                 return
+
+    def _log_capabilities(self, index: int) -> None:
+        """DEBUG snapshot of the bound pad, plus a WARNING if the trigger and
+        shoulder controls are unmapped -- the fingerprint of the reconnect bug
+        where those inputs stop responding while the rest of the pad works."""
+        if self._controller is None:
+            return
+        mapping: dict[str, str] = {}
+        with contextlib.suppress(Exception):  # pragma: no cover - driver dependent
+            mapping = self._controller.get_mapping()
+        with contextlib.suppress(Exception):  # pragma: no cover - driver dependent
+            joy = self._controller.as_joystick()
+            log.debug(
+                "Controller %r caps: guid=%s axes=%d buttons=%d hats=%d",
+                self._name,
+                joy.get_guid(),
+                joy.get_numaxes(),
+                joy.get_numbuttons(),
+                joy.get_numhats(),
+            )
+        if mapping:
+            missing = [name for name in self._ESSENTIAL_MAPPINGS if not mapping.get(name)]
+            log.debug("Controller %r mapping keys: %s", self._name, sorted(mapping))
+            if missing:
+                log.warning(
+                    "Controller %r reconnected without %s mapped; "
+                    "brake/throttle and bumpers may not respond",
+                    self._name,
+                    ", ".join(missing),
+                )
+
+    def _close_controller(self) -> None:
+        """Release the SDL controller before dropping our reference, so its
+        bookkeeping is torn down cleanly across a hot-plug."""
+        if self._controller is not None:
+            with contextlib.suppress(Exception):  # pragma: no cover - driver/stub dependent
+                self._controller.quit()
+        self._controller = None
+        self._instance_id = None
+        self._id_pending = False
+        self._buttons_down.clear()
+
+    def _is_attached(self) -> bool:
+        """Whether the bound pad is still physically present. Assumes attached
+        if the API is unavailable (e.g. the test stub), so we don't drop a
+        working binding on a spurious ADDED event."""
+        if self._controller is None:
+            return False
+        try:
+            return bool(self._controller.attached())
+        except Exception:  # pragma: no cover - driver/stub dependent
+            return True
+
+    def _reopen(self) -> None:
+        """Drop the current pad and bind whatever is connected now.
+
+        The first real event's instance id (see ``_id_pending``) corrects a
+        stale id left by a hot-plug, so we never cycle the SDL subsystem:
+        quitting and re-initializing it while the event loop is live
+        re-registers SDL's controller event watch and makes every controller
+        event arrive twice."""
+        self._close_controller()
+        self._open_first()
 
     def take_disconnect(self) -> bool:
         """Return and clear the pending-disconnect flag (app pauses on True)."""
@@ -205,6 +294,7 @@ class ControllerManager:
         self._throttle = self._brake = 0.0
         self.modifier = False
         self._repeat_button = None
+        self._buttons_down.clear()
         self.rumble.reset()
 
     # -- input notification ---------------------------------------------------
@@ -223,30 +313,94 @@ class ControllerManager:
 
     # -- event handling -------------------------------------------------------
 
-    def process_event(self, event: pygame.event.Event) -> None:
-        """Update device/axis/modifier state from a CONTROLLER* event."""
+    def process_event(self, event: pygame.event.Event) -> bool:
+        """Update device/axis/modifier state from a CONTROLLER* event.
+
+        Returns True only for a button press/release that belongs to the bound
+        controller and should be forwarded to the active state. Axis, device,
+        and rejected (foreign-id) events return False, so the app never routes a
+        stray event -- e.g. a duplicate from a pad that enumerates twice -- into
+        a game action."""
         etype = event.type
         if etype == pygame.CONTROLLERDEVICEADDED:
-            if self._controller is None:
-                self._open_first()
-            return
+            device_index = getattr(event, "device_index", None)
+            log.debug("Controller device added (slot %s)", device_index)
+            # Re-open when nothing is bound, or the bound pad has quietly
+            # detached (a missed REMOVED event) -- otherwise a stale binding
+            # would block the reconnect.
+            if self._controller is not None and self._is_attached():
+                log.debug("Ignoring add; a pad is already bound (instance %s)", self._instance_id)
+                return False
+            # Re-open in place. The first real event's id (see _id_pending)
+            # corrects a stale id from the hot-plug; we deliberately do not cycle
+            # the SDL subsystem, which would double every controller event.
+            self._reopen()
+            return False
         if etype == pygame.CONTROLLERDEVICEREMOVED:
+            log.debug("Controller device removed (instance %s)", event.instance_id)
             if self._instance_id is not None and event.instance_id == self._instance_id:
-                self._controller = None
-                self._instance_id = None
+                self._close_controller()
                 self._reset_analog()
                 self._disconnected = True
+                self._logged_mismatch_id = None
                 log.info("Controller disconnected")
-            return
-        if not self.active or event.instance_id != self._instance_id:
-            return
+            return False
+        if not self.active:
+            return False
+        if event.instance_id != self._instance_id:
+            if self._id_pending:
+                # First real event after (re)open: its id is authoritative, so a
+                # stale id from Controller.id after a hot-plug is corrected here.
+                log.info(
+                    "Controller bound to instance %s (opened as %s)",
+                    event.instance_id,
+                    self._instance_id,
+                )
+                self._instance_id = event.instance_id
+                self._id_pending = False
+                self._logged_mismatch_id = None
+            else:
+                # A genuinely foreign id: a second pad, or a duplicate from a pad
+                # that enumerates twice. Drop it (log once) so it never doubles a
+                # toggle or other action.
+                if event.instance_id != self._logged_mismatch_id:
+                    self._logged_mismatch_id = event.instance_id
+                    log.debug(
+                        "Dropping controller event from instance %s (bound to %s)",
+                        event.instance_id,
+                        self._instance_id,
+                    )
+                return False
+        else:
+            # Matched the bound id, so it is live: stop treating the id as
+            # provisional (a duplicate under a different id is now a duplicate).
+            self._id_pending = False
         if etype == pygame.CONTROLLERAXISMOTION:
             self._on_axis(event.axis, event.value)
+            return False
         elif etype == pygame.CONTROLLERBUTTONDOWN:
+            if event.button in self._buttons_down:
+                # Duplicate press with no intervening release: ignore it so a pad
+                # that delivers a button twice cannot fire the action twice.
+                log.debug(
+                    "Ignoring duplicate button-down %s (instance %s)",
+                    event.button,
+                    event.instance_id,
+                )
+                return False
+            self._buttons_down.add(event.button)
             self.active_device = CONTROLLER
+            log.debug("Button down %s (instance %s)", event.button, event.instance_id)
             self._on_button_down(event.button)
+            return True
         elif etype == pygame.CONTROLLERBUTTONUP:
+            if event.button not in self._buttons_down:
+                return False  # stray/duplicate release
+            self._buttons_down.discard(event.button)
+            log.debug("Button up %s (instance %s)", event.button, event.instance_id)
             self._on_button_up(event.button)
+            return True
+        return False
 
     def _on_axis(self, axis: int, raw: int) -> None:
         value = raw / AXIS_MAX
@@ -349,7 +503,7 @@ class ControllerManager:
 
     def shutdown(self) -> None:
         self.rumble.reset()  # silence the pad before we drop it
-        self._controller = None
+        self._close_controller()
         if self._sdl is not None:
             with contextlib.suppress(Exception):  # pragma: no cover
                 self._sdl.quit()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -143,6 +143,127 @@ def test_disconnect_latches_once():
     m.shutdown()
 
 
+def test_reconnect_reopens_after_removed(monkeypatch):
+    # A device-added after a device-removed must reopen the pad, so a reconnect
+    # restores controller input rather than leaving it dead.
+    m = ControllerManager(enabled=True)
+    m._controller = object()
+    m._instance_id = 7
+    m.process_event(pygame.event.Event(pygame.CONTROLLERDEVICEREMOVED, instance_id=7))
+    assert not m.connected
+
+    reopened = []
+    monkeypatch.setattr(m, "_reopen", lambda: reopened.append(True))
+    m.process_event(pygame.event.Event(pygame.CONTROLLERDEVICEADDED, device_index=3))
+    assert reopened == [True]  # bound the reconnected pad
+    m.shutdown()
+
+
+def test_reopen_does_not_cycle_subsystem(monkeypatch):
+    # _reopen must drop the old pad and rebind WITHOUT quitting/re-initializing
+    # the SDL subsystem -- cycling it re-registers the event watch and doubles
+    # every controller event.
+    m = ControllerManager(enabled=True)
+    calls = []
+    fake_sdl = type(
+        "FakeSDL",
+        (),
+        {"quit": lambda self: calls.append("quit"), "init": lambda self: calls.append("init")},
+    )()
+    m._sdl = fake_sdl
+    m._controller = object()
+    m._instance_id = 7
+    monkeypatch.setattr(m, "_open_first", lambda: calls.append("open"))
+    m._reopen()
+    assert calls == ["open"]  # reopened, never cycled the subsystem
+    m.shutdown()
+
+
+def test_add_ignored_while_pad_still_attached(monkeypatch):
+    # A spurious device-added must not drop a working, still-attached binding.
+    m = ControllerManager(enabled=True)
+    m._controller = object()
+    m._instance_id = 7
+    monkeypatch.setattr(m, "_is_attached", lambda: True)
+    reopened = []
+    monkeypatch.setattr(m, "_reopen", lambda: reopened.append(True))
+    m.process_event(pygame.event.Event(pygame.CONTROLLERDEVICEADDED, device_index=3))
+    assert reopened == []  # left the existing pad bound
+    assert m._instance_id == 7
+    m.shutdown()
+
+
+def test_binding_latches_to_first_event_id():
+    # A hot-plug can leave Controller.id stale, so the pad's real events arrive
+    # under a different id. The first real event's id is authoritative: the
+    # manager adopts it and applies the event (triggers come back to life).
+    m = ControllerManager(enabled=True)
+    m._controller = object()
+    m._instance_id = 0
+    m._id_pending = True  # freshly (re)opened, id still provisional
+    m.process_event(_axis(pygame.CONTROLLER_AXIS_TRIGGERLEFT, 32767, instance_id=2))
+    assert m._instance_id == 2  # adopted the id the events actually carry
+    assert not m._id_pending  # latched
+    assert m._brake_target > 0  # ...and the event was applied
+    m.shutdown()
+
+
+def test_foreign_duplicate_button_is_not_forwarded():
+    # Once the binding is latched, a button under a *different* id (a duplicate
+    # from a pad that enumerates twice) must not be forwarded to the state, or
+    # it would fire the action a second time.
+    m = ControllerManager(enabled=True)
+    m._controller = object()
+    m._instance_id = 0
+    m._id_pending = False  # already latched to id 0
+    # The genuine press is forwarded...
+    assert m.process_event(_button(pygame.CONTROLLER_BUTTON_A, instance_id=0)) is True
+    # ...its duplicate under id 2 is dropped, not forwarded.
+    assert m.process_event(_button(pygame.CONTROLLER_BUTTON_A, instance_id=2)) is False
+    m.shutdown()
+
+
+def test_duplicate_button_down_not_forwarded():
+    # A pad that delivers a button twice (same id, no intervening release) must
+    # forward only the first press to the state.
+    m = ControllerManager(enabled=True)
+    m._controller = object()
+    m._instance_id = 0
+    assert m.process_event(_button(pygame.CONTROLLER_BUTTON_A, instance_id=0)) is True
+    assert m.process_event(_button(pygame.CONTROLLER_BUTTON_A, instance_id=0)) is False
+    # After a genuine release, the next press is fresh again.
+    assert m.process_event(_button_up(pygame.CONTROLLER_BUTTON_A, instance_id=0)) is True
+    assert m.process_event(_button(pygame.CONTROLLER_BUTTON_A, instance_id=0)) is True
+    m.shutdown()
+
+
+def test_duplicate_button_down_does_not_double_toggle():
+    # Regression: a single RB+A press delivered twice in a frame must toggle the
+    # engine exactly once, not on-then-off.
+    from freight_fate.app import App
+
+    app = App()
+    c = force_controller(app)
+    c._id_pending = False  # bound to id 0
+    driving = start_drive(app)
+    quiet_trip(driving)
+    calls = []
+    real = driving._toggle_engine
+    driving._toggle_engine = lambda: calls.append(1) or real()
+
+    def down(button):
+        app._dispatch_controller(
+            pygame.event.Event(pygame.CONTROLLERBUTTONDOWN, button=button, instance_id=0)
+        )
+
+    down(pygame.CONTROLLER_BUTTON_RIGHTSHOULDER)  # hold modifier
+    down(pygame.CONTROLLER_BUTTON_RIGHTSHOULDER)  # duplicate delivery
+    down(pygame.CONTROLLER_BUTTON_A)  # press
+    down(pygame.CONTROLLER_BUTTON_A)  # duplicate delivery
+    assert calls == [1]  # toggled exactly once
+    app.shutdown()
+
+
 def test_disabled_manager_ignores_controller():
     m = ControllerManager(enabled=True)
     m._controller = object()
@@ -242,6 +363,7 @@ def test_controller_info_buttons_speak(monkeypatch):
     # B button speaks speed; RB+B speaks fuel.
     app._dispatch_controller(_button(pygame.CONTROLLER_BUTTON_B))
     assert any("per hour" in t for t in spoken)
+    app._dispatch_controller(_button_up(pygame.CONTROLLER_BUTTON_B))  # release before re-press
     spoken.clear()
     app._dispatch_controller(_button(pygame.CONTROLLER_BUTTON_RIGHTSHOULDER))
     app._dispatch_controller(_button(pygame.CONTROLLER_BUTTON_B))
@@ -259,6 +381,27 @@ def test_controller_disconnect_pauses_driving():
     driving.on_controller_disconnect()
     assert isinstance(app.state, PauseMenuState)
     app.shutdown()
+
+
+def test_event_pump_error_is_survived(monkeypatch):
+    # A pygame-internal failure out of event.get() (as seen on some Bluetooth
+    # hot-plugs) must be logged and skipped, not crash the main loop.
+    from freight_fate.app import App
+
+    app = App()
+    calls = {"n": 0}
+    real_get = pygame.event.get
+
+    def flaky_get(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise SystemError("<built-in function get> returned a result with an exception set")
+        return real_get(*args, **kwargs)
+
+    monkeypatch.setattr(pygame.event, "get", flaky_get)
+    monkeypatch.setattr(pygame.event, "pump", lambda: None)
+    app.run(max_frames=3)  # would raise if the error escaped the loop
+    assert calls["n"] >= 2  # survived the raising frame and kept pumping
 
 
 def test_plain_state_not_trapped_by_controller():


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for branch targets,
     test commands, and accessibility expectations. -->

## What changed and why

Fixes related to hot-plugging controllers, one of which could crash the game, another could leave the triggers and shoulder buttons inoperative, leading to the inability to accelerate or brake.

## What players or maintainers will notice

Controller hot-plugging should hopefully be a bit more robust.

## Tests and checks run

test_controller.py + did a run with controller connecting / disconnecting.

<!-- e.g. uv run pytest, uv run ruff check src tests tools,
     plus any manual spoken-text or keyboard checks. -->

## Accessibility impact

neutral

<!-- Every gameplay path must stay usable by keyboard and screen reader.
     Say how you checked spoken text or keyboard flow, or why this change
     has no accessibility impact. -->

## Changelog

Entries added udner fixed section

CI requires a `CHANGELOG.md` entry when user-facing paths (such as `src/`
or `docs/`) change. Check one:

- [ ] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.
