### PR TITLE
Fix cloud restore integrity failures: match the server's number layout when verifying signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- **Restoring a cloud backup works again.** Every new server-verified backup
+  was wrongly refused with "failed its integrity check" the moment you tried
+  to restore it, because the game checked the server's signature against a
+  slightly different written form of the save than the server had signed.
+  Restores of verified backups now complete normally.
 - **Cloud backup now tells you when this computer needs to reconnect.** If
   orinks.net stops accepting this computer's sign-in, the cloud backup menu
   now says so and explains the fix, instead of wrongly reporting that your

--- a/src/freight_fate/cloud_save_integrity.py
+++ b/src/freight_fate/cloud_save_integrity.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import base64
 import binascii
 import json
+import math
 from collections.abc import Mapping
+from decimal import Decimal
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
@@ -24,11 +26,77 @@ class CloudSaveIntegrityError(ValueError):
         self.code = code
 
 
+def _js_number(value: float) -> str:
+    """Serialize a float exactly as JavaScript's JSON.stringify does.
+
+    The server signs the canonical form it built with JSON.stringify, where
+    numbers carry no int/float distinction: 6.0 prints as "6", tiny values
+    stay decimal down to 1e-6, exponents are never zero-padded, and -0
+    prints as "0". Python's repr disagrees on all four, so leaning on
+    json.dumps here made every server signature unverifiable (the ".0" on
+    whole floats alone broke every real profile).
+    """
+    if math.isnan(value) or math.isinf(value):
+        raise ValueError("NaN and infinity cannot appear in a profile")
+    if value == 0.0:
+        return "0"
+    sign = "-" if value < 0 else ""
+    # repr() already yields the shortest round-trip digits, the same digits
+    # ECMAScript's Number::toString picks; only the layout rules differ.
+    digits, exponent = Decimal(repr(abs(value))).normalize().as_tuple()[1:]
+    mantissa = "".join(map(str, digits))
+    k = len(mantissa)
+    n = exponent + k  # value == 0.mantissa * 10**n
+    if k <= n <= 21:
+        body = mantissa + "0" * (n - k)
+    elif 0 < n <= 21:
+        body = f"{mantissa[:n]}.{mantissa[n:]}"
+    elif -6 < n <= 0:
+        body = f"0.{'0' * -n}{mantissa}"
+    else:
+        tail = f".{mantissa[1:]}" if k > 1 else ""
+        body = f"{mantissa[0]}{tail}e{'+' if n > 0 else '-'}{abs(n - 1)}"
+    return sign + body
+
+
+def _canonical_value(value) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        # json.dumps escaping of a lone string matches JSON.stringify plus
+        # the server's non-ASCII escape pass byte for byte.
+        return json.dumps(value, ensure_ascii=True)
+    if isinstance(value, int):
+        # The server parsed every number into a double; an int the double
+        # cannot hold exactly would canonicalize differently there, so honest
+        # profiles must stay inside the safe-integer range.
+        if abs(value) > 2**53:
+            raise ValueError("integer outside the JSON-safe range")
+        return str(value)
+    if isinstance(value, float):
+        return _js_number(value)
+    if isinstance(value, dict):
+        parts = (
+            f"{json.dumps(key, ensure_ascii=True)}:{_canonical_value(item)}"
+            for key, item in sorted(value.items())
+        )
+        return "{" + ",".join(parts) + "}"
+    if isinstance(value, list):
+        return "[" + ",".join(_canonical_value(item) for item in value) + "]"
+    raise TypeError(f"unsupported profile value: {type(value).__name__}")
+
+
 def canonical_profile(payload: dict) -> bytes:
+    """The byte form both sides sign: key-sorted, ASCII-escaped JSON with
+    numbers laid out by JavaScript's rules (see _js_number) — the server
+    builds its copy with JSON.stringify, and the signature only verifies
+    when the two agree on every byte."""
     try:
