### PR TITLE
Fix gaps in live weather route forecasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@
 
 ### Fixed
 
+- **Live weather no longer announces a simulated forecast while loading.**
+  Pressing V before the first live observation arrives now says that live
+  weather is still loading instead of describing an invented forecast. This
+  also works when Live weather controls calendar is turned off. Route weather
+  now names cities whose observations are loading or unavailable instead of
+  silently skipping them, and weather-change announcements identify live
+  observations and simulated fallback conditions.
 - **Cloud Backup works again on test builds.** Careers from a recent test
   build were being turned away with a message about the backup being
   unreadable. Nothing was wrong with those careers: the game had changed what

--- a/src/freight_fate/sim/trip.py
+++ b/src/freight_fate/sim/trip.py
@@ -835,9 +835,15 @@ class Trip:
         self.weather.set_city(target.key, target.lat, target.lon)
         changed = self.weather.update(game_min)
         if changed is not None:
+            if self.weather.live:
+                source = f"Live weather near {target.spoken_qualified}"
+            elif self.weather.provider is not None:
+                source = "Simulated fallback weather"
+            else:
+                source = "Weather"
             self._emit(
                 TripEventKind.WEATHER_CHANGE,
-                f"Weather changing: {self.weather.describe(self.imperial)}",
+                f"{source} changing: {self.weather.describe(self.imperial)}",
                 weather=changed,
             )
         self.truck.grip = self.weather.effects.grip

--- a/src/freight_fate/sim/weather.py
+++ b/src/freight_fate/sim/weather.py
@@ -417,6 +417,11 @@ class WeatherSystem:
         except Exception:  # pragma: no cover - defensive
             return False
 
