### PR TITLE
Point cloud reconnect guidance at the per-computer token list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,22 @@
 ### Fixed
 
 - **Cloud backup now tells you when this computer needs to reconnect.** If
-  orinks.net stops accepting this computer's sign-in, which can happen after
-  you connect a second computer with a new driver token, the cloud backup menu
-  now says so and walks you to Settings, Online to reconnect, instead of
-  wrongly reporting that your backups could not be reached.
+  orinks.net stops accepting this computer's sign-in, the cloud backup menu
+  now says so and explains the fix, instead of wrongly reporting that your
+  backups could not be reached.
 - **Long deliveries are easier on the game while you drive.** The destination
   exit is now worked out once and remembered instead of being recalculated
   every moment of the drive, removing a heavy background load tied to a
   reported crash on coast-to-coast routes.
+
+### Changed
+
+- **Playing on more than one computer no longer signs the other one out.**
+  orinks.net now gives each of your computers its own token: add a computer
+  from the driver setup page and your other machines keep working. If the
+  game says your sign-in is no longer accepted, it now points you to the
+  computer list on the setup page to get a fresh token for that computer.
+
 ## 1.8.1 - 2026-07-13
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -597,4 +597,4 @@ fit for an audio-first game.
 - [x] Opt-in Profile sharing for fictional road journals, achievements, and last-saved profile summaries
 - [x] Online posts carry the game's build identity (release tag or source checkout) so moderation can tell which version a driver runs
 - [x] Validated and server-signed private cloud revisions with verified public profile summaries
-- [ ] Per-machine driver tokens on orinks.net, so connecting a second computer no longer retires the first one's sign-in (the game now at least says reconnect instead of blaming the network; see issue #64)
+- [x] Per-computer driver tokens on orinks.net: each computer gets its own token from a named, revocable computer list on the driver setup page, so connecting a second computer no longer retires the first one's sign-in (issue #64; game-side reconnect guidance points at the computer list)

--- a/src/freight_fate/cloud_saves.py
+++ b/src/freight_fate/cloud_saves.py
@@ -128,12 +128,15 @@ class CloudAuthError(Exception):
 
 
 # The spoken guidance for CloudAuthError, shared by every cloud menu so the
-# player always hears the same recovery path.
+# player always hears the same recovery path. orinks.net issues one token
+# per computer, so a refusal means this computer's token was signed out
+# from the account's computer list (or replaced by a sign-out-everywhere).
 AUTH_HELP = (
-    "orinks.net no longer accepts this computer's sign-in. This can happen "
-    "after you connect another computer with a new driver token. Choose Set "
-    "up orinks.net account under Settings, Online, and paste a fresh Driver "
-    "ID and driver token to reconnect."
+    "orinks.net no longer accepts this computer's sign-in. This usually "
+    "means this computer was signed out from the computer list on your "
+    "orinks.net driver setup page. On that page, choose Add computer to get "
+    "a fresh token, then paste it under Set up orinks.net account in "
+    "Settings, Online."
 )
 
 


### PR DESCRIPTION
## What changed and why

orinks.net now issues one token per computer (landed on orinks-net dev), so the spoken guidance for a refused sign-in should no longer blame "connecting another computer" — that stopped retiring tokens. The shared AUTH_HELP text now explains that this computer was likely signed out from the account's computer list and walks the player through Add computer on the driver setup page for a fresh token. ROADMAP checks off the per-computer tokens bullet, and the changelog gains a Changed entry announcing multi-computer play.

## What players or maintainers will notice

If orinks.net rejects this computer's sign-in, the cloud backup menu, restore flow, and status line now direct the player to the computer list on the setup page instead of describing the old one-token behavior.

## Tests and checks run

- `uv run pytest tests/test_cloud_saves.py tests/test_settings_menu.py` — 38 passed
- `uv run ruff check src tests tools`

## Accessibility impact

Spoken-text only: the reconnect guidance stays plain player language and names the exact controls it refers to ("Add computer" on the driver setup page; "Set up orinks.net account" in Settings, Online). No menu structure or keyboard flow changes.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)