### PR TITLE
fix(integrity): retune the exported cloud-save economy for the career arc

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1250,11 +1250,29 @@ From a batch of player reports:
   were cash the career could not account for and cloud upload screening
   refused the save and stamped a sticky integrity flag. Lifetime earnings
   now book the whole settlement.
-- [ ] **Review integrity flags stamped before that fix.** Drivers flagged by
-  the advance accounting bug are legitimate; a save carrying the old
-  shortfall keeps failing upload until the driver spends the difference on
-  fuel or repairs. Decide whether to clear those flags by hand or repair
-  the earnings figure on load, and confirm no honest driver is stuck.
+- [x] **Review integrity flags stamped before that fix.** All five production
+  flags were cleared by hand on 2026-07-20. One (a level 2 career, four
+  deliveries) was a false positive with no sign of an edit; the other four
+  had been confirmed separately by offline forensics and were cleared as a
+  deliberate amnesty.
+- [x] **Stop screening from branding accounts on arithmetic alone.** A failed
+  money or XP check now rejects the upload and keeps the payload for review
+  instead of stamping a sticky flag that hid the driver until a human
+  cleared it. Flags are still available by hand, from evidence. Both rules
+  were wrong in the accusing direction: the XP ceiling was a copied 1.2 per
+  mile sitting exactly on what a spotless career earns, and the money check
+  priced owned equipment as if it had all been bought.
+- [x] **Cloud screening reads the economy from the game.** Starting cash, the
+  advance cap, and the XP rates ship in the exported invariants rather than
+  being kept by hand on the server, so a balance pass cannot silently turn
+  the rules against honest drivers.
+- [ ] **Carry the same fixes onto the 1.9 line.** The career arc changes the
+  XP model (flat per-delivery XP plus class, streak, and condition
+  multipliers) and adds the owner-operator buy-in, where a driver takes
+  title to a carrier tractor worth far more than the buy-in. Regenerate the
+  exported invariants for save version 11 before 1.9 ships — the server
+  gate matches on exact save version, so an un-regenerated export rejects
+  every 1.9 backup.
 
 ### Fatigue and driver responsibility
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,11 +130,29 @@ From a batch of player reports:
   were cash the career could not account for and cloud upload screening
   refused the save and stamped a sticky integrity flag. Lifetime earnings
   now book the whole settlement.
-- [ ] **Review integrity flags stamped before that fix.** Drivers flagged by
-  the advance accounting bug are legitimate; a save carrying the old
-  shortfall keeps failing upload until the driver spends the difference on
-  fuel or repairs. Decide whether to clear those flags by hand or repair
-  the earnings figure on load, and confirm no honest driver is stuck.
+- [x] **Review integrity flags stamped before that fix.** All five production
+  flags were cleared by hand on 2026-07-20. One (a level 2 career, four
+  deliveries) was a false positive with no sign of an edit; the other four
+  had been confirmed separately by offline forensics and were cleared as a
+  deliberate amnesty.
+- [x] **Stop screening from branding accounts on arithmetic alone.** A failed
+  money or XP check now rejects the upload and keeps the payload for review
+  instead of stamping a sticky flag that hid the driver until a human
+  cleared it. Flags are still available by hand, from evidence. Both rules
+  were wrong in the accusing direction: the XP ceiling was a copied 1.2 per
+  mile sitting exactly on what a spotless career earns, and the money check
+  priced owned equipment as if it had all been bought.
+- [x] **Cloud screening reads the economy from the game.** Starting cash, the
+  advance cap, and the XP rates ship in the exported invariants rather than
+  being kept by hand on the server, so a balance pass cannot silently turn
+  the rules against honest drivers.
+- [ ] **Carry the same fixes onto the 1.9 line.** The career arc changes the
+  XP model (flat per-delivery XP plus class, streak, and condition
+  multipliers) and adds the owner-operator buy-in, where a driver takes
+  title to a carrier tractor worth far more than the buy-in. Regenerate the
+  exported invariants for save version 11 before 1.9 ships — the server
+  gate matches on exact save version, so an un-regenerated export rejects
+  every 1.9 backup.
 
 ### Fatigue and driver responsibility
 

--- a/docs/profile-invariants.md
+++ b/docs/profile-invariants.md
@@ -84,17 +84,30 @@ always knows the current content set, SHOULD reject unknown keys.
 
 ## 2. Plausibility rules (server-side; tighten freely, bump the version)
 
