### PR TITLE
docs(changelog): keep the cloud-restore note in player language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@
 
 - **Restoring a cloud backup works again.** Every new server-verified backup
   was wrongly refused with "failed its integrity check" the moment you tried
-  to restore it, because the game checked the server's signature against a
-  slightly different written form of the save than the server had signed.
-  Restores of verified backups now complete normally.
+  to restore it. The refusal was the game's mistake, not a problem with your
+  save. Restores of verified backups now complete normally.
 - **Cloud backup now tells you when this computer needs to reconnect.** If
   orinks.net stops accepting this computer's sign-in, the cloud backup menu
   now says so and explains the fix, instead of wrongly reporting that your


### PR DESCRIPTION
## What changed and why

Reworded the Unreleased cloud-restore bullet in `CHANGELOG.md`. The old text explained the failure in terms of the server's signature and the written form of the save — internal mechanics that don't belong in player-read release notes. The entry now sticks to what players experienced.

## What players or maintainers will notice

The release note still quotes the "failed its integrity check" message players actually saw, so they can recognize the fix, and now adds the reassurance that the refusal was the game's mistake, not a problem with their save. No code or behavior changes.

## Tests and checks run

Changelog-only change; the pre-commit release-note gate passed. No code paths touched, so no test runs apply.

## Accessibility impact

Improves the spoken release notes: the entry is shorter, in plain player language, with no technical jargon for a screen reader to wade through.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)