### PR TITLE
fix(integrity): read the cloud-save economy from the game, not from copies

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,11 +130,29 @@ From a batch of player reports:
   were cash the career could not account for and cloud upload screening
   refused the save and stamped a sticky integrity flag. Lifetime earnings
   now book the whole settlement.
-- [ ] **Review integrity flags stamped before that fix.** Drivers flagged by
-  the advance accounting bug are legitimate; a save carrying the old
-  shortfall keeps failing upload until the driver spends the difference on
-  fuel or repairs. Decide whether to clear those flags by hand or repair
-  the earnings figure on load, and confirm no honest driver is stuck.
+- [x] **Review integrity flags stamped before that fix.** All five production
+  flags were cleared by hand on 2026-07-20. One (a level 2 career, four
+  deliveries) was a false positive with no sign of an edit; the other four
+  had been confirmed separately by offline forensics and were cleared as a
+  deliberate amnesty.
+- [x] **Stop screening from branding accounts on arithmetic alone.** A failed
+  money or XP check now rejects the upload and keeps the payload for review
+  instead of stamping a sticky flag that hid the driver until a human
+  cleared it. Flags are still available by hand, from evidence. Both rules
+  were wrong in the accusing direction: the XP ceiling was a copied 1.2 per
+  mile sitting exactly on what a spotless career earns, and the money check
+  priced owned equipment as if it had all been bought.
+- [x] **Cloud screening reads the economy from the game.** Starting cash, the
+  advance cap, and the XP rates ship in the exported invariants rather than
+  being kept by hand on the server, so a balance pass cannot silently turn
+  the rules against honest drivers.
+- [ ] **Carry the same fixes onto the 1.9 line.** The career arc changes the
+  XP model (flat per-delivery XP plus class, streak, and condition
+  multipliers) and adds the owner-operator buy-in, where a driver takes
+  title to a carrier tractor worth far more than the buy-in. Regenerate the
+  exported invariants for save version 11 before 1.9 ships — the server
+  gate matches on exact save version, so an un-regenerated export rejects
+  every 1.9 backup.
 
 ### Fatigue and driver responsibility
 

--- a/docs/profile-invariants.md
+++ b/docs/profile-invariants.md
@@ -84,17 +84,30 @@ always knows the current content set, SHOULD reject unknown keys.
 
 ## 2. Plausibility rules (server-side; tighten freely, bump the version)
 
-2.1 **Money against career history.** Gross lifetime pay is bounded by
-`career.total_earnings`; a balance far above
-`starting money (5,000) + total_earnings` cannot be honest. Flag anything
-above that sum plus a modest allowance for bonuses; hard-reject multiples
-of it. A level-2 driver with nine million dollars fails.
+2.1 **Money against career history.** Cash is bounded by
+`startingMoney + career.total_earnings + pay_advance`. Every way the game
+adds money also books lifetime earnings, and spending only ever lowers the
+balance, so this holds for any honest career. A level-2 driver with nine
+million dollars fails.
+
+Do **not** add the price of owned trucks and upgrades to the left side. The
+game grants equipment it never charged list price for — an owner-operator
+buys out a carrier tractor worth far more than the buy-in — so pricing gear
+as if it had been bought reads as roughly $150,000 of invented money and
+rejects the backup of every driver who took that step. A career that
+launders invented money through the garage is left to offline forensics.
 
 2.2 **XP against the curve and the miles.** Level thresholds are the
-`LEVEL_XP` table in `models/career.py` (0, 1,000, 2,500, 4,500, 7,000,
-10,000 ... 572,000 at the top). XP accrues from deliveries; profiles with
-huge XP over tiny `deliveries`/`total_miles` fail. Rough honest shape:
-XP on the order of miles driven times single-digit multipliers.
+`LEVEL_XP` table in `models/career.py`. The ceiling is
+`deliveries * xpFlatPerDelivery + total_miles * xpPerMileMax`, both
+exported in the invariants, plus a slack of a dollar or so for rounding.
+
+Take those two figures from the export, never from a number copied into
+the server. The rate they describe is what a spotless career actually
+earns, so a career that delivers every mile on time sits exactly on the
+ceiling rather than under it: a copied value that falls even slightly
+behind a balance pass convicts the drivers who played best, which is what
+happened when a hardcoded 1.2 per mile met the 1.9 arc's higher rates.
 
 2.3 **Endorsements.** Earned endorsements come free at levels 2/3/4
 (refrigerated/heavy_haul/high_value) — they are DERIVED from level, never

--- a/src/freight_fate/models/career.py
+++ b/src/freight_fate/models/career.py
@@ -7,6 +7,14 @@ from dataclasses import dataclass
 # XP needed to go from level N to N+1 (then +1500 per level beyond the table)
 LEVEL_XP = [0, 1000, 2500, 4500, 7000, 10_000, 14_000, 19_000, 25_000]
 
