### PR TITLE
Fall back to per-user save folder when the game dir is read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@
 
 ### Fixed
 
+- **The game no longer crashes when it is installed in a protected folder.**
+  If you put Freight Fate somewhere Windows guards, such as Program Files, the
+  game could not write next to itself and would crash the moment it tried to
+  save, often right as you reached a facility. Freight Fate now notices when
+  its own folder is read only and keeps your saves in your personal user
+  folder instead, so the game saves and plays normally wherever you install
+  it. Saves that are already beside the game are still used as before.
 - **The engine load now follows throttle smoothly.** Engine effort remains
   audible when you accelerate or ease off, while manual releases and
   adaptive-cruise corrections blend gradually instead of making the engine

--- a/src/freight_fate/models/profile.py
+++ b/src/freight_fate/models/profile.py
@@ -8,6 +8,11 @@ macOS apps live in ``/Applications`` and must not write beside themselves
 (that folder is admin-owned and often read-only), so on macOS saves go in the
 standard per-user ``~/Library/Application Support/FreightFate`` folder.
 
+The same reasoning covers Windows and Linux when the game itself sits in a
+read-only location (for example Windows ``Program Files``): if the ``saves``
+folder beside the game cannot be written, saves fall back to that per-user
+data directory instead of failing on the first write and crashing mid-session.
+
 Override the location with the ``FREIGHT_FATE_DATA_DIR`` environment variable
 (which the tests use). Saves from older versions or misplaced layouts are
 migrated into the active location automatically on first run.
@@ -53,6 +58,7 @@ SECRET_FILE = "profile.key"
 save_listener: Callable[[Profile], None] | None = None
 
 _legacy_checked = False
+_unwritable_warned = False
 
 
 def _macos_data_dir() -> Path:
@@ -75,16 +81,48 @@ def _legacy_data_dir() -> Path:
     return base / "FreightFate"
 
 
+def _is_writable_dir(path: Path) -> bool:
+    """Whether ``path`` exists (or can be created) and accepts a write.
+
+    Detects installs in protected locations, such as Windows ``Program
+    Files``, where the portable ``saves`` folder beside the game would raise
+    on the first save and crash the game mid-session.
+    """
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / ".freightfate-write-test"
+        probe.write_text("", encoding="ascii")
+        probe.unlink()
+    except OSError:
+        return False
+    return True
+
+
 def _save_root() -> Path:
     """The active save directory for this platform.
 
     Windows and Linux keep the portable ``saves`` folder next to the game.
     macOS uses the per-user Application Support folder so the app never has to
-    write into ``/Applications``.
+    write into ``/Applications``. When the game sits in a read-only location
+    such as ``Program Files``, Windows and Linux fall back to that same
+    per-user folder rather than crashing on the first save.
     """
     if sys.platform == "darwin":
         return _macos_data_dir()
-    return game_root() / "saves"
+    if _is_writable_dir(game_root()):
+        return game_root() / "saves"
+    fallback = _legacy_data_dir()
+    global _unwritable_warned
+    if not _unwritable_warned:
+        _unwritable_warned = True
+        log.warning(
+            "Game directory %s is not writable; saving to the per-user folder "
+            "%s instead. Move Freight Fate out of a protected location such as "
+            "Program Files to keep saves beside the game.",
+            game_root(),
+            fallback,
+        )
+    return fallback
 
 
 def game_root() -> Path:

--- a/tests/test_portable_saves.py
+++ b/tests/test_portable_saves.py
@@ -185,6 +185,32 @@ def test_legacy_copy_migration_is_logged(monkeypatch, tmp_path, caplog):
     assert any("legacy saves" in record.message for record in caplog.records)
 
 
+def test_unwritable_game_dir_falls_back_to_user_dir(monkeypatch, tmp_path):
+    """A read-only install (for example Program Files) must not crash on save:
+    the save root falls back to the per-user data directory instead."""
+    _, legacy = _reset(monkeypatch, tmp_path)
+    monkeypatch.setattr(profile_mod, "_unwritable_warned", False)
+    monkeypatch.setattr(profile_mod, "_is_writable_dir", lambda path: False)
+    assert profile_mod.data_dir() == legacy
+
+
+def test_save_survives_unwritable_game_dir(monkeypatch, tmp_path):
+    """Saving works end to end when the game's own folder cannot be written."""
+    _, legacy = _reset(monkeypatch, tmp_path)
+    monkeypatch.setattr(profile_mod, "_unwritable_warned", False)
+    monkeypatch.setattr(profile_mod, "_is_writable_dir", lambda path: False)
+    saved = profile_mod.Profile(name="Ryan").save()
+    assert saved == legacy / "profiles" / "Ryan.json"
+    assert saved.is_file()
+
+
+def test_writable_game_dir_still_saves_beside_the_game(monkeypatch, tmp_path):
+    """When the game folder is writable, the portable layout is unchanged."""
+    game, _ = _reset(monkeypatch, tmp_path)
+    monkeypatch.setattr(profile_mod, "_is_writable_dir", lambda path: True)
+    assert profile_mod.data_dir() == game / "saves"
+
+
 def test_macos_uses_application_support(monkeypatch, tmp_path):
     """macOS saves land in Application Support, never beside the app bundle."""
     monkeypatch.delenv("FREIGHT_FATE_DATA_DIR", raising=False)


### PR DESCRIPTION
## What changed and why

Freight Fate keeps saves beside the game on Windows and Linux (the portable
layout). When the game is installed somewhere the current user cannot write,
most notably `C:\Program Files`, the save write fails and the exception
propagates, crashing the game. It typically crashes on reaching a facility,
because that is when an autosave and a cloud backup fire.

`_save_root()` now checks whether the game directory is writable and, if not,
falls back to the per-user data directory (`%APPDATA%\FreightFate` on Windows,
the XDG data home on Linux). This mirrors how macOS already avoids writing
into `/Applications`. When the game folder is writable the portable layout is
unchanged, and saves already sitting beside the game are still used.

## What players or maintainers will notice

Players who install the game in a protected folder can now play and save
normally instead of hitting a crash; their saves are kept in their personal
user folder. Anyone with a writable install sees no change. A one time warning
is logged when the fallback engages, so a support question is one grep away.

## Tests and checks run

- `uv run pytest tests/test_portable_saves.py` (new tests plus the existing
  migration tests): pass
- `uv run pytest` (full suite): pass
- `uv run ruff check src tests tools`: clean
- `uv run python -m compileall src tests tools`: clean

New tests cover the fallback location when the game directory is unwritable,
an end to end save under that condition, and confirmation that a writable
directory still saves beside the game.

## Accessibility impact

No gameplay path, menu, prompt, or spoken text changes. The only added output
is a warning log line, not player-facing speech. The change removes a hard
crash, which improves reliability for screen-reader users who install to a
default Windows location.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`,
      written in plain player language and matching the style of the existing
      entries.
