### PR TITLE
Fix untitled bug reports: cloud reconnect messaging (#64) and the per-frame destination-exit scan (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   you connect a second computer with a new driver token, the cloud backup menu
   now says so and walks you to Settings, Online to reconnect, instead of
   wrongly reporting that your backups could not be reached.
+- **Long deliveries are easier on the game while you drive.** The destination
+  exit is now worked out once and remembered instead of being recalculated
+  every moment of the drive, removing a heavy background load tied to a
+  reported crash on coast-to-coast routes.
 ## 1.8.1 - 2026-07-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Cloud backup now tells you when this computer needs to reconnect.** If
+  orinks.net stops accepting this computer's sign-in, which can happen after
+  you connect a second computer with a new driver token, the cloud backup menu
+  now says so and walks you to Settings, Online to reconnect, instead of
+  wrongly reporting that your backups could not be reached.
 ## 1.8.1 - 2026-07-13
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -597,3 +597,4 @@ fit for an audio-first game.
 - [x] Opt-in Profile sharing for fictional road journals, achievements, and last-saved profile summaries
 - [x] Online posts carry the game's build identity (release tag or source checkout) so moderation can tell which version a driver runs
 - [x] Validated and server-signed private cloud revisions with verified public profile summaries
+- [ ] Per-machine driver tokens on orinks.net, so connecting a second computer no longer retires the first one's sign-in (the game now at least says reconnect instead of blaming the network; see issue #64)

--- a/src/freight_fate/cloud_saves.py
+++ b/src/freight_fate/cloud_saves.py
@@ -117,6 +117,30 @@ def _error_body(e: urllib.error.HTTPError) -> dict:
         return {}
 
 
+class CloudAuthError(Exception):
+    """orinks.net answered but refused this machine's driver credentials.
+
+    Raised (never swallowed into a generic ``None``) so the Cloud backup
+    menus can tell the player to reconnect instead of blaming the network.
+    The usual cause: the account issued a fresh driver token to another
+    computer, which retires the token stored on this one.
+    """
+
+
+# The spoken guidance for CloudAuthError, shared by every cloud menu so the
+# player always hears the same recovery path.
+AUTH_HELP = (
+    "orinks.net no longer accepts this computer's sign-in. This can happen "
+    "after you connect another computer with a new driver token. Choose Set "
+    "up orinks.net account under Settings, Online, and paste a fresh Driver "
+    "ID and driver token to reconnect."
+)
+
+
+def _auth_refused(e: urllib.error.HTTPError, body: dict) -> bool:
+    return e.code == 401 or body.get("error") in ("unauthorized", "driver_not_found")
+
+
 # -- sync state ----------------------------------------------------------------
 
 
@@ -251,10 +275,21 @@ def upload_save(
 
 def list_saves(identity: OnlineIdentity, *, transport: Transport = _http_json) -> list[dict] | None:
     """All kept cloud revisions for this driver (newest first), or None when
-    the site is unreachable. Called from menu worker threads only."""
+    the site is unreachable. Raises :class:`CloudAuthError` when the server
+    answers but refuses the credentials. Called from menu worker threads only."""
     url = f"{_saves_url()}?driverId={identity.driver_id}"
     try:
         reply = transport(url, None, _auth_headers(identity))
+    except urllib.error.HTTPError as e:
+        body = _error_body(e)
+        if _auth_refused(e, body) or e.code == 404:
+            log.warning(
+                "Cloud save list refused (HTTP %s): this computer's sign-in is no longer accepted",
+                e.code,
+            )
+            raise CloudAuthError from e
+        log.warning("Cloud save list failed: HTTP %s", e.code)
+        return None
     except Exception as e:
         log.debug("Cloud save list failed: %s", e)
         return None
@@ -277,6 +312,21 @@ def download_save(
         url += f"&revision={revision}"
     try:
         reply = transport(url, None, _auth_headers(identity))
+    except urllib.error.HTTPError as e:
+        body = _error_body(e)
+        if _auth_refused(e, body):
+            log.warning(
+                "Cloud save download of %s refused (HTTP %s): this computer's sign-in is no longer accepted",
+                save_name,
+                e.code,
+            )
+            raise CloudAuthError from e
+        log.warning("Cloud save download of %s failed: HTTP %s", save_name, e.code)
+        return None
+    except Exception as e:
+        log.debug("Cloud save download failed: %s", e)
+        return None
+    try:
         content = base64.b64decode(reply["content"])
     except Exception as e:
         log.debug("Cloud save download failed: %s", e)
@@ -598,9 +648,17 @@ class CloudSaves:
                 result.get("latestRevision"),
             )
             return
+        if result.get("reason") in ("unauthorized", "driver_not_found", "http_401"):
+            # The credentials were retired (usually by connecting another
+            # computer); every retry would fail identically, and the player
+            # can only fix it by reconnecting.
+            self._set_status(
+                "Backups are paused: orinks.net no longer accepts this "
+                "computer's sign-in. Reconnect under Settings, Online."
+            )
+            self._done_with(name, snapshot)
+            return
         if result.get("reason") in (
-            "unauthorized",
-            "driver_not_found",
             "too_large",
             "invalid_schema",
             "invalid_name",

--- a/src/freight_fate/states/cloud_save_states.py
+++ b/src/freight_fate/states/cloud_save_states.py
@@ -50,6 +50,7 @@ class CloudBackupState(MenuState):
     def __init__(self, ctx) -> None:
         super().__init__(ctx)
         self._saves: list[dict] | None = None
+        self._auth_failed = False
         self._fetched = threading.Event()
         self._announced = False
         self._status = "Checking your cloud backups."
@@ -66,6 +67,7 @@ class CloudBackupState(MenuState):
 
     def _start_fetch(self) -> None:
         self._saves = None
+        self._auth_failed = False
         self._fetched.clear()
         self._announced = False
         identity = self._identity()
@@ -74,7 +76,10 @@ class CloudBackupState(MenuState):
             return
 
         def worker() -> None:
-            self._saves = cloud_saves.list_saves(identity)
+            try:
+                self._saves = cloud_saves.list_saves(identity)
+            except cloud_saves.CloudAuthError:
+                self._auth_failed = True
             self._fetched.set()
 
         threading.Thread(target=worker, name="cloud-saves-list", daemon=True).start()
@@ -104,7 +109,9 @@ class CloudBackupState(MenuState):
                 MenuItem("Checking your cloud backups", self.speak_current),
                 MenuItem("Back", self.go_back),
             ]
-        if self._saves is None:
+        if self._auth_failed:
+            self._status = "Reconnect needed: orinks.net no longer accepts this computer's sign-in."
+        elif self._saves is None:
             self._status = "Cloud backups could not be reached."
         else:
             self._status = self._service().status
@@ -115,7 +122,15 @@ class CloudBackupState(MenuState):
                 help="This stays here so you can review the latest Cloud backup result.",
             )
         ]
-        if self._saves is None:
+        if self._auth_failed:
+            items.append(
+                MenuItem(
+                    "Reconnect needed: your orinks.net sign-in is no longer accepted",
+                    self.speak_current,
+                    help=cloud_saves.AUTH_HELP,
+                )
+            )
+        elif self._saves is None:
             items.append(
                 MenuItem(
                     "Your cloud backups could not be reached",
@@ -171,6 +186,11 @@ class CloudBackupState(MenuState):
         if self._announced or not self._fetched.is_set() or self._identity() is None:
             return
         self._announced = True
+        if self._auth_failed:
+            self._status = "Reconnect needed: orinks.net no longer accepts this computer's sign-in."
+            self.refresh(keep_index=False)
+            self.ctx.say(cloud_saves.AUTH_HELP, interrupt=True)
+            return
         if self._saves is None:
             self._status = "Cloud backups could not be reached."
             self.refresh(keep_index=False)
@@ -312,6 +332,9 @@ class CloudSlotState(MenuState):
             except CloudSaveIntegrityError as error:
                 self._outcome = error.code
                 return
+            except cloud_saves.CloudAuthError:
+                self._outcome = "auth_failed"
+                return
             if payload is None:
                 self._outcome = "download_failed"
                 return
@@ -406,6 +429,13 @@ class CloudSlotState(MenuState):
             self._status = "Backup needs a newer Freight Fate version. Nothing restored."
             self.ctx.say(
                 "This backup needs a newer Freight Fate version. Update the game and try again. Nothing was restored.",
+                interrupt=True,
+            )
+        elif outcome == "auth_failed":
+            self._status = "Reconnect needed. Nothing was restored."
+            self.ctx.say(
+                f"{cloud_saves.AUTH_HELP} Nothing was restored, and your "
+                "local career is unchanged.",
                 interrupt=True,
             )
         elif outcome in ("invalid_profile", "restore_failed"):

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -106,6 +106,8 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
         self._destination_exit_taken = False
         self._missed_destination_exit_said = False
         self._destination_exit_announced_key = ""
+        # (position when computed, scan result) -- see _destination_exit_details
+        self._destination_exit_cache: tuple[float, tuple[float, str, str] | None] | None = None
         self._cruise_mph: float | None = None
         self._cruise_throttle = 0.0
         self._cruise_applied = 0.0

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -325,6 +325,25 @@ class DrivingEventMixin:
     def _destination_exit_details(
         self, *, include_past: bool = False
     ) -> tuple[float, str, str] | None:
+        if include_past:
+            return self._scan_destination_exit_details(include_past=True)
+        # This runs every frame from _check_destination_exit, and the scan
+        # walks every interchange on the route building spoken phrases -- far
+        # too much churn to redo per tick on a coast-to-coast route. The
+        # winning exit only changes when the truck passes it, so reuse the
+        # last answer until then. A backward position move (missed-exit
+        # rewind, rescue) invalidates the cache wholesale, because exits
+        # behind the compute position come back into play.
+        pos = self.trip.position_mi
+        cache = self._destination_exit_cache
+        if cache is None or pos < cache[0] or (cache[1] is not None and cache[1][0] <= pos + 0.05):
+            cache = (pos, self._scan_destination_exit_details())
+            self._destination_exit_cache = cache
+        return cache[1]
+
+    def _scan_destination_exit_details(
+        self, *, include_past: bool = False
+    ) -> tuple[float, str, str] | None:
         if not self.route.legs:
             return None
         # Matched against real interchange sign text, so compare the spoken

--- a/tests/test_cloud_saves.py
+++ b/tests/test_cloud_saves.py
@@ -24,11 +24,13 @@ from freight_fate.cloud_save_integrity import CloudSaveIntegrityError, canonical
 from freight_fate.cloud_saves import (
     DEBOUNCE_S,
     RETRY_INTERVAL_S,
+    CloudAuthError,
     CloudSaves,
     SyncState,
     backup_summary,
     cloud_content,
     download_save,
+    list_saves,
     profile_dict_from_content,
     restore_to_disk,
     save_slot_name,
@@ -69,6 +71,13 @@ class FakeTransport:
     @property
     def posts(self) -> list[dict]:
         return [p for _, p, _ in self.requests if p is not None]
+
+
+def auth_error(code: int = 401, error: str | None = None) -> urllib.error.HTTPError:
+    """The server's answer to a retired driver token (see issue 64: a new
+    token issued to a second computer retires the one stored here)."""
+    body = json.dumps({"error": error} if error else {}).encode("utf-8")
+    return urllib.error.HTTPError("url", code, "Unauthorized", None, io.BytesIO(body))
 
 
 def conflict_error(latest_revision: int = 5) -> urllib.error.HTTPError:
@@ -547,3 +556,44 @@ def test_cloud_toggle_speaks_the_disclosure_when_turned_on():
         assert not app.cloud.enabled
     finally:
         app.shutdown()
+
+
+# -- retired credentials (issue 64) ----------------------------------------------
+
+
+def test_list_saves_refused_credentials_raise_cloud_auth_error():
+    # A 401 means orinks.net answered and said no: the menus must tell the
+    # player to reconnect, never blame the network.
+    with pytest.raises(CloudAuthError):
+        list_saves(IDENTITY, transport=FakeTransport(error=auth_error(401)))
+
+
+def test_list_saves_unknown_driver_raises_cloud_auth_error():
+    with pytest.raises(CloudAuthError):
+        list_saves(
+            IDENTITY, transport=FakeTransport(error=auth_error(404, error="driver_not_found"))
+        )
+
+
+def test_list_saves_network_trouble_stays_none():
+    assert list_saves(IDENTITY, transport=FakeTransport(error=OSError("no route"))) is None
+
+
+def test_download_refused_credentials_raise_cloud_auth_error():
+    with pytest.raises(CloudAuthError):
+        download_save(
+            IDENTITY, save_name="Road Star", transport=FakeTransport(error=auth_error(401))
+        )
+
+
+def test_upload_with_retired_token_pauses_backups_with_reconnect_status():
+    transport = FakeTransport(error=auth_error(401))
+    clock = Clock()
+    service = make_service(transport, clock)
+    service.queue_backup(Profile(name="Road Star"))
+    drain(service, clock)
+
+    assert "Reconnect under Settings, Online" in service.status
+    # Not transient: the snapshot is dropped instead of retried forever.
+    drain(service, clock)
+    assert len(transport.posts) == 1

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -1178,6 +1178,89 @@ def test_delivery_exit_prefers_nearest_interchange_over_early_city_sign():
         app.shutdown()
 
 
+def test_destination_exit_scan_is_cached_until_the_exit_passes():
+    # The scan walks every interchange on the route building spoken phrases,
+    # and _check_destination_exit runs every frame -- the cache must absorb
+    # that (issue 70's crash landed in this per-frame churn) while still
+    # rescanning when the winning exit is passed or the truck moves backward.
+    import dataclasses
+
+    from freight_fate.app import App
+    from freight_fate.data.world_models import Interchange
+    from freight_fate.models.jobs import CARGO_CATALOG, Job
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.driving import DrivingState
+
+    app = App()
+    try:
+        app.ctx.profile = Profile(name="Cached Exit", current_city="Buffalo")
+        route = app.ctx.world.supported_route("Buffalo", "Rochester")
+        leg = route.legs[-1]
+        early = Interchange(
+            at_mi=10.0,
+            exit_ref="10",
+            destinations=("Rochester",),
+            name="",
+            highway=leg.highway,
+            source="test",
+        )
+        near = Interchange(
+            at_mi=leg.miles - 1.0,
+            exit_ref="near",
+            destinations=("Freight district",),
+            name="",
+            highway=leg.highway,
+            source="test",
+        )
+        route.legs[-1] = dataclasses.replace(leg, interchanges=(early, near))
+        job = Job(
+            CARGO_CATALOG["general"],
+            12.0,
+            "Buffalo",
+            "company yard",
+            "Rochester",
+            route.miles,
+            1000.0,
+            12.0,
+            destination_location="Rochester freight market",
+        )
+        driving = DrivingState(app.ctx, job, route, phase="delivery")
+
+        calls = 0
+        scan = driving._scan_destination_exit_details
+
+        def counting_scan(**kwargs):
+            nonlocal calls
+            calls += 1
+            return scan(**kwargs)
+
+        driving._scan_destination_exit_details = counting_scan
+
+        first = driving._destination_exit_details()
+        assert first is not None
+        assert first[1] == "exit near"
+        assert driving._destination_exit_details() == first
+        assert calls == 1
+
+        # Passing the winning exit forces one rescan; nothing is left ahead,
+        # and that empty answer is itself cached.
+        driving.trip.position_mi = first[0] + 0.1
+        assert driving._destination_exit_details() is None
+        assert driving._destination_exit_details() is None
+        assert calls == 2
+
+        # A backward move (the missed-exit rewind) brings the exit back.
+        driving.trip.position_mi = first[0] - 1.0
+        assert driving._destination_exit_details() == first
+        assert calls == 3
+
+        # include_past bypasses the cache entirely for the one-shot callers.
+        assert driving._destination_exit_details(include_past=True) == first
+        assert calls == 4
+    finally:
+        app.shutdown()
+
+
 def test_terse_destination_exit_omits_press_x_instruction(monkeypatch):
     from freight_fate.app import App
 


### PR DESCRIPTION
## What changed and why

Two fixes for the untitled [Bug] reports:

- **Issue #64** — when orinks.net refuses this computer's driver credentials (typically because connecting a second computer issued a fresh token and retired this one), the cloud code treated it like network trouble: the menus said "your cloud backups could not be reached" and the log recorded nothing. `list_saves`/`download_save` now raise `CloudAuthError` on a refused credential, refusals are logged at warning level so player-attached logs show the cause, and the Cloud backup menu, restore flow, and upload status all give reconnect guidance instead.
- **Issue #70** — the access-violation crash in the attached log landed in `_destination_exit_details`, which `_check_destination_exit` ran every frame; each call rescanned every interchange on every leg and rebuilt their spoken phrases. The winning exit only changes when the truck passes it, so the scan result is now cached, recomputed only when the exit is passed, and invalidated on any backward position move (missed-exit rewind, rescue). Likely also covers issue #69, which dies at job finish on the same path.

ROADMAP records the real underlying #64 limitation as follow-up: per-machine driver tokens on orinks.net.

## What players or maintainers will notice

- A player whose sign-in was retired now hears "orinks.net no longer accepts this computer's sign-in" with spoken directions to Settings, Online, instead of a wrong "could not be reached" message — in the backup list, during a restore, and in the status line.
- Long deliveries no longer carry a heavy per-frame background load; destination-exit announcements behave exactly as before.

## Tests and checks run

- `uv run pytest` — full suite, 1159 passed
- `uv run ruff check src tests tools` and `uv run python -m compileall src`
- New tests: retired-credential paths for list/download/upload (including that backups pause with a reconnect status instead of retrying forever), and destination-exit cache behavior (reuse, rescan on passing the exit, invalidation on backward moves, `include_past` bypass)

## Accessibility impact

All new player-facing text is spoken, in plain player language, and names the exact menu path ("Set up orinks.net account under Settings, Online"). No keyboard-flow changes: the reconnect notice appears as ordinary menu items and status lines in the existing Cloud backup menu. The destination-exit change is internal caching only; spoken announcements are unchanged (covered by existing tests).

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)