### PR TITLE
Lazy Controller Subsystem Initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- **Controllers are left alone when controller support is off.** With the setting disabled, the game no longer starts up the controller system or grabs a connected pad; turning support on in Settings, Gameplay activates it, and turning it back off releases the controller again.
+
 - **Engine sound now stays present through automatic gear changes.** Shifts still ease the engine tone briefly, without the repeated volume pumping that could sound like the engine was dropping out.
 
 - **Manual and automatic transmissions behave reliably on steep grades.** The

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,7 +126,7 @@ From a batch of player reports:
   grace so shift flares stay quiet. Follow-up if wanted: a governor that cuts
   throttle at redline, and a reverse-speed cap, so sustained redline damage
   is hard to reach at all.
-- [ ] **Don't bind a controller when the controller setting is off.**
+- [x] **Don't bind a controller when the controller setting is off.**
   `ControllerManager.__init__` opens the first pad unconditionally; with the
   setting disabled the game still enumerates and binds (issue #61: a fight
   stick got picked up despite controller-off). Gate `_open_first()` and the

--- a/src/freight_fate/controller.py
+++ b/src/freight_fate/controller.py
@@ -136,17 +136,45 @@ class ControllerManager:
         self._repeat_countdown = 0.0
         self._repeat_held = 0.0
 
+        # Defer touching the SDL controller subsystem until support is on, so a
+        # player with controllers disabled never enumerates or binds a pad. It
+        # comes up lazily on the first enable (see set_enabled/_init_subsystem).
+        self._sdl = None
+        if enabled:
+            self._init_subsystem()
+        else:
+            log.debug("Controller support off at startup; subsystem not initialized")
+
+    # -- device lifecycle -----------------------------------------------------
+
+    def _init_subsystem(self) -> None:
+        """Initialize the SDL controller subsystem and bind the first pad.
+
+        Idempotent and headless-safe: a failure leaves ``_sdl`` None (keyboard
+        only), and a repeat call while already initialized is a no-op."""
+        if self._sdl is not None:
+            return
         try:
             from pygame._sdl2 import controller as sdl_controller
 
             self._sdl = sdl_controller
             self._sdl.init()
+            log.debug("Controller subsystem initialized")
             self._open_first()
         except Exception:  # pragma: no cover - platform/driver dependent
             log.info("Controller subsystem unavailable; keyboard only", exc_info=True)
             self._sdl = None
 
-    # -- device lifecycle -----------------------------------------------------
+    def _teardown_subsystem(self) -> None:
+        """Silence and release the pad, then uninitialize the subsystem so no
+        controller handles or SDL state remain while support is off."""
+        self.rumble.reset()  # silence the pad before we drop it
+        self._close_controller()
+        if self._sdl is not None:
+            with contextlib.suppress(Exception):  # pragma: no cover
+                self._sdl.quit()
+            self._sdl = None
+            log.debug("Controller subsystem torn down")
 
     @property
     def connected(self) -> bool:
@@ -163,7 +191,10 @@ class ControllerManager:
 
     def set_enabled(self, enabled: bool) -> None:
         self.enabled = enabled
-        if not enabled:
+        if enabled:
+            self._init_subsystem()  # bring the subsystem up on first enable
+        else:
+            self._teardown_subsystem()  # close handles + uninit while off
             self._reset_analog()
             self.active_device = KEYBOARD
 
@@ -513,9 +544,4 @@ class ControllerManager:
         return self._clutch if self.active else 0.0
 
     def shutdown(self) -> None:
-        self.rumble.reset()  # silence the pad before we drop it
-        self._close_controller()
-        if self._sdl is not None:
-            with contextlib.suppress(Exception):  # pragma: no cover
-                self._sdl.quit()
-            self._sdl = None
+        self._teardown_subsystem()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -275,6 +275,44 @@ def test_disabled_manager_ignores_controller():
     m.shutdown()
 
 
+def test_disabled_manager_never_inits_subsystem(monkeypatch):
+    # With controller support off, the SDL subsystem must not be touched: no
+    # enumeration, no pad bound. Guard against a real pad on the test machine.
+    opened = []
+    monkeypatch.setattr(ControllerManager, "_open_first", lambda self: opened.append(True))
+    m = ControllerManager(enabled=False)
+    assert m._sdl is None  # subsystem never initialized
+    assert m._controller is None
+    assert opened == []  # never went looking for a pad
+    m.shutdown()
+
+
+def test_enabling_inits_subsystem(monkeypatch):
+    # Turning support on for the first time brings the subsystem up.
+    m = ControllerManager(enabled=False)
+    inited = []
+    monkeypatch.setattr(m, "_init_subsystem", lambda: inited.append(True))
+    m.set_enabled(True)
+    assert m.enabled
+    assert inited == [True]
+    m.shutdown()
+
+
+def test_disabling_tears_down_subsystem():
+    # Disabling releases the open pad and uninitializes the subsystem so no
+    # controller handles or SDL state linger while support is off.
+    m = ControllerManager(enabled=True)
+    m._controller = object()
+    m._instance_id = 0
+    quits = []
+    m._sdl = type("FakeSDL", (), {"quit": lambda self: quits.append(True)})()
+    m.set_enabled(False)
+    assert m._controller is None  # handle released
+    assert m._sdl is None  # subsystem uninitialized
+    assert quits == [True]
+    m.shutdown()
+
+
 # -- menus -------------------------------------------------------------------
 
 


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for branch targets,
     test commands, and accessibility expectations. -->

## What changed and why

The controller subsystem now initializes only when needed. If the user's controller preference under settings > gameplay is off when the game starts up, the initialization doesn't happen. If it is on, then it does happen. When the state of the preference changes, the subsystem is either initialized or torn down depending on if it got flipped to enabled or disabled. Logging of the initialization and teardown is now present and appears when the logging level is set to DEBUG. Additionally, the path that doesn't initialize the subsystem on startup also logs.

This was an item on the road map.

## What players or maintainers will notice

Nothing. Behaviorally, it should be no different.

## Tests and checks run

test_controller.py

<!-- e.g. uv run pytest, uv run ruff check src tests tools,
     plus any manual spoken-text or keyboard checks. -->

## Accessibility impact

neutral
<!-- Every gameplay path must stay usable by keyboard and screen reader.
     Say how you checked spoken text or keyboard flow, or why this change
     has no accessibility impact. -->

## Changelog

Entries added

CI requires a `CHANGELOG.md` entry when user-facing paths (such as `src/`
or `docs/`) change. Check one:

- [ ] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.