+# What a mile of driving teaches, by whether the load landed on time. These are
+# named (not inline) because the cloud-save validator re-derives the highest XP
+# a career could honestly hold from them: a hand-copied ceiling on the server
+# drifts the moment these move, and the failure lands on the player as a
+# rejected backup. Export them via profile_integrity_invariants instead.
+XP_PER_MILE_ON_TIME = 1.2
+XP_PER_MILE_LATE = 0.8
+
 # Endorsements unlocked automatically at these levels.
 ENDORSEMENT_LEVELS = {
     "refrigerated": 2,
@@ -64,7 +72,7 @@ class Career:
         self.deliveries += 1
         self.total_miles += miles
         self.total_earnings += pay
-        gained = miles * (1.2 if on_time else 0.8)
+        gained = miles * (XP_PER_MILE_ON_TIME if on_time else XP_PER_MILE_LATE)
         self.xp += gained
         if on_time:
             self.on_time_deliveries += 1

--- a/src/freight_fate/profile_integrity_invariants.py
+++ b/src/freight_fate/profile_integrity_invariants.py
@@ -6,9 +6,10 @@ import json
 from pathlib import Path
 
 from .achievements import ACHIEVEMENTS
-from .models.career import LEVEL_XP, Career
+from .models.career import LEVEL_XP, XP_PER_MILE_ON_TIME, Career
+from .models.economy import PAY_ADVANCE_LIMIT
 from .models.market import MARKET_CARGO_KEYS
-from .models.profile import SAVE_VERSION, Profile
+from .models.profile import SAVE_VERSION, STARTING_MONEY, Profile
 from .models.trucks import TRUCK_CATALOG, UPGRADE_CATALOG, TruckCondition
 
 # Signature keys ride inside the saved file but never inside a cloud upload --
@@ -30,6 +31,24 @@ def _profile_fields() -> list[str]:
     Export it instead, so the two sides cannot drift.
     """
     return sorted((set(Profile.__dataclass_fields__) | {"version"}) - _LOCAL_ONLY_FIELDS)
+
+
+def _xp_per_mile_max() -> float:
+    """The most XP one mile can teach, taking every bonus at its best.
+
+    The validator's ceiling is `deliveries * flat + miles * this`. It has to
+    sit at or above what the game can actually award, because anything lower
+    convicts honest drivers -- the tighter the fit, the more a later balance
+    pass costs. Recompute it here from the real constants when the XP model
+    grows terms (class, streak, and condition multipliers all land on this
+    line in the 1.9 career arc).
+    """
+    return XP_PER_MILE_ON_TIME
+
+
+def _xp_flat_per_delivery() -> float:
+    """XP a settled load teaches regardless of distance (none on this line)."""
+    return 0.0
 
 
 def _truck_condition_fields() -> list[str]:
@@ -57,6 +76,16 @@ def invariant_data() -> dict:
     return {
         "achievementIds": sorted(achievement.id for achievement in ACHIEVEMENTS),
         "cityLabels": dict(sorted(city_labels.items())),
+        # The economy terms the cloud-save validator needs to tell an edited
+        # career from an honest one. They ship as data for the same reason the
+        # field lists do: a copy kept on the server falls behind the next
+        # balance pass, and every honest player on the new build then hears
+        # that their backup was rejected. See the money and XP checks in
+        # convex/freightFateSharedProfileValidation.ts.
+        "startingMoney": _json_number(STARTING_MONEY),
+        "payAdvanceLimit": _json_number(PAY_ADVANCE_LIMIT),
+        "xpPerMileMax": _json_number(_xp_per_mile_max()),
+        "xpFlatPerDelivery": _json_number(_xp_flat_per_delivery()),
         "levelXp": LEVEL_XP,
         "marketCargoKeys": sorted(MARKET_CARGO_KEYS),
         "profileFields": _profile_fields(),


### PR DESCRIPTION
## What changed and why

Cloud upload screening kept two economy rules by hand on the orinks.net side,
and both had drifted into rejecting honest careers.

The XP ceiling was a hardcoded `1.2` per mile. That is exactly what a career
delivering every mile on time earns, so the drivers who played best sat one XP
under the line with no headroom for any future balance pass.

The money rule added the list price of owned trucks and upgrades to the
player's cash. The game grants equipment it never charged list price for, so
that reads as money the career never earned.

This side of the fix stops the server from having to guess. `STARTING_MONEY`,
the pay-advance cap, and the XP rates now ship in the exported invariants
alongside the field lists that are already exported for exactly this reason: a
copy kept on the server goes stale on the next balance pass, and the failure
lands on the player as a rejected backup. The XP per-mile rates move from
inline literals to named constants so there is one place to change them.

The server-side half (dropping gear from the money identity, reading these
figures, and keeping rejected payloads for review instead of auto-flagging the
account) shipped separately on orinks-net.

## What players or maintainers will notice

Players: nothing in this build. No gameplay, spoken text, or menu changes —
the numbers exported here are identical to the ones the game already used.

Maintainers: `docs/profile-invariants.md` sections 2.1 and 2.2 now describe the
rules as they actually are, including why gear must not be priced into the
money check. Changing any XP constant in `models/career.py` now requires
regenerating the export.

## Tests and checks run

- `uv run pytest` — full suite green
- `uv run ruff check src tests tools` — clean
- `uv run python -m compileall src tests tools` — clean
- Verified the regenerated export against the deployed server data file: the
  only differences are the four added keys, nothing existing moved.

## Accessibility impact

None. No spoken text, prompt, menu item, or keyboard path is touched. The
changes are two named constants, four added keys in a source-tree-only export
consumed by the website, and documentation.

## Changelog

- [x] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.