### PR TITLE
Add independent calendar control for live weather

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
 
 ### Fixed
 
+- **Terminal weather now agrees with the live report on the road.** Time and
+  weather uses the real station temperature even when live weather does not
+  control the career calendar. If the first observation is still loading, the
+  terminal says so instead of announcing a modeled temperature that may change
+  when you start driving.
 - **Interstates stop enforcing a side street's speed limit mid-route.** A
   handful of highway legs still carried a 25 to 40 mile per hour sample in
   the middle of the corridor, picked up from a nearby city street or ramp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- **Live weather can now leave your career calendar running.** The new Live
+  weather controls calendar setting keeps today's real date when on. Turn it
+  off to keep live city conditions while your career date advances at midnight
+  and the seasons pass normally. Live conditions are adjusted to the career
+  season so summer snow and cold-season thunderstorms do not slip through. An
+  established career begins its independent calendar from today's date when
+  you turn the setting off, avoiding a jump back to its old hidden date; a new
+  career still begins on March 21.
 - **Hold a gentle speed without holding the accelerator.** In the low-speed stretches where adaptive cruise is unavailable, such as facility access roads, gate queues, and work zones, pressing K now engages a speed keeper: it holds your current speed at or below the zone limit, creeps along behind queued traffic, and hands control back the moment you brake or reach the open road. Made for players who cannot keep a key held down, or whose fingers simply tire. On by default; turn it off in Settings, Gameplay.
 
 ### Changed
@@ -72,11 +80,6 @@
   newer cargo types never rose or fell. Loading such a career now fills in
   the missing market prices, which also keeps cloud backups of these older
   careers in step with orinks.net.
-- **Live weather can now leave your career calendar running.** The new Live
-  weather controls calendar setting keeps today's real date when on. Turn it
-  off to keep live city conditions while your career date advances at midnight
-  and the seasons pass normally. Live conditions are adjusted to the career
-  season so summer snow and cold-season thunderstorms do not slip through.
 
 ## 1.8.3 - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@
   newer cargo types never rose or fell. Loading such a career now fills in
   the missing market prices, which also keeps cloud backups of these older
   careers in step with orinks.net.