+    @property
+    def live_weather_loading(self) -> bool:
+        """Whether live weather is selected but no observation is ready yet."""
+        return self.provider is not None and not self.live and not self._provider_offline()
+
     def _poll_provider(self) -> WeatherKind | None:
         """Apply real-world conditions when a provider is attached.
 

--- a/src/freight_fate/states/city_dispatch.py
+++ b/src/freight_fate/states/city_dispatch.py
@@ -753,36 +753,39 @@ class RouteSelectState(MenuState):
             for name in route.cities[1:][:5]:
                 city = self.ctx.world.cities[name]
                 kind = provider.get(city.key)
-                if kind is not None:
-                    from ..sim.season import (
-                        adjust_for_calendar,
-                        real_clock_game_hours,
-                        temperature_c,
+                spoken_city = self.ctx.world.spoken_city(name, qualified=True)
+                if kind is None:
+                    checker = getattr(provider, "unavailable", None)
+                    unavailable = checker is not None and checker(city.key)
+                    status = (
+                        "live weather unavailable; simulated fallback may apply"
+                        if unavailable
+                        else "live weather still loading"
                     )
+                    parts.append(f"{spoken_city}: {status}")
+                    continue
+                from ..sim.season import (
+                    adjust_for_calendar,
+                    real_clock_game_hours,
+                    temperature_c,
+                )
 
-                    hours = (
-                        real_clock_game_hours()
-                        if self.ctx.settings.live_weather_controls_calendar
-                        else self.ctx.profile.calendar_game_hours
-                    )
-                    observed = None
-                    getter = getattr(provider, "get_temperature", None)
-                    if getter is not None and self.ctx.settings.live_weather_controls_calendar:
-                        observed = getter(city.key)
-                    kind = adjust_for_calendar(
-                        kind,
-                        observed if observed is not None else temperature_c(city.region, hours),
-                        hours,
-                    )
-                    parts.append(
-                        f"{self.ctx.world.spoken_city(name, qualified=True)}: {kind.value}"
-                    )
-            if parts:
-                self.ctx.say("Live weather along the route. " + ". ".join(parts) + ".")
-                return
-            self.ctx.say(
-                "Live weather is still loading. Try again in a moment, or check V while driving."
-            )
+                hours = (
+                    real_clock_game_hours()
+                    if self.ctx.settings.live_weather_controls_calendar
+                    else self.ctx.profile.calendar_game_hours
+                )
+                observed = None
+                getter = getattr(provider, "get_temperature", None)
+                if getter is not None and self.ctx.settings.live_weather_controls_calendar:
+                    observed = getter(city.key)
+                kind = adjust_for_calendar(
+                    kind,
+                    observed if observed is not None else temperature_c(city.region, hours),
+                    hours,
+                )
+                parts.append(f"{spoken_city}: {kind.value}")
+            self.ctx.say("Weather along the route. " + ". ".join(parts) + ".")
             return
         regions: list[str] = []
         for city_name in route.cities:

--- a/src/freight_fate/states/driving_controls.py
+++ b/src/freight_fate/states/driving_controls.py
@@ -706,8 +706,15 @@ class DrivingControlsMixin:
         return "No route stop is nearby. You can pull over and rest on the shoulder."
 
     def _speak_weather(self) -> None:
-        source = "Live conditions" if self.weather.live else "Currently"
         safe_speed = self.ctx.settings.speed_text(self.weather.effects.safe_speed_mph)
+        if self.weather.live_weather_loading:
+            self.ctx.say(
+                f"It is {time_of_day(self.trip.local_hour)}. "
+                "Live weather is still loading. "
+                f"Safe speed about {safe_speed}."
+            )
+            return
+        source = "Live conditions" if self.weather.live else "Currently"
         parts = [
             f"It is {time_of_day(self.trip.local_hour)}.",
             f"{source} {self.weather.describe(self.ctx.settings.imperial_units)}.",

--- a/tests/test_driving_cruise_weather.py
+++ b/tests/test_driving_cruise_weather.py
@@ -909,6 +909,31 @@ def test_real_weather_starts_clear_with_no_simulated_warmup(monkeypatch):
         app.shutdown()
 
 
+def test_live_weather_calendar_off_does_not_announce_simulated_forecast_while_loading(
+    monkeypatch,
+):
+    """V must not invent a forecast while the selected live source is loading.
+
+    The calendar toggle changes seasonal plausibility, not the weather source.
+    """
+    from freight_fate.app import App
+
+    provider = _FakeWeatherProvider(kind=None)
+    app = App()
+    spoken = []
+    monkeypatch.setattr(app.ctx, "say", lambda text, interrupt=True: spoken.append(text))
+    monkeypatch.setattr(app.ctx, "real_weather_provider", lambda: provider)
+    app.ctx.settings.real_weather = True
+    app.ctx.settings.live_weather_controls_calendar = False
+    try:
+        driving = start_drive(app)
+        driving._speak_weather()
+        assert "Live weather is still loading" in spoken[-1]
+        assert "Ahead:" not in spoken[-1]
+    finally:
+        app.shutdown()
+
+
 def test_real_weather_applies_and_awards_live_condition(monkeypatch):
     """Once live conditions arrive, they take over from clear and award their
     achievement -- e.g. genuine live rain unlocks the rain achievement."""

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -2276,6 +2276,52 @@ def test_route_planning_labels_name_through_cities_with_states():
         app.shutdown()
 
 
+def test_live_route_weather_accounts_for_loading_and_unavailable_cities(monkeypatch):
+    """A partial live response must not sound like a complete route outlook."""
+    from freight_fate.app import App
+    from freight_fate.models import JobBoard, Profile
+    from freight_fate.sim.weather import WeatherKind
+    from freight_fate.states.city_dispatch import RouteSelectState
+
+    app = App()
+    spoken = []
+    try:
+        world = app.ctx.world
+        job = next(
+            j
+            for j in JobBoard(world, seed=3).offers("Chicago", endorsements=set(), level=2)
+            if len(world.supported_route_options(j.origin, j.destination)[0].cities) > 3
+        )
+        route = world.supported_route_options(job.origin, job.destination)[0]
+        first, second, third = route.cities[1:4]
+
+        class PartialProvider:
+            def request(self, *args):
+                pass
+
+            def get(self, city):
+                return WeatherKind.CLOUDY if city == first else None
+
+            def unavailable(self, city):
+                return city == second
+
+        app.ctx.profile = Profile(name="Route Weather Driver")
+        monkeypatch.setattr(app.ctx, "real_weather_provider", lambda: PartialProvider())
+        monkeypatch.setattr(app.ctx, "say", lambda text, interrupt=True: spoken.append(text))
+
+        state = RouteSelectState(app.ctx, job, [route])
+        state._speak_forecast(route)
+
+        assert f"{world.spoken_city(first, qualified=True)}: cloudy" in spoken[-1]
+        assert (
+            f"{world.spoken_city(second, qualified=True)}: live weather unavailable; "
+            "simulated fallback may apply"
+        ) in spoken[-1]
+        assert f"{world.spoken_city(third, qualified=True)}: live weather still loading" in spoken[-1]
+    finally:
+        app.shutdown()
+
+
 def test_destination_exit_scan_stays_on_the_final_approach():
     """Routes that finish on rural highways carry no baked interchanges, and
     the scan used to crown the last labeled exit anywhere on the route as the