-        return json.dumps(
-            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
-        ).encode("utf-8")
+        return _canonical_value(payload).encode("utf-8")
     except (TypeError, ValueError) as exc:
         raise CloudSaveIntegrityError("invalid_profile", "Unsupported profile data.") from exc
 

--- a/tests/test_cloud_saves.py
+++ b/tests/test_cloud_saves.py
@@ -597,3 +597,42 @@ def test_upload_with_retired_token_pauses_backups_with_reconnect_status():
     # Not transient: the snapshot is dropped instead of retried forever.
     drain(service, clock)
     assert len(transport.posts) == 1
+
+
+# -- cross-language canonicalization (the byte form both sides sign) -------------
+
+
+def test_canonical_profile_matches_the_server_byte_for_byte():
+    # Expected string produced by the server's own canonicalization
+    # (JSON.stringify over sorted keys, then the non-ASCII escape pass) run
+    # in Node. The signature only verifies when Python lays out numbers the
+    # same way: whole floats lose their ".0", decimals hold down to 1e-6,
+    # exponents are unpadded, and negative zero prints as "0".
+    payload = {
+        "b": [1.5, 2.0, 1e-7, 0.00001],
+        "a": {"x": -0.0, "y": 129881.73999999999, "z": 29571.0},
+        "n": None,
+        "s": "café — truck",
+        "t": True,
+        "big": 1e21,
+        "tiny": 8.673617379884035e-19,
+        "whole": 6.0,
+    }
+    expected = (
+        '{"a":{"x":0,"y":129881.73999999999,"z":29571},'
+        '"b":[1.5,2,1e-7,0.00001],"big":1e+21,"n":null,'
+        '"s":"caf\\u00e9 \\u2014 truck","t":true,'
+        '"tiny":8.673617379884035e-19,"whole":6}'
+    )
+    assert canonical_profile(payload) == expected.encode("utf-8")
+
+
+def test_whole_float_profile_signature_round_trips():
+    # The exact shape that broke every real restore: ordinary careers carry
+    # whole floats (total_miles, reputation), which the old canonical form
+    # rendered as "29571.0" while the server had signed "29571".
+    profile = Profile(name="Road Star", money=77_000.0)
+    reply = make_cloud_reply(profile.to_dict())
+    payload = download_save(IDENTITY, save_name="Road Star", transport=FakeTransport(reply=reply))
+    assert payload is not None
+    assert payload["profile"]["money"] == 77_000.0


### PR DESCRIPTION
## What changed and why

Every server-verified cloud backup failed to restore with "This backup failed its integrity check." Root cause: the server signs the canonical JSON it builds with `JSON.stringify`, where numbers have no int/float distinction (`6.0` prints as `6`), while the game verified against Python `json.dumps` output, which keeps the `.0` on whole floats. Since every real profile carries whole floats (`total_miles`, `reputation`, ...), no real backup could ever pass verification. Both sides' own test suites passed because each signs and verifies within itself; the seam had no cross-language test.

Diagnosed against production data (driver trssharp, revision 57): the game's `verify_cloud_revision` rejected the genuine signed blob; a byte diff of the two canonical forms showed exactly the dropped `.0`s. `canonical_profile` now serializes numbers by ECMAScript rules — whole floats lose `.0`, decimal layout holds down to `1e-6`, exponents are unpadded, negative zero prints `0`, ints outside the double-safe range are refused — and the same real blob now verifies with the game's code.

## What players or maintainers will notice

Restoring a verified cloud backup completes normally instead of always being refused. This unblocks the player whose newer save is stuck on one machine.

## Tests and checks run

- `uv run pytest` — full suite, 1161 passed
- `uv run ruff check src tests tools`
- New regression tests: a byte-for-byte fixture generated by running the server's own canonicalization algorithm in Node, plus a signature round-trip on a profile with whole floats (the exact shape that failed)
- Manual proof: trssharp's live revision 57 (server-signed) verified OK with the fixed code

## Accessibility impact

No spoken-text or keyboard changes; the existing restore success/failure announcements now simply fire correctly.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)