+- **Live weather can now leave your career calendar running.** The new Live
+  weather controls calendar setting keeps today's real date when on. Turn it
+  off to keep live city conditions while your career date advances at midnight
+  and the seasons pass normally. Live conditions are adjusted to the career
+  season so summer snow and cold-season thunderstorms do not slip through.
 
 ## 1.8.3 - 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ visual display mirrors all speech for sighted players and helpers.
   "real world" and each city uses its live current conditions from the free
   [National Weather Service](https://www.weather.gov/documentation/services-web-api)
   API. If it is raining in Chicago right now, it is raining in your game. Works
-  without an API key and falls back to simulated weather offline.
+  without an API key and falls back to simulated weather offline. A separate
+  calendar setting lets career dates and seasons keep advancing while live
+  conditions remain enabled.
 - **Route planning** — route options per job with distance, highways, state
   context, grade/terrain, toll events, curated POIs, and weather forecasts.
   Geometry coverage is broad, while generated placeholder POIs are reported as

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -273,7 +273,8 @@ Net-new realism candidates, roughly by area:
   weather on the season follows the real-world calendar by default so it
   matches those conditions. Players can now turn off **Live weather controls
   calendar** to keep live conditions while the career date and seasons
-  advance; a seasonal reconciliation guard prevents summer snow and
+  advance; established careers anchor that independent calendar to today's
+  date at the handoff while new careers retain the March 21 start. A seasonal reconciliation guard prevents summer snow and
   cold-season thunderstorms in that mode. Real observation temperature is now extracted too (`_temp_to_c`
   -> `RealWeatherProvider.get_temperature` -> `WeatherSystem._temperature`), so
   live mode reports the station's real degrees and falls back to the climate

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -270,8 +270,11 @@ Net-new realism candidates, roughly by area:
   (winter ice/squalls, summer hail). Seasons are opt-in via `WeatherSystem`'s
   `game_hours` so seed-based tests stay deterministic; real-weather mode keeps
   driving conditions (and thus hazard context) from live data, and with live
-  weather on the season follows the real-world calendar so it matches those
-  conditions. Real observation temperature is now extracted too (`_temp_to_c`
+  weather on the season follows the real-world calendar by default so it
+  matches those conditions. Players can now turn off **Live weather controls
+  calendar** to keep live conditions while the career date and seasons
+  advance; a seasonal reconciliation guard prevents summer snow and
+  cold-season thunderstorms in that mode. Real observation temperature is now extracted too (`_temp_to_c`
   -> `RealWeatherProvider.get_temperature` -> `WeatherSystem._temperature`), so
   live mode reports the station's real degrees and falls back to the climate
   model only when a reading is missing. Weather also bites mechanically now,

--- a/docs/profile-invariants.md
+++ b/docs/profile-invariants.md
@@ -33,6 +33,7 @@ Ranges — all numeric fields must be finite (no NaN, no infinity):
 - `money`: greater than -1,000,000 and below 1,000,000,000 (structural
   ceiling; the real judgment is rule 2.1).
 - `fatigue`, `road_grime_pct`: 0 to 100.
+- `calendar_offset_days`: integer from 0 through 364.
 - `truck_damage_pct`, `tire_wear_pct`: 0 to 100.
 - `truck_fuel_gal`: 0 to the largest buildable tank (biggest catalog tank
   plus the long-range upgrade's 50 extra gallons — 250 today).

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -338,7 +338,12 @@ snow and ice are cold-season risks, thunderstorms a warm-season one, and the
 regional temperature follows the time of year and time of day. The current
 date and season are announced with the clock (press C while driving), in the
 Tab status menu, and at the city terminal. With live weather turned on, the
-date, season, and temperature follow the real-world calendar instead.
+default is for the date, season, and temperature to follow the real-world
+calendar. Turn **Live weather controls calendar** off to keep live city
+conditions while the career date advances at midnight and its seasons pass.
+Conditions remain seasonally plausible, so live snow is changed to rain or
+cloud when the career calendar is in warm weather, and thunderstorms are
+changed to heavy rain when the career season is too cold for them.
 
 Stops are reported as you approach them. A one-mile cue tells you when to take
 an exit. Press X to signal for the exit, slow to 45 miles per hour or less, and
@@ -531,6 +536,7 @@ Speech and weather settings include:
 | Speech volume | Appears only when the current voice source supports volume changes. |
 | Speech voice | Appears only when selectable voices are available. |
 | Weather source | Switches between simulated weather and live city conditions when available. |
+| Live weather controls calendar | When on, live weather uses today's real date and season. When off, live conditions continue while the career date advances at midnight and its seasons pass. |
 
 Online settings include:
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -344,6 +344,10 @@ conditions while the career date advances at midnight and its seasons pass.
 Conditions remain seasonally plausible, so live snow is changed to rain or
 cloud when the career calendar is in warm weather, and thunderstorms are
 changed to heavy rain when the career season is too cold for them.
+The Time and weather item at a terminal always uses the live station
+temperature when it is available, regardless of which calendar controls the
+season. On the first request it may say live weather is still loading; try the
+item again after a moment rather than treating a modeled temperature as live.
 
 Stops are reported as you approach them. A one-mile cue tells you when to take
 an exit. Press X to signal for the exit, slow to 45 miles per hour or less, and

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -341,6 +341,9 @@ Tab status menu, and at the city terminal. With live weather turned on, the
 default is for the date, season, and temperature to follow the real-world
 calendar. Turn **Live weather controls calendar** off to keep live city
 conditions while the career date advances at midnight and its seasons pass.
+For an established career, turning it off begins the independent calendar on
+today's date so the date does not jump backward. A newly created career still
+begins on March 21.
 Conditions remain seasonally plausible, so live snow is changed to rain or
 cloud when the career calendar is in warm weather, and thunderstorms are
 changed to heavy rain when the career season is too cold for them.

--- a/src/freight_fate/models/profile.py
+++ b/src/freight_fate/models/profile.py
@@ -306,6 +306,10 @@ class Profile:
     road_grime_pct: float = 0.0
     truck_fuel_gal: float = 150.0
     game_hours: float = 6.0  # in-game clock, hours since career start
+    # Whole-day offset used only by the spoken calendar and seasonal weather.
+    # Existing careers can anchor their independent calendar to today's date
+    # without changing deadlines, HOS, markets, or elapsed career time.
+    calendar_offset_days: int = 0
     tutorial_done: bool = False
     truck: str = "rig"  # key into trucks.TRUCK_CATALOG
     owned_trucks: list[str] = field(default_factory=lambda: ["rig"])
@@ -353,6 +357,33 @@ class Profile:
 
     def market_day(self) -> int:
         return int(self.game_hours // 24)
+
+    @property
+    def calendar_game_hours(self) -> float:
+        return self.game_hours + self.calendar_offset_days * 24.0
+
+    def has_started_career(self) -> bool:
+        """Whether this profile has progressed beyond a just-created career."""
+        return bool(
+            self.game_hours > 6.0 + 1e-6
+            or self.calendar_offset_days != 0
+            or self.tutorial_done
+            or self.active_trip is not None
+            or self.dispatch_board_cache is not None
+            or self.money != STARTING_MONEY
+            or bool(self.upgrades)
+            or self.pay_advance > 0
+            or self.career.xp > 0
+            or self.career.deliveries > 0
+            or self.career.total_miles > 0
+            or bool(self.achievements)
+        )
+
+    def anchor_calendar_to(self, target_game_hours: float) -> None:
+        """Make the independent calendar show target's date without moving time."""
+        target_day = int(target_game_hours // 24) % 365
+        career_day = int(self.game_hours // 24) % 365
+        self.calendar_offset_days = (target_day - career_day) % 365
 
     # -- persistence -----------------------------------------------------------
 

--- a/src/freight_fate/profile_invariants.py
+++ b/src/freight_fate/profile_invariants.py
@@ -62,6 +62,10 @@ def check_profile_invariants(profile: Profile) -> list[Violation]:
     _check_range(out, "fatigue", "Fatigue", profile.fatigue, 0.0, 100.0)
     _check_range(out, "road_grime", "Road grime", profile.road_grime_pct, 0.0, 100.0)
     _check_range(out, "pay_advance", "The pay advance", profile.pay_advance, 0.0, ADVANCE_CEILING)
+    if not isinstance(profile.calendar_offset_days, int) or not (
+        0 <= profile.calendar_offset_days < 365
+    ):
+        out.append(Violation("calendar_offset", "The calendar offset is not possible."))
     _check_range(out, "damage", "Truck damage", profile.truck_damage_pct, 0.0, 100.0)
     _check_range(out, "tire_wear", "Tire wear", profile.tire_wear_pct, 0.0, 100.0)
     if not _finite(profile.truck_fuel_gal) or not (0.0 <= profile.truck_fuel_gal <= _MAX_FUEL_GAL):

--- a/src/freight_fate/settings.py
+++ b/src/freight_fate/settings.py
@@ -26,6 +26,10 @@ class Settings:
     # step up to standard or fast in Settings, Gameplay.
     time_scale: float = 10.0
     real_weather: bool = False  # live conditions from the NWS API
+    # Preserve the historical behavior by default: live weather also follows
+    # the wall-clock date. Turn this off to let the career calendar advance
+    # while live conditions continue to come from the NWS.
+    live_weather_controls_calendar: bool = True
     hos_mode: str = (
         "realistic"  # hours of service: realistic/relaxed (debug_off is an internal dev bypass)
     )
@@ -119,6 +123,8 @@ class Settings:
             s.haptics_enabled = True
         if not isinstance(s.cloud_saves, bool):
             s.cloud_saves = False
+        if not isinstance(s.live_weather_controls_calendar, bool):
+            s.live_weather_controls_calendar = True
         for attr in (
             "master_volume",
             "sfx_volume",

--- a/src/freight_fate/sim/season.py
+++ b/src/freight_fate/sim/season.py
@@ -144,6 +144,27 @@ def adjust_for_temperature(kind: WeatherKind, temp_c: float | None) -> WeatherKi
     return kind
 
 
+def adjust_for_calendar(
+    kind: WeatherKind, temp_c: float | None, game_hours: float | None
+) -> WeatherKind:
+    """Reconcile weather with both temperature and the selected calendar.
+
+    Temperature handles the physical precipitation phase. The season check is
+    the final gameplay guard: snow is winter-only and thunderstorms are
+    summer-only, preventing a live observation from contradicting an
+    independently advancing career calendar.
+    """
+    adjusted = adjust_for_temperature(kind, temp_c)
+    if game_hours is None:
+        return adjusted
+    current_season = season(game_hours)
+    if adjusted is WeatherKind.SNOW and current_season != "winter":
+        return WeatherKind.RAIN if temp_c is not None and temp_c < 6.0 else WeatherKind.CLOUDY
+    if adjusted is WeatherKind.THUNDERSTORM and current_season != "summer":
+        return WeatherKind.HEAVY_RAIN
+    return adjusted
+
+
 def temperature_text(region: str, game_hours: float, imperial: bool = True) -> str:
     """Spoken temperature in the player's units."""
     temp_c = temperature_c(region, game_hours)

--- a/src/freight_fate/sim/weather.py
+++ b/src/freight_fate/sim/weather.py
@@ -243,10 +243,12 @@ class WeatherSystem:
         seed: int | None = None,
         provider=None,
         game_hours: float | None = None,
+        live_weather_controls_calendar: bool = True,
     ) -> None:
         self._rng = random.Random(seed)
         self.region = region
         self.provider = provider
+        self.live_weather_controls_calendar = live_weather_controls_calendar
         # Career clock at this point in the trip. When provided, weather is
         # season- and temperature-aware (snow only when cold, storms only when
         # warm); when None, the simulated draw is used as-is so seed-based
@@ -278,7 +280,7 @@ class WeatherSystem:
         otherwise they follow the career clock, and are off entirely when no
         career clock was supplied.
         """
-        if self.provider is not None:
+        if self.provider is not None and self.live_weather_controls_calendar:
             from .season import real_clock_game_hours
 
             return real_clock_game_hours()
@@ -316,12 +318,25 @@ class WeatherSystem:
 
     def _seasonal(self, kind: WeatherKind) -> WeatherKind:
         """Reconcile a simulated condition with the season's temperature."""
-        temp = self._temperature()
+        # When live weather does not control the calendar, precipitation must
+        # agree with the career season even if the real station is currently
+        # reporting a wintry condition. This prevents summer snow and cold-
+        # season thunderstorms in the career's independent calendar.
+        if self.provider is not None and not self.live_weather_controls_calendar:
+            clock = self._season_clock()
+            if clock is None:
+                temp = None
+            else:
+                from .season import temperature_c
+
+                temp = temperature_c(self.region, clock)
+        else:
+            temp = self._temperature()
         if temp is None:
             return kind
-        from .season import adjust_for_temperature
+        from .season import adjust_for_calendar
 
-        return adjust_for_temperature(kind, temp)
+        return adjust_for_calendar(kind, temp, self._season_clock())
 
     def set_city(self, city: str, lat: float, lon: float) -> None:
         """Track the city whose real weather should apply (provider mode)."""
@@ -417,9 +432,10 @@ class WeatherSystem:
             self.live = False
             return None
         self.live = True
-        if kind != self.current:
-            self.current = kind
-            return kind
+        guarded = self._seasonal(kind)
+        if guarded != self.current:
+            self.current = guarded
+            return guarded
         return None
 
     def should_thunder(self) -> bool:

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -291,7 +291,7 @@ class CityMenuState(MenuState):
         zone = city_zone(city)
         hour = to_local(p.game_hours, zone) % 24.0
         day = p.market_day() + 1
-        desc, live = None, False
+        desc, live, loading = None, False, False
         provider = self.ctx.real_weather_provider()
         if provider is not None:
             # Keyed by the city key, not the spoken name: two cities can share
@@ -300,6 +300,9 @@ class CityMenuState(MenuState):
             kind = provider.get(city.key)
             if kind is not None:
                 desc, live = kind.value, True
+            else:
+                unavailable = getattr(provider, "unavailable", None)
+                loading = unavailable is None or not unavailable(city.key)
         from ..sim.season import (
             adjust_for_calendar,
             date_text,
@@ -319,19 +322,33 @@ class CityMenuState(MenuState):
         if live:
             observed = None
             getter = getattr(provider, "get_temperature", None)
-            if getter is not None and self.ctx.settings.live_weather_controls_calendar:
+            if getter is not None:
                 observed = getter(city.key)
-            guard_temp = observed
-            if guard_temp is None:
-                guard_temp = temperature_c(city.region, season_hours)
-            desc = adjust_for_calendar(kind, guard_temp, season_hours).value
-        if desc is None:
+            # The calendar toggle controls date, season, and plausibility -- it
+            # never replaces a real station temperature with a modeled one.
+            guard_temp = (
+                observed
+                if self.ctx.settings.live_weather_controls_calendar and observed is not None
+                else temperature_c(city.region, season_hours)
+            )
+            parts = [adjust_for_calendar(kind, guard_temp, season_hours).value]
+            if observed is not None:
+                if self.ctx.settings.imperial_units:
+                    parts.append(f"{observed * 9 / 5 + 32:.0f} degrees")
+                else:
+                    parts.append(f"{observed:.0f} degrees Celsius")
+            else:
+                parts.append("temperature unavailable")
+            desc = ", ".join(parts)
+        if loading:
+            desc = "still loading; try Time and weather again in a moment"
+        elif desc is None:
             # deterministic per city and hour, so asking twice agrees
             seed = zlib.crc32(f"{city.key}:{int(p.game_hours)}".encode())
             desc = WeatherSystem(city.region, seed=seed, game_hours=season_hours).describe(
                 self.ctx.settings.imperial_units
             )
-        source = "Live weather" if live else "Weather"
+        source = "Live weather" if live or loading else "Weather"
         self.ctx.say(
             f"It is {clock_text(hour)} {zone.name}, {time_of_day(hour)}, "
             f"{date_text(season_hours)}, in {season(season_hours)}, "

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -317,7 +317,7 @@ class CityMenuState(MenuState):
         season_hours = (
             real_clock_game_hours()
             if provider is not None and self.ctx.settings.live_weather_controls_calendar
-            else p.game_hours
+            else p.calendar_game_hours
         )
         if live:
             observed = None

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -300,11 +300,31 @@ class CityMenuState(MenuState):
             kind = provider.get(city.key)
             if kind is not None:
                 desc, live = kind.value, True
-        from ..sim.season import date_text, real_clock_game_hours, season
+        from ..sim.season import (
+            adjust_for_calendar,
+            date_text,
+            real_clock_game_hours,
+            season,
+            temperature_c,
+        )
 
-        # With live weather on, the season follows the real calendar so it
-        # matches the real conditions; otherwise it follows the career clock.
-        season_hours = real_clock_game_hours() if provider is not None else p.game_hours
+        # Live conditions and the calendar are separate player choices. The
+        # legacy default follows today's real date; an independent calendar
+        # advances with career time even while conditions remain live.
+        season_hours = (
+            real_clock_game_hours()
+            if provider is not None and self.ctx.settings.live_weather_controls_calendar
+            else p.game_hours
+        )
+        if live:
+            observed = None
+            getter = getattr(provider, "get_temperature", None)
+            if getter is not None and self.ctx.settings.live_weather_controls_calendar:
+                observed = getter(city.key)
+            guard_temp = observed
+            if guard_temp is None:
+                guard_temp = temperature_c(city.region, season_hours)
+            desc = adjust_for_calendar(kind, guard_temp, season_hours).value
         if desc is None:
             # deterministic per city and hour, so asking twice agrees
             seed = zlib.crc32(f"{city.key}:{int(p.game_hours)}".encode())

--- a/src/freight_fate/states/city_dispatch.py
+++ b/src/freight_fate/states/city_dispatch.py
@@ -711,7 +711,7 @@ class RouteSelectState(MenuState):
                     hours = (
                         real_clock_game_hours()
                         if self.ctx.settings.live_weather_controls_calendar
-                        else self.ctx.profile.game_hours
+                        else self.ctx.profile.calendar_game_hours
                     )
                     observed = None
                     getter = getattr(provider, "get_temperature", None)

--- a/src/freight_fate/states/city_dispatch.py
+++ b/src/freight_fate/states/city_dispatch.py
@@ -699,8 +699,29 @@ class RouteSelectState(MenuState):
         if provider is not None:
             parts = []
             for name in route.cities[1:][:5]:
-                kind = provider.get(name)
+                city = self.ctx.world.cities[name]
+                kind = provider.get(city.key)
                 if kind is not None:
+                    from ..sim.season import (
+                        adjust_for_calendar,
+                        real_clock_game_hours,
+                        temperature_c,
+                    )
+
+                    hours = (
+                        real_clock_game_hours()
+                        if self.ctx.settings.live_weather_controls_calendar
+                        else self.ctx.profile.game_hours
+                    )
+                    observed = None
+                    getter = getattr(provider, "get_temperature", None)
+                    if getter is not None and self.ctx.settings.live_weather_controls_calendar:
+                        observed = getter(city.key)
+                    kind = adjust_for_calendar(
+                        kind,
+                        observed if observed is not None else temperature_c(city.region, hours),
+                        hours,
+                    )
                     parts.append(
                         f"{self.ctx.world.spoken_city(name, qualified=True)}: {kind.value}"
                     )

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -42,8 +42,10 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
             seed=self.trip_seed,
             provider=ctx.real_weather_provider(),
             game_hours=profile.game_hours,
+            live_weather_controls_calendar=ctx.settings.live_weather_controls_calendar,
         )
         self._weather_source_real = ctx.settings.real_weather
+        self._live_weather_controls_calendar = ctx.settings.live_weather_controls_calendar
         trip_start_hour = profile.game_hours % 24.0 if start_hour is None else start_hour
         self.trip = Trip(
             route,

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -41,7 +41,7 @@ class DrivingState(DrivingControlsMixin, DrivingUpdateMixin, DrivingEventMixin, 
             region,
             seed=self.trip_seed,
             provider=ctx.real_weather_provider(),
-            game_hours=profile.game_hours,
+            game_hours=profile.calendar_game_hours,
             live_weather_controls_calendar=ctx.settings.live_weather_controls_calendar,
         )
         self._weather_source_real = ctx.settings.real_weather

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -589,6 +589,12 @@ class DrivingUpdateMixin:
         self._live_weather_controls_calendar = controls_calendar
         self.weather.provider = self.ctx.real_weather_provider() if real else None
         self.weather.live_weather_controls_calendar = controls_calendar
+        if not controls_calendar:
+            # The setting may just have anchored an established profile to
+            # today's date. Include time already driven on this active trip.
+            self.weather.game_hours = (
+                self.ctx.profile.calendar_game_hours + self.trip.game_minutes / 60.0
+            )
         if not real:
             self.weather.live = False
         self.ctx.audio.set_weather(self.weather.effects.sound)

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -579,10 +579,16 @@ class DrivingUpdateMixin:
 
     def _sync_weather_source(self) -> None:
         real = self.ctx.settings.real_weather
-        if real == self._weather_source_real:
+        controls_calendar = self.ctx.settings.live_weather_controls_calendar
+        if (
+            real == self._weather_source_real
+            and controls_calendar == self._live_weather_controls_calendar
+        ):
             return
         self._weather_source_real = real
+        self._live_weather_controls_calendar = controls_calendar
         self.weather.provider = self.ctx.real_weather_provider() if real else None
+        self.weather.live_weather_controls_calendar = controls_calendar
         if not real:
             self.weather.live = False
         self.ctx.audio.set_weather(self.weather.effects.sound)

--- a/src/freight_fate/states/main_menu.py
+++ b/src/freight_fate/states/main_menu.py
@@ -1355,9 +1355,16 @@ class SettingsCategoryState(MenuState):
         self._announce()
 
     def _toggle_live_weather_calendar(self, _d: int) -> None:
+        turning_off = self.ctx.settings.live_weather_controls_calendar
         self.ctx.settings.live_weather_controls_calendar = (
             not self.ctx.settings.live_weather_controls_calendar
         )
+        profile = self.ctx.profile
+        if turning_off and profile is not None and profile.has_started_career():
+            from ..sim.season import real_clock_game_hours
+
+            profile.anchor_calendar_to(real_clock_game_hours())
+            profile.save()
         self._announce()
 
     def _channel(self) -> str:

--- a/src/freight_fate/states/main_menu.py
+++ b/src/freight_fate/states/main_menu.py
@@ -1132,6 +1132,18 @@ class SettingsCategoryState(MenuState):
                 "Real world uses live city conditions when available.",
             )
         )
+        specs.append(
+            (
+                lambda: (
+                    "Live weather controls calendar: "
+                    f"{'on' if s.live_weather_controls_calendar else 'off'}"
+                ),
+                self._toggle_live_weather_calendar,
+                "When on, live weather uses today's real date and season. When off, "
+                "the career date advances at midnight and seasons pass while weather "
+                "conditions still come from the real world.",
+            )
+        )
         return specs
 
     def _toggle_speed_keeper(self, _d: int = 1) -> None:
@@ -1340,6 +1352,12 @@ class SettingsCategoryState(MenuState):
 
     def _toggle_real_weather(self, _d: int) -> None:
         self.ctx.settings.real_weather = not self.ctx.settings.real_weather
+        self._announce()
+
+    def _toggle_live_weather_calendar(self, _d: int) -> None:
+        self.ctx.settings.live_weather_controls_calendar = (
+            not self.ctx.settings.live_weather_controls_calendar
+        )
         self._announce()
 
     def _channel(self) -> str:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -259,11 +259,13 @@ def test_profile_roundtrip():
     p = Profile(name="Roundtrip Test")
     p.money = 1234.5
     p.career.xp = 2600
+    p.calendar_offset_days = 147
     path = p.save()
     loaded = Profile.load(path)
     assert loaded.money == 1234.5
     assert loaded.career.level == 3
     assert loaded.name == "Roundtrip Test"
+    assert loaded.calendar_offset_days == 147
 
 
 def test_profile_save_is_atomic_and_versioned():

--- a/tests/test_profile_invariants.py
+++ b/tests/test_profile_invariants.py
@@ -52,6 +52,13 @@ def test_range_edits_are_caught():
     assert {"money", "fatigue", "xp", "reputation"} <= found
 
 
+@pytest.mark.parametrize("value", [-1, 365, 1.5, float("nan")])
+def test_calendar_offset_edits_are_caught(value):
+    p = Profile(name="Edited Calendar")
+    p.calendar_offset_days = value
+    assert "calendar_offset" in codes(p)
+
+
 def test_condition_edits_are_caught():
     p = Profile(name="Edited")
     p.tire_wear_pct = -20.0  # fresher than new

--- a/tests/test_season.py
+++ b/tests/test_season.py
@@ -246,6 +246,7 @@ def test_terminal_sleep_uses_independent_calendar_with_live_weather(monkeypatch)
         terminal._time_weather()
         assert "March 21" in spoken[-1]
         assert "July 17" not in spoken[-1]
+        assert "77 degrees" in spoken[-1]
 
         # A fresh driver gets a confirmation before deliberately sleeping.
         terminal._sleep()
@@ -254,5 +255,37 @@ def test_terminal_sleep_uses_independent_calendar_with_live_weather(monkeypatch)
         assert app.ctx.profile.game_hours == pytest.approx(16.0)
         assert "March 21" in spoken[-1]  # 6 AM + 10 hours has not crossed midnight
         assert "July 17" not in spoken[-1]
+        assert "77 degrees" in spoken[-1]
+    finally:
+        app.shutdown()
+
+
+def test_terminal_does_not_present_modeled_temperature_while_live_weather_loads(monkeypatch):
+    from freight_fate.app import App
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.city import CityMenuState
+
+    class _LoadingProvider:
+        def request(self, *a):
+            pass
+
+        def get(self, *a):
+            return None
+
+        def unavailable(self, *a):
+            return False
+
+    app = App()
+    spoken = []
+    monkeypatch.setattr(app.ctx, "say", lambda text, interrupt=True: spoken.append(text))
+    monkeypatch.setattr(app.ctx, "real_weather_provider", lambda: _LoadingProvider())
+    app.ctx.settings.real_weather = True
+    app.ctx.settings.live_weather_controls_calendar = False
+    app.ctx.profile = Profile(name="Loading Weather Driver")
+    try:
+        CityMenuState(app.ctx)._time_weather()
+        assert "Live weather" in spoken[-1]
+        assert "still loading" in spoken[-1]
+        assert "degrees" not in spoken[-1]
     finally:
         app.shutdown()

--- a/tests/test_season.py
+++ b/tests/test_season.py
@@ -8,6 +8,7 @@ from freight_fate.sim.season import (
     CAREER_START_DAY_OF_YEAR,
     DAYS_PER_YEAR,
     FREEZING_C,
+    adjust_for_calendar,
     adjust_for_temperature,
     career_year,
     date_text,
@@ -103,6 +104,21 @@ def test_thunderstorms_need_warmth():
     assert adjust_for_temperature(WeatherKind.THUNDERSTORM, 25.0) is WeatherKind.THUNDERSTORM
 
 
+def test_calendar_guard_keeps_snow_in_winter_and_storms_in_summer():
+    summer = _hours_for_day(200)
+    winter = _hours_for_day(15)
+    assert adjust_for_calendar(WeatherKind.SNOW, -10.0, summer) is WeatherKind.RAIN
+    assert (
+        adjust_for_calendar(WeatherKind.THUNDERSTORM, 25.0, winter)
+        is WeatherKind.HEAVY_RAIN
+    )
+    assert adjust_for_calendar(WeatherKind.SNOW, -10.0, winter) is WeatherKind.SNOW
+    assert (
+        adjust_for_calendar(WeatherKind.THUNDERSTORM, 25.0, summer)
+        is WeatherKind.THUNDERSTORM
+    )
+
+
 def test_dry_conditions_and_unknown_temperature_pass_through():
     for kind in (WeatherKind.CLEAR, WeatherKind.CLOUDY, WeatherKind.FOG, WeatherKind.WIND):
         assert adjust_for_temperature(kind, -20.0) is kind
@@ -145,7 +161,98 @@ def test_live_weather_makes_season_follow_the_real_clock():
     )
 
 
+def test_live_weather_can_leave_calendar_on_career_clock():
+    """Live conditions do not freeze the career calendar when opted out."""
+
+    class _Provider:
+        def request(self, *a):
+            pass
+
+        def get(self, *a):
+            return WeatherKind.CLEAR
+
+    start = _hours_for_day(151) + 23.5
+    live = WeatherSystem(
+        "great_lakes",
+        seed=1,
+        game_hours=start,
+        provider=_Provider(),
+        live_weather_controls_calendar=False,
+    )
+    before = live.date_text
+    live.update(60.0)
+    assert live.date_text != before
+    assert live.date_text == date_text(start + 1.0)
+    assert live.season == season(start + 1.0)
+
+
+def test_live_snow_is_guarded_by_independent_career_season():
+    class _Provider:
+        def request(self, *a):
+            pass
+
+        def get(self, *a):
+            return WeatherKind.SNOW
+
+        def get_temperature(self, *a):
+            return -10.0
+
+    summer = _hours_for_day(200) + 15.0
+    live = WeatherSystem(
+        "great_lakes",
+        seed=1,
+        game_hours=summer,
+        provider=_Provider(),
+        live_weather_controls_calendar=False,
+    )
+    live.set_city("Chicago", 41.8, -87.6)
+    live.update(0.0)
+    assert live.live is True
+    assert live.season == "summer"
+    assert live.current is not WeatherKind.SNOW
+
+
 def test_temperature_text_uses_player_units():
     hours = _hours_for_day(200) + 15
     assert temperature_text("florida", hours, imperial=True).endswith("Fahrenheit")
     assert temperature_text("florida", hours, imperial=False).endswith("Celsius")
+
+
+def test_terminal_sleep_uses_independent_calendar_with_live_weather(monkeypatch):
+    """Regression: the terminal readout must honor the calendar toggle too."""
+    from freight_fate.app import App
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.city import CityMenuState
+
+    class _Provider:
+        def request(self, *a):
+            pass
+
+        def get(self, *a):
+            return WeatherKind.CLEAR
+
+        def get_temperature(self, *a):
+            return 25.0
+
+    app = App()
+    spoken = []
+    monkeypatch.setattr(app.ctx, "say", lambda text, interrupt=True: spoken.append(text))
+    monkeypatch.setattr(app.ctx, "real_weather_provider", lambda: _Provider())
+    app.ctx.settings.real_weather = True
+    app.ctx.settings.live_weather_controls_calendar = False
+    app.ctx.profile = Profile(name="Calendar Driver")
+    terminal = CityMenuState(app.ctx)
+    try:
+        terminal._time_weather()
+        assert "March 21" in spoken[-1]
+        assert "July 17" not in spoken[-1]
+
+        # A fresh driver gets a confirmation before deliberately sleeping.
+        terminal._sleep()
+        terminal._sleep()
+        terminal._time_weather()
+        assert app.ctx.profile.game_hours == pytest.approx(16.0)
+        assert "March 21" in spoken[-1]  # 6 AM + 10 hours has not crossed midnight
+        assert "July 17" not in spoken[-1]
+    finally:
+        app.shutdown()

--- a/tests/test_season.py
+++ b/tests/test_season.py
@@ -41,6 +41,19 @@ def test_career_year_increments_after_a_full_year():
     assert career_year(24.0 * DAYS_PER_YEAR) == 2
 
 
+def test_profile_calendar_offset_changes_date_without_changing_career_time():
+    from freight_fate.models.profile import Profile
+
+    profile = Profile(name="Established", game_hours=30.0)
+    target = _hours_for_day(200) + 15.0
+    profile.anchor_calendar_to(target)
+
+    assert profile.game_hours == 30.0
+    assert date_text(profile.calendar_game_hours) == date_text(target)
+    assert profile.calendar_game_hours % 24 == profile.game_hours % 24
+    assert 0 <= profile.calendar_offset_days < 365
+
+
 def test_weather_system_exposes_date_text():
     sim = WeatherSystem("heartland", seed=1, game_hours=0.0)
     assert sim.date_text == "March 21"

--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -150,6 +150,48 @@ def test_live_weather_calendar_setting_defaults_on_and_persists():
         app.shutdown()
 
 
+def test_disabling_live_calendar_anchors_established_career_to_today(monkeypatch):
+    from freight_fate.app import App
+    from freight_fate.models.profile import Profile
+    from freight_fate.sim.season import date_text
+
+    app = App()
+    app.ctx.profile = Profile(name="Established Driver", game_hours=54.0)
+    target = 200.0 * 24.0 + 17.0
+    monkeypatch.setattr("freight_fate.sim.season.real_clock_game_hours", lambda: target)
+    try:
+        original_game_hours = app.ctx.profile.game_hours
+        cat = open_settings_category(app, "Speech and weather")
+        while not cat.items[cat.index].text.startswith("Live weather controls calendar"):
+            cat.handle_event(key_event(pygame.K_DOWN))
+        cat.handle_event(key_event(pygame.K_RETURN))
+
+        assert app.ctx.settings.live_weather_controls_calendar is False
+        assert app.ctx.profile.game_hours == original_game_hours
+        assert date_text(app.ctx.profile.calendar_game_hours) == date_text(target)
+        assert app.ctx.profile.calendar_game_hours % 24 == original_game_hours % 24
+    finally:
+        app.shutdown()
+
+
+def test_disabling_live_calendar_keeps_new_career_on_march_21(monkeypatch):
+    from freight_fate.app import App
+    from freight_fate.models.profile import Profile
+
+    app = App()
+    app.ctx.profile = Profile(name="Brand New Driver")
+    monkeypatch.setattr("freight_fate.sim.season.real_clock_game_hours", lambda: 200.0 * 24.0)
+    try:
+        cat = open_settings_category(app, "Speech and weather")
+        while not cat.items[cat.index].text.startswith("Live weather controls calendar"):
+            cat.handle_event(key_event(pygame.K_DOWN))
+        cat.handle_event(key_event(pygame.K_RETURN))
+        assert app.ctx.profile.calendar_offset_days == 0
+        assert app.ctx.profile.calendar_game_hours == 6.0
+    finally:
+        app.shutdown()
+
+
 def test_settings_menu_volume_survives_new_app_session():
     from freight_fate.app import App
     from freight_fate.settings import Settings

--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -131,6 +131,25 @@ def test_settings_menu_saves_each_change():
         app.shutdown()
 
 
+def test_live_weather_calendar_setting_defaults_on_and_persists():
+    from freight_fate.app import App
+    from freight_fate.settings import Settings
+
+    app = App()
+    try:
+        assert app.ctx.settings.live_weather_controls_calendar is True
+        cat = open_settings_category(app, "Speech and weather")
+        while not cat.items[cat.index].text.startswith("Live weather controls calendar"):
+            cat.handle_event(key_event(pygame.K_DOWN))
+        assert "today's real date" in cat.current_help()
+        cat.handle_event(key_event(pygame.K_RETURN))
+        assert app.ctx.settings.live_weather_controls_calendar is False
+        assert Settings.load().live_weather_controls_calendar is False
+        assert cat.items[cat.index].text == "Live weather controls calendar: off"
+    finally:
+        app.shutdown()
+
+
 def test_settings_menu_volume_survives_new_app_session():
     from freight_fate.app import App
     from freight_fate.settings import Settings

--- a/tests/test_trip_resume.py
+++ b/tests/test_trip_resume.py
@@ -286,6 +286,23 @@ def test_weather_source_change_applies_to_the_active_trip(monkeypatch):
         app.shutdown()
 
 
+def test_live_weather_calendar_change_applies_to_active_trip(monkeypatch):
+    from freight_fate.app import App
+    from freight_fate.sim.season import date_text
+
+    app = App()
+    app.ctx.settings.real_weather = True
+    try:
+        driving = start_drive(app)
+        assert driving.weather.live_weather_controls_calendar is True
+        app.ctx.settings.live_weather_controls_calendar = False
+        driving.update(1 / 60)
+        assert driving.weather.live_weather_controls_calendar is False
+        assert driving.weather.date_text == date_text(driving.weather.game_hours)
+    finally:
+        app.shutdown()
+
+
 @pytest.mark.smoke
 def test_arrival_summary_calls_out_on_time_delivery_bonus():
     from freight_fate.app import App


### PR DESCRIPTION
## What changed and why

Adds Live weather controls calendar. Players can keep live city conditions while their career date advances through seasons. Established careers anchor their independent calendar to the current date when switching off live calendar control, without altering deadlines or other elapsed-time systems. Terminal weather reports now use the observed live temperature or clearly say that live data is still loading.

## What players or maintainers will notice

With the setting off, date and season advance at midnight while live weather remains enabled. Existing careers continue from today instead of jumping back to their hidden starting date. Terminal weather agrees with the live temperature reported while driving.

## Tests and checks run

- uv run pytest tests/test_season.py tests/test_settings_menu.py tests/test_models.py tests/test_profile_invariants.py tests/test_trip_resume.py
- uv run ruff check src tests tools
- uv run python -m compileall src tests tools
- Frozen Windows build smoke test

## Accessibility impact

The new setting, help text, calendar announcements, terminal weather loading message, and live-temperature readout are all spoken. Regression tests cover the settings keyboard flow and spoken terminal behavior.

## Changelog

- [x] I added a player-facing bullet under ## Unreleased in CHANGELOG.md, written in plain player language and matching the style of the existing entries.