--- a/tests/test_real_weather.py
+++ b/tests/test_real_weather.py
@@ -198,6 +198,30 @@ def test_weather_system_applies_live_conditions():
     assert ws.current is WeatherKind.HEAVY_RAIN
 
 
+def test_live_conditions_do_not_evolve_simulated_weather_with_independent_calendar():
+    """The calendar toggle must not restart the simulated transition timer.
+
+    Live weather may change when the provider's observation or target city
+    changes, but it must not wander from rain to heavy rain or fog on its own.
+    """
+    p = SyncProvider(fetch=lambda lat, lon: ("Rain", 5.0, 18.0, 5.0))
+    ws = WeatherSystem(
+        "great_lakes",
+        seed=2,
+        provider=p,
+        game_hours=100.0,
+        live_weather_controls_calendar=False,
+    )
+    ws.set_city("Chicago", 41.88, -87.63)
+    ws.update(1.0)
+    assert ws.live
+    assert ws.current is WeatherKind.RAIN
+
+    for _ in range(200):
+        assert ws.update(30.0) is None
+    assert ws.current is WeatherKind.RAIN
+
+
 def test_weather_system_holds_clear_while_live_data_pending():
     """With a provider attached, weather starts clear and holds -- no simulated
     warm-up -- until live data (or a confirmed offline state) arrives."""

--- a/tests/test_weather_trip.py
+++ b/tests/test_weather_trip.py
@@ -98,6 +98,28 @@ def test_weather_eventually_changes():
     assert any(c is not None for c in changes)
 
 
+def test_offline_live_weather_change_is_identified_as_simulated_fallback(world):
+    class OfflineProvider:
+        def request(self, *args):
+            pass
+
+        def get(self, city):
+            return None
+
+        def unavailable(self, city):
+            return True
+
+    trip, _truck = make_trip(world)
+    trip.weather.provider = OfflineProvider()
+    trip.weather.minutes_until_change = 0.0
+    trip.weather._sample = lambda *args, **kwargs: WeatherKind.RAIN
+
+    events = trip.update(1.0)
+
+    change = next(event for event in events if event.kind is TripEventKind.WEATHER_CHANGE)
+    assert change.message.startswith("Simulated fallback weather changing: rain")
+
+
 def test_bad_weather_reduces_grip():
     assert EFFECTS[WeatherKind.SNOW].grip < EFFECTS[WeatherKind.CLEAR].grip
     assert EFFECTS[WeatherKind.HEAVY_RAIN].grip < EFFECTS[WeatherKind.RAIN].grip


### PR DESCRIPTION
## What changed and why

Live route weather could silently omit cities whose observations were still loading or unavailable. The remaining observations sounded like a complete outlook, while those omitted stretches could use simulated fallback weather and produce unreported rain or heavy rain. V could also announce a simulated forecast while the selected live source was merely loading.

This change accounts for each upcoming city in order, identifies loading and unavailable observations, distinguishes live weather changes from simulated fallback changes, and suppresses invented V forecasts while live data is pending.

## What players or maintainers will notice

W route weather reports now name cities whose live observations are still loading or unavailable and warn when simulated fallback may apply. On the road, weather-change announcements identify whether the condition is a live observation near a named city or simulated fallback weather. V says live weather is still loading instead of speaking an Ahead forecast before the first observation arrives. These behaviors also apply when Live weather controls calendar is off.

## Tests and checks run

- uv run pytest tests/test_weather_trip.py tests/test_real_weather.py tests/test_season.py tests/test_trip_resume.py tests/test_driving_cruise_weather.py tests/test_announcements.py -q
- uv run pytest tests/test_driving_features.py::test_live_route_weather_accounts_for_loading_and_unavailable_cities -q
- uv run ruff check src tests tools
- uv run python -m compileall src tests tools
- git diff --cached --check

## Accessibility impact

All changes are spoken-text improvements on existing keyboard-accessible W and V paths. Regression tests capture the exact screen-reader output for partial live route data, live-weather loading, and simulated fallback identification.

## Changelog

- [x] I added a player-facing bullet under ## Unreleased in CHANGELOG.md, written in plain player language and matching the existing style.
- [ ] This change is not player-facing, and every commit message in this PR includes [skip changelog].