### PR TITLE
Minor Engine Audio Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **Engine sound now stays present through automatic gear changes.** Shifts still ease the engine tone briefly, without the repeated volume pumping that could sound like the engine was dropping out.
 
+- Smoothed out the transition between the tail of the engine start sound with the start of the engine loop, ramping from a forced full load down to the off throttle idle load
+
 - **Manual and automatic transmissions behave reliably on steep grades.** The
   diesel governor now holds a safe low-gear road speed without quietly damaging
   the engine, and automatic trucks avoid shifts that cannot pull the hill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### Changed
 
+- **The engine no longer jumps in volume the instant an automatic shift
+  finishes.** It now eases back up to full pull over a brief moment, so completed
+  shifts sound smooth instead of abruptly snapping back under load.
 - **Route alerts no longer repeat at one mile.** Fuel stops, rest stops, and
   other actionable exits now speak once at five miles. State lines speak once
   as you cross them.

--- a/src/freight_fate/audio.py
+++ b/src/freight_fate/audio.py
@@ -84,6 +84,10 @@ ENGINE_START_ASSUMED_LEN_S = 2.0  # fallback if the clip length can't be queried
 # Short fade-in for a silent (no-crank) engine loop start, e.g. resuming a trip
 # whose engine was already running, or coming back from an in-trip menu.
 ENGINE_RESUME_FADE_S = 0.25
+# After the crank hands off, the loop starts at the crank's (full-load) volume so
+# there is no dip, then eases down to its true off-throttle load over this window.
+ENGINE_START_SETTLE_S = 0.6  # ease from crank level down to idle load
+ENGINE_START_SETTLE_CURVE = "ease_out"  # key into audio_fades.CURVES
 
 BASS_NO_SOUND_DEVICE = 0
 
@@ -190,6 +194,7 @@ class _PygameBackend:
         self._music_buffer: io.BytesIO | None = None  # streamed; must outlive playback
         self._engine_running = False
         self._engine_intro_gain = 1.0  # crossfade multiplier on the engine loop
+        self._engine_intro_load = 0.0  # ignition load boost: 1.0 forces full load
         self._engine_starting = False  # True only during the ignition crossfade
         self._engine_last_rpm = ENGINE_RPM_IDLE
         self._fades = FadeScheduler()
@@ -421,6 +426,7 @@ class _PygameBackend:
         # plays, then crossfaded up. A silent (resume) start skips the crank
         # and just eases the loop in.
         self._engine_intro_gain = 0.0
+        self._engine_intro_load = 0.0
         if play_start_sound:
             self._begin_engine_start_crossfade()
         else:
@@ -459,6 +465,9 @@ class _PygameBackend:
         channel.set_volume(base)
         clip_len = snd.get_length()
         delay = max(0.0, clip_len - ENGINE_START_CROSSFADE_S) if ENGINE_START_TAIL_ANCHOR else 0.0
+        # Boost the loop to full (crank) load through the handoff so it meets the
+        # crank tail at the same level instead of the quieter off-throttle idle.
+        self._engine_intro_load = 1.0
         self._fades.add(
             Fade(
                 lambda m: channel.set_volume(base * m),
@@ -480,11 +489,27 @@ class _PygameBackend:
                 on_done=self._end_engine_starting,
             )
         )
+        # Once the crossfade completes, ease the load boost back off so the loop
+        # settles to its real off-throttle volume.
+        self._fades.add(
+            Fade(
+                self._set_engine_intro_load,
+                1.0,
+                0.0,
+                ENGINE_START_SETTLE_S,
+                curve=ENGINE_START_SETTLE_CURVE,
+                delay_s=delay + ENGINE_START_CROSSFADE_S,
+            )
+        )
 
     def _set_engine_intro_gain(self, gain: float) -> None:
         self._engine_intro_gain = max(0.0, min(1.0, gain))
         # Re-apply the band volumes at the last known RPM so the ramp is heard
         # immediately, regardless of when set_engine_rpm next runs.
+        self.set_engine_rpm(self._engine_last_rpm)
+
+    def _set_engine_intro_load(self, value: float) -> None:
+        self._engine_intro_load = max(0.0, min(1.0, value))
         self.set_engine_rpm(self._engine_last_rpm)
 
     def _end_engine_starting(self) -> None:
@@ -500,6 +525,7 @@ class _PygameBackend:
         self._engine_running = False
         self._fades.clear()
         self._engine_intro_gain = 1.0
+        self._engine_intro_load = 0.0
         self._engine_starting = False
         for ch in CH_ENGINE:
             self.stop_loop(ch, fade_ms=250)
@@ -512,6 +538,9 @@ class _PygameBackend:
             return
         self._engine_last_rpm = rpm
         load_gain = engine_load_gain(throttle)