-2.1 **Money against career history.** Gross lifetime pay is bounded by
-`career.total_earnings`; a balance far above
-`starting money (5,000) + total_earnings` cannot be honest. Flag anything
-above that sum plus a modest allowance for bonuses; hard-reject multiples
-of it. A level-2 driver with nine million dollars fails.
+2.1 **Money against career history.** Cash is bounded by
+`startingMoney + career.total_earnings + pay_advance`. Every way the game
+adds money also books lifetime earnings, and spending only ever lowers the
+balance, so this holds for any honest career. A level-2 driver with nine
+million dollars fails.
+
+Do **not** add the price of owned trucks and upgrades to the left side. The
+game grants equipment it never charged list price for — an owner-operator
+buys out a carrier tractor worth far more than the buy-in — so pricing gear
+as if it had been bought reads as roughly $150,000 of invented money and
+rejects the backup of every driver who took that step. A career that
+launders invented money through the garage is left to offline forensics.
 
 2.2 **XP against the curve and the miles.** Level thresholds are the
-`LEVEL_XP` table in `models/career.py` (0, 1,000, 2,500, 4,500, 7,000,
-10,000 ... 572,000 at the top). XP accrues from deliveries; profiles with
-huge XP over tiny `deliveries`/`total_miles` fail. Rough honest shape:
-XP on the order of miles driven times single-digit multipliers.
+`LEVEL_XP` table in `models/career.py`. The ceiling is
+`deliveries * xpFlatPerDelivery + total_miles * xpPerMileMax`, both
+exported in the invariants, plus a slack of a dollar or so for rounding.
+
+Take those two figures from the export, never from a number copied into
+the server. The rate they describe is what a spotless career actually
+earns, so a career that delivers every mile on time sits exactly on the
+ceiling rather than under it: a copied value that falls even slightly
+behind a balance pass convicts the drivers who played best, which is what
+happened when a hardcoded 1.2 per mile met the 1.9 arc's higher rates.
 
 2.3 **Endorsements.** Earned endorsements come free at levels 2/3/4
 (refrigerated/heavy_haul/high_value) — they are DERIVED from level, never

--- a/docs/profile-invariants.md
+++ b/docs/profile-invariants.md
@@ -78,17 +78,30 @@ always knows the current content set, SHOULD reject unknown keys.
 
 ## 2. Plausibility rules (server-side; tighten freely, bump the version)
 
-2.1 **Money against career history.** Gross lifetime pay is bounded by
-`career.total_earnings`; a balance far above
-`starting money (5,000) + total_earnings` cannot be honest. Flag anything
-above that sum plus a modest allowance for bonuses; hard-reject multiples
-of it. A level-2 driver with nine million dollars fails.
+2.1 **Money against career history.** Cash is bounded by
+`startingMoney + career.total_earnings + pay_advance`. Every way the game
+adds money also books lifetime earnings, and spending only ever lowers the
+balance, so this holds for any honest career. A level-2 driver with nine
+million dollars fails.
+
+Do **not** add the price of owned trucks and upgrades to the left side. The
+game grants equipment it never charged list price for — an owner-operator
+buys out a carrier tractor worth far more than the buy-in — so pricing gear
+as if it had been bought reads as roughly $150,000 of invented money and
+rejects the backup of every driver who took that step. A career that
+launders invented money through the garage is left to offline forensics.
 
 2.2 **XP against the curve and the miles.** Level thresholds are the
-`LEVEL_XP` table in `models/career.py` (0, 1,000, 2,500, 4,500, 7,000,
-10,000 ... 572,000 at the top). XP accrues from deliveries; profiles with
-huge XP over tiny `deliveries`/`total_miles` fail. Rough honest shape:
-XP on the order of miles driven times single-digit multipliers.
+`LEVEL_XP` table in `models/career.py`. The ceiling is
+`deliveries * xpFlatPerDelivery + total_miles * xpPerMileMax`, both
+exported in the invariants, plus a slack of a dollar or so for rounding.
+
+Take those two figures from the export, never from a number copied into
+the server. The rate they describe is what a spotless career actually
+earns, so a career that delivers every mile on time sits exactly on the
+ceiling rather than under it: a copied value that falls even slightly
+behind a balance pass convicts the drivers who played best, which is what
+happened when a hardcoded 1.2 per mile met the 1.9 arc's higher rates.
 
 2.3 **Endorsements.** Earned endorsements come free at levels 2/3/4
 (refrigerated/heavy_haul/high_value) — they are DERIVED from level, never

