### PR TITLE
test(driving): deterministic destination-exit announcement test

### DIFF
--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -1302,6 +1302,18 @@ def test_destination_exit_announces_and_disables_cruise(monkeypatch):
     try:
         driving = start_drive(app)
         quiet_trip(driving)
+        # Pin the exit signage: the random job assignment picks the route,
+        # and not every destination exit carries a "toward" phrase in its
+        # sign data, so scanning the real interchanges here is a coin flip.
+        monkeypatch.setattr(
+            driving,
+            "_destination_exit_details",
+            lambda *, include_past=False: (
+                24.0,
+                "exit 20",
+                "exit 20 for US-64 East toward Memphis",
+            ),
+        )
         destination = driving._destination_exit_stop()
         driving.trip.position_mi = destination.at_mi - 4.0
         driving._cruise_mph = 60.0


### PR DESCRIPTION
## What changed and why

The nightly Build failed tonight (and on 2026-07-12) on the Windows test job: `test_destination_exit_announces_and_disables_cruise` asserts the spoken announcement contains a "toward" phrase, but the test drives a real new career with a randomly assigned job. Whether the destination exit's sign data includes "toward" depends on which route the RNG picked, so the test was a coin flip. This pins the exit details via monkeypatch (same pattern the missed-exit test already uses), so the announcement wording under test no longer depends on route data.

## What players will notice

Nothing — test-only change.

## Tests run

- `uv run pytest tests/test_driving_features.py -k destination_exit` — 8 passed
- The fixed test run 10 consecutive times — 10/10 passed
- `uv run ruff check tests/test_driving_features.py` — clean

## Accessibility impact

None; no spoken text changed.

## Changelog

- [x] Not player-facing: `[skip changelog]` in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)