+        # During the ignition handoff, boost load toward full so the loop meets
+        # the crank tail; the boost eases back to 0 afterward.
+        load_gain += self._engine_intro_load * (1.0 - load_gain)
         for i, (_key, center) in enumerate(ENGINE_BANDS):
             # triangular weight, 1.0 at band center, 0 beyond ~600 rpm away
             w = max(0.0, 1.0 - abs(rpm - center) / 620.0)
@@ -654,6 +683,7 @@ class _BassBackend:
         self._engine_base_freq = 0.0
         self._engine_intro_stream = None  # ignition one-shot, kept for the crossfade
         self._engine_intro_gain = 1.0  # crossfade multiplier on the engine loop
+        self._engine_intro_load = 0.0  # ignition load boost: 1.0 forces full load
         self._engine_starting = False  # True only during the ignition crossfade
         self._engine_last_rpm = ENGINE_RPM_IDLE
         self._fades = FadeScheduler()
@@ -912,6 +942,7 @@ class _BassBackend:
         # Hold the loop silent while the ignition one-shot plays; crossfade it
         # up at the tail. A silent (resume) start skips the crank.
         self._engine_intro_gain = 0.0
+        self._engine_intro_load = 0.0
         if play_start_sound:
             self._begin_engine_start_crossfade()
         else:
@@ -970,6 +1001,9 @@ class _BassBackend:
         self._engine_intro_stream = stream
         clip_len = self._stream_length_s(stream)
         delay = max(0.0, clip_len - ENGINE_START_CROSSFADE_S) if ENGINE_START_TAIL_ANCHOR else 0.0
+        # Boost the loop to full (crank) load through the handoff so it meets the
+        # crank tail at the same level instead of the quieter off-throttle idle.
+        self._engine_intro_load = 1.0
 
         def fade_crank(m: float) -> None:
             with contextlib.suppress(self._BassError):
@@ -996,6 +1030,18 @@ class _BassBackend:
                 on_done=self._end_engine_starting,
             )
         )
+        # Once the crossfade completes, ease the load boost back off so the loop
+        # settles to its real off-throttle volume.
+        self._fades.add(
+            Fade(
+                self._set_engine_intro_load,
+                1.0,
+                0.0,
+                ENGINE_START_SETTLE_S,
+                curve=ENGINE_START_SETTLE_CURVE,
+                delay_s=delay + ENGINE_START_CROSSFADE_S,
+            )
+        )
 
     def _stream_length_s(self, stream) -> float:
         """Length of a stream in seconds, or a safe fallback."""
@@ -1007,6 +1053,10 @@ class _BassBackend:
 
     def _set_engine_intro_gain(self, gain: float) -> None:
         self._engine_intro_gain = max(0.0, min(1.0, gain))
+        self.set_engine_rpm(self._engine_last_rpm)
+
+    def _set_engine_intro_load(self, value: float) -> None:
+        self._engine_intro_load = max(0.0, min(1.0, value))
         self.set_engine_rpm(self._engine_last_rpm)
 
     def _end_engine_starting(self) -> None:
@@ -1022,6 +1072,7 @@ class _BassBackend:
         self._engine_running = False
         self._fades.clear()
         self._engine_intro_gain = 1.0
+        self._engine_intro_load = 0.0
         self._engine_starting = False
         self._engine_intro_stream = None
         if self._engine_stream is not None:
@@ -1036,12 +1087,16 @@ class _BassBackend:
             return
         self._engine_last_rpm = rpm
         target = self._engine_base_freq * engine_freq_mult(rpm)
+        load_gain = engine_load_gain(throttle)
+        # During the ignition handoff, boost load toward full so the loop meets
+        # the crank tail; the boost eases back to 0 afterward.
+        load_gain += self._engine_intro_load * (1.0 - load_gain)
         vol = max(
             0.0,
             min(
                 1.0,
                 ENGINE_LOOP_GAIN
-                * engine_load_gain(throttle)
+                * load_gain
                 * self.engine_volume
                 * self.master_volume
                 * self._engine_intro_gain,

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -125,6 +125,7 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
         self._lane_rumble_timer = 0.0
         self._lane_guidance_state = "center"
         self._reverse_cue_active = False
+        self._shift_recover_t = 1.0  # 0->1 recovery progress after an automatic shift ends
         # Prev-frame accel/brake state, so a forward<->reverse shift needs a
         # fresh press (release then press) rather than a held control.
         self._reverse_brake_held = False

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F403,F405
 from __future__ import annotations
 
+from ..audio_fades import curve as _resolve_curve
 from .driving_core import *
 from .driving_rest_states import TrafficStopState
 
@@ -13,6 +14,17 @@ LANE_GUIDANCE_PAN = 0.85
 # The grace period lets a shift's momentary flare pass unremarked.
 OVERREV_GRACE_S = 1.5
 OVERREV_REPEAT_S = 10.0
+
+# An automatic shift caps audible engine load so the bed doesn't duck out.
+SHIFT_LOAD_CAP = 0.45
+# When the shift completes the cap eases from SHIFT_LOAD_CAP back to full over
+# this window. The curve (a key into audio_fades.CURVES) shapes the return: an
+# ease-out leaves the shift level quickly -- so the engine doesn't sit soft --
+# while still arriving at full load gently instead of snapping. A plain "linear"
+# ramp had to be stretched long to hide the snap, which sounded too soft.
+SHIFT_LOAD_RECOVERY_S = 0.032
+SHIFT_LOAD_RECOVERY_CURVE = "ease_out"
+_shift_recovery_curve = _resolve_curve(SHIFT_LOAD_RECOVERY_CURVE)
 
 
 class DrivingUpdateMixin:
@@ -475,14 +487,25 @@ class DrivingUpdateMixin:
             # off -- inaudible under the old RPM-weighted band volumes, but
             # plainly audible with the constant-volume BASS engine loop.
             audio.engine_stop(shutdown_sound=False)
-        engine_load = t.throttle
+        # A shift briefly unloads the engine, but the old 0.08 clamp cut loop
+        # gain by roughly forty percent and made repeated shifts sound like the
+        # engine was ducking or nearly dropping out. Cap the load to a
+        # perceptible torque easing while shifting, then -- once the shift ends
+        # -- ease the cap back to full over SHIFT_LOAD_RECOVERY_S along the
+        # recovery curve, so the return "under load" is a shaped glide rather
+        # than a single-frame snap.
         if t.transmission.automatic and t.transmission.shifting:
-            # A shift briefly unloads the engine, but the old 0.08 clamp cut
-            # loop gain by roughly forty percent and made repeated shifts
-            # sound like the engine was ducking or nearly dropping out.
-            # Retain a perceptible torque easing without losing the continuous
-            # engine bed that communicates RPM and engagement.
-            engine_load = min(engine_load, 0.45)
+            self._shift_recover_t = 0.0
+            cap = SHIFT_LOAD_CAP
+        elif self._shift_recover_t < 1.0:
+            step = dt / SHIFT_LOAD_RECOVERY_S if SHIFT_LOAD_RECOVERY_S > 0 else 1.0
+            self._shift_recover_t = min(1.0, self._shift_recover_t + step)
+            cap = SHIFT_LOAD_CAP + (1.0 - SHIFT_LOAD_CAP) * _shift_recovery_curve(
+                self._shift_recover_t
+            )
+        else:
+            cap = 1.0
+        engine_load = min(t.throttle, cap)
         audio.set_engine_rpm(t.rpm, engine_load)
         audio.set_road_noise(t.velocity_mps)
         if t.engine_on and t.transmission.in_reverse:

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -270,10 +270,12 @@ def test_deliberate_engine_start_plays_crank_and_arms_crossfade(monkeypatch):
     keys = _record_sfx_keys(monkeypatch, impl)
     a.engine_start()  # deliberate ignition
     assert "engine/start" in keys
-    # A crank fade-out plus the loop fade-in are scheduled, and the loop starts
-    # silent so the ignition is not drowned out.
-    assert len(impl._fades) == 2
+    # A crank fade-out, the loop fade-in, and the post-handoff load settle are
+    # scheduled; the loop starts silent so the ignition is not drowned out, and
+    # its load is boosted to full so it meets the crank tail without a dip.
+    assert len(impl._fades) == 3
     assert impl._engine_intro_gain == 0.0
+    assert impl._engine_intro_load == 1.0
     a.engine_stop()
     a.shutdown()
 


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for branch targets,
     test commands, and accessibility expectations. -->

## What changed and why

With the advent of load-based engine volume came an audible gap when the engine was started. The tail of the ignition sound would crossfade into the engine loop; however, now, the engine loop is at a lower volume because it's off throttle at idle. Thus, there was an audible dip in volume. This eases that dip into a linear ramp  down. I can't say I'm 100% satisfied with the way it sounds, but to my mind, it's better than the immediate dip.

 A similar situation occurs when shifting. the volume is allowed to dip, then it snaps back in when the e shift concludes and the engine is once again under load. There has been a curve introduced to dampen that transient. It's tunable with `SHIFT_LOAD_RECOVERY_S`.

## What players or maintainers will notice

A smoother engine start and less snap when shifting.

## Tests and checks run

Everything

<!-- e.g. uv run pytest, uv run ruff check src tests tools,
     plus any manual spoken-text or keyboard checks. -->

## Accessibility impact

neutral

<!-- Every gameplay path must stay usable by keyboard and screen reader.
     Say how you checked spoken text or keyboard flow, or why this change
     has no accessibility impact. -->

## Changelog

Entries added

CI requires a `CHANGELOG.md` entry when user-facing paths (such as `src/`
or `docs/`) change. Check one:

- [ ] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.