--- a/src/freight_fate/models/career.py
+++ b/src/freight_fate/models/career.py
@@ -7,6 +7,14 @@ from dataclasses import dataclass
 # XP needed to go from level N to N+1 (then +1500 per level beyond the table)
 LEVEL_XP = [0, 1000, 2500, 4500, 7000, 10_000, 14_000, 19_000, 25_000]
 
+# What a mile of driving teaches, by whether the load landed on time. These are
+# named (not inline) because the cloud-save validator re-derives the highest XP
+# a career could honestly hold from them: a hand-copied ceiling on the server
+# drifts the moment these move, and the failure lands on the player as a
+# rejected backup. Export them via profile_integrity_invariants instead.
+XP_PER_MILE_ON_TIME = 1.2
+XP_PER_MILE_LATE = 0.8
+
 # Endorsements unlocked automatically at these levels.
 ENDORSEMENT_LEVELS = {
     "refrigerated": 2,
@@ -64,7 +72,7 @@ class Career:
         self.deliveries += 1
         self.total_miles += miles
         self.total_earnings += pay
-        gained = miles * (1.2 if on_time else 0.8)
+        gained = miles * (XP_PER_MILE_ON_TIME if on_time else XP_PER_MILE_LATE)
         self.xp += gained
         if on_time:
             self.on_time_deliveries += 1

--- a/src/freight_fate/models/career.py
+++ b/src/freight_fate/models/career.py
@@ -72,6 +72,11 @@ ENDORSEMENT_LABELS_SPOKEN = {
 # bringing the cargo in undamaged proves the lesson stuck. Every settled
 # load also teaches a flat slice of the trade -- docks, paperwork, people --
 # so short early hauls still move the career.
+#
+# Cloud-save screening re-derives the highest XP an honest career could hold
+# from these, via profile_integrity_invariants. Change any of them and the
+# export must be regenerated: the server once kept its own 1.2 per mile,
+# which these rates outgrew, and honest drivers had backups refused for it.
 XP_SPECIALTY_MULT = 1.5
 XP_PREMIUM_MULT = 1.25
 XP_STREAK_STEP = 0.05  # extra share per consecutive on-time delivery

--- a/src/freight_fate/profile_integrity_invariants.py
+++ b/src/freight_fate/profile_integrity_invariants.py
@@ -6,9 +6,18 @@ import json
 from pathlib import Path
 
 from .achievements import ACHIEVEMENTS
-from .models.career import LEVEL_XP, Career
+from .models.career import (
+    DELIVERY_COMPLETION_XP,
+    LEVEL_XP,
+    XP_CLEAN_BONUS,
+    XP_PER_MILE_ON_TIME,
+    XP_SPECIALTY_MULT,
+    XP_STREAK_MAX_BONUS,
+    Career,
+)
+from .models.economy import PAY_ADVANCE_LIMIT
 from .models.market import MARKET_CARGO_KEYS
-from .models.profile import SAVE_VERSION, Profile
+from .models.profile import SAVE_VERSION, STARTING_MONEY, Profile
 from .models.trucks import TRUCK_CATALOG, UPGRADE_CATALOG, TruckCondition
 
 # Signature keys ride inside the saved file but never inside a cloud upload --
@@ -30,6 +39,32 @@ def _profile_fields() -> list[str]:
     Export it instead, so the two sides cannot drift.
     """
     return sorted((set(Profile.__dataclass_fields__) | {"version"}) - _LOCAL_ONLY_FIELDS)
+
+
+def _xp_best_case_multiplier() -> float:
+    """Every share bonus in `record_delivery` taken at once, at its best.
+
+    Both bonuses multiply the whole award, flat completion XP included, so
+    this factor belongs to both terms below.
+    """
+    return (1.0 + XP_STREAK_MAX_BONUS) * (1.0 + XP_CLEAN_BONUS)
+
+
+def _xp_per_mile_max() -> float:
+    """The most XP one mile can teach, taking every bonus at its best.
+
+    The validator's ceiling is `deliveries * flat + miles * this`. It has to
+    sit at or above what the game can actually award, because anything lower
+    convicts honest drivers -- a copied 1.2 here was below even the base
+    on-time rate on this line. Recompute it from the real constants whenever
+    the XP model grows a term.
+    """
+    return XP_PER_MILE_ON_TIME * XP_SPECIALTY_MULT * _xp_best_case_multiplier()
+
+
+def _xp_flat_per_delivery() -> float:
+    """XP a settled load teaches regardless of distance, at its best."""
+    return DELIVERY_COMPLETION_XP * _xp_best_case_multiplier()
 
 
 def _truck_condition_fields() -> list[str]:
@@ -64,6 +99,16 @@ def invariant_data() -> dict:
     return {
         "achievementIds": sorted(achievement.id for achievement in ACHIEVEMENTS),
         "cityLabels": dict(sorted(city_labels.items())),
+        # The economy terms the cloud-save validator needs to tell an edited
+        # career from an honest one. They ship as data for the same reason the
+        # field lists do: a copy kept on the server falls behind the next
+        # balance pass, and every honest player on the new build then hears
+        # that their backup was rejected. See the money and XP checks in
+        # convex/freightFateSharedProfileValidation.ts.
+        "startingMoney": _json_number(STARTING_MONEY),
+        "payAdvanceLimit": _json_number(PAY_ADVANCE_LIMIT),
+        "xpPerMileMax": _json_number(_xp_per_mile_max()),
+        "xpFlatPerDelivery": _json_number(_xp_flat_per_delivery()),
         "levelXp": LEVEL_XP,
         "marketCargoKeys": sorted(MARKET_CARGO_KEYS),
         "profileFields": _profile_fields(),

--- a/src/freight_fate/profile_integrity_invariants.py
+++ b/src/freight_fate/profile_integrity_invariants.py
@@ -6,9 +6,10 @@ import json
 from pathlib import Path
 
 from .achievements import ACHIEVEMENTS
-from .models.career import LEVEL_XP, Career
+from .models.career import LEVEL_XP, XP_PER_MILE_ON_TIME, Career
+from .models.economy import PAY_ADVANCE_LIMIT
 from .models.market import MARKET_CARGO_KEYS
-from .models.profile import SAVE_VERSION, Profile
+from .models.profile import SAVE_VERSION, STARTING_MONEY, Profile
 from .models.trucks import TRUCK_CATALOG, UPGRADE_CATALOG, TruckCondition
 
 # Signature keys ride inside the saved file but never inside a cloud upload --
@@ -30,6 +31,24 @@ def _profile_fields() -> list[str]:
     Export it instead, so the two sides cannot drift.
     """
     return sorted((set(Profile.__dataclass_fields__) | {"version"}) - _LOCAL_ONLY_FIELDS)
+
+
+def _xp_per_mile_max() -> float:
+    """The most XP one mile can teach, taking every bonus at its best.
+
+    The validator's ceiling is `deliveries * flat + miles * this`. It has to
+    sit at or above what the game can actually award, because anything lower
+    convicts honest drivers -- the tighter the fit, the more a later balance
+    pass costs. Recompute it here from the real constants when the XP model
+    grows terms (class, streak, and condition multipliers all land on this
+    line in the 1.9 career arc).
+    """
+    return XP_PER_MILE_ON_TIME
+
+
+def _xp_flat_per_delivery() -> float:
+    """XP a settled load teaches regardless of distance (none on this line)."""
+    return 0.0
 
 
 def _truck_condition_fields() -> list[str]:
@@ -57,6 +76,16 @@ def invariant_data() -> dict:
     return {
         "achievementIds": sorted(achievement.id for achievement in ACHIEVEMENTS),
         "cityLabels": dict(sorted(city_labels.items())),
+        # The economy terms the cloud-save validator needs to tell an edited
+        # career from an honest one. They ship as data for the same reason the
+        # field lists do: a copy kept on the server falls behind the next
+        # balance pass, and every honest player on the new build then hears
+        # that their backup was rejected. See the money and XP checks in
+        # convex/freightFateSharedProfileValidation.ts.
+        "startingMoney": _json_number(STARTING_MONEY),
+        "payAdvanceLimit": _json_number(PAY_ADVANCE_LIMIT),
+        "xpPerMileMax": _json_number(_xp_per_mile_max()),
+        "xpFlatPerDelivery": _json_number(_xp_flat_per_delivery()),
         "levelXp": LEVEL_XP,
         "marketCargoKeys": sorted(MARKET_CARGO_KEYS),
         "profileFields": _profile_fields(),

--- a/tests/test_profile_integrity_invariants.py
+++ b/tests/test_profile_integrity_invariants.py
@@ -1,3 +1,7 @@
+import random
+
+from freight_fate.models.career import XP_PREMIUM_MULT, XP_SPECIALTY_MULT, Career
+from freight_fate.models.profile import Profile
 from freight_fate.profile_integrity_invariants import invariant_data, rendered_invariants
 
 
@@ -8,3 +12,40 @@ def test_integrity_invariants_include_public_projection_labels():
     assert data["truckLabels"]["rig"] == "standard rig"
     assert data["levelXp"][0] == 0
     assert rendered_invariants().endswith("\n")
+
+
+def test_exported_xp_ceiling_bounds_every_honest_career():
+    """The exported ceiling must sit at or above what record_delivery awards.
+
+    The server rejects a cloud backup whose XP exceeds
+    `deliveries * xpFlatPerDelivery + total_miles * xpPerMileMax`. If a
+    balance pass raises the game's rates past the exported figures, that
+    check starts convicting the drivers who played best -- which is exactly
+    how a hardcoded 1.2 per mile came to sit below the on-time rate. Drive
+    a spread of careers through the real award path and hold the line.
+    """
+    data = invariant_data()
+    per_mile = data["xpPerMileMax"]
+    flat = data["xpFlatPerDelivery"]
+    rng = random.Random(7)
+
+    for _ in range(2_000):
+        career = Career()
+        for _ in range(rng.randint(1, 40)):
+            career.record_delivery(
+                rng.uniform(1.0, 900.0),
+                pay=0.0,
+                on_time=rng.random() < 0.9,
+                damage_pct=rng.choice([0.0, 0.5, 30.0]),
+                cargo_class_mult=rng.choice([1.0, XP_PREMIUM_MULT, XP_SPECIALTY_MULT]),
+            )
+        ceiling = career.deliveries * flat + career.total_miles * per_mile
+        assert career.xp <= ceiling, (
+            f"{career.xp} XP over {career.total_miles} miles in "
+            f"{career.deliveries} deliveries breaches the exported ceiling {ceiling}"
+        )
+
+
+def test_exported_starting_money_matches_a_fresh_career():
+    """The money rule's floor is this figure; a new profile must equal it."""
+    assert invariant_data()["startingMoney"] == Profile().money


### PR DESCRIPTION
## What changed and why

Carries #100 onto the 1.9 line and retunes the exported XP terms for this
line's model. Merge that one first; this branch contains it.

Cloud upload screening derives the highest XP an honest career could hold from
figures the game exports. On dev that is a flat rate per mile. Here the award
is flat completion XP plus per-mile XP scaled by cargo class, on-time streak,
and clean delivery, so `profile_integrity_invariants.py` recomputes both terms
from the real constants: `xpPerMileMax` 1.2 -> 4.002 and `xpFlatPerDelivery`
0 -> 250.125.

This matters more here than on dev. The server's old hand-copied ceiling was
1.2 per mile, which is below even this line's base on-time rate. Simulated
against the real `record_delivery` path, **1999 of 2000 honest careers breach
it** — every one would have had its cloud backup refused and, under the old
screening, its account hidden from the driver board until a human cleared it.

`test_exported_xp_ceiling_bounds_every_honest_career` now drives a spread of
careers through the real award path and asserts the exported ceiling stays
above them, so the next balance pass fails the suite instead of the players.

## What players or maintainers will notice

Players: nothing in this build. No gameplay, spoken text, or menu changes.

Maintainers: changing any XP constant in `models/career.py` now requires
regenerating the export, and the new property test will say so.

**Release-merge note:** the server gate matches save version with strict
equality, and production currently serves dev's version 5 while this line
writes 11. Regenerating the server's copy of the invariants is deliberately
NOT part of this PR — doing it early breaks Cloud Backup for everyone on
dev/nightly. It belongs to the 1.9 cutover, and the export must deploy before
or with the 1.9 build, never after. Recorded as an unchecked ROADMAP bullet.

## Tests and checks run

- `uv run pytest` — full suite green (exit 0 under `-x`)
- `uv run ruff check src tests tools` — clean
- New: `test_exported_xp_ceiling_bounds_every_honest_career` (2,000 simulated
  careers through `record_delivery`), and
  `test_exported_starting_money_matches_a_fresh_career`
- Confirmed the new ceiling test has teeth: it fails against the old 1.2
  figure

## Accessibility impact

None. No spoken text, prompt, menu item, or keyboard path is touched — two
derived figures in a source-tree-only export, a comment, and tests.

## Changelog

- [x] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.