### PR TITLE
data(map): terrain reads real relief -- no more mountains in flat country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@
   of build is talking. Stable releases sound the same as before, and version
   numbers no longer skip when a stable release comes out.
 
+### Fixed
+
+- **The road tells you the truth about the terrain.** Stretches that were
+  quietly called mountain in flat country -- the East Texas piney woods, the
+  Hill Country's gentle dips -- now read as the flat or rolling ground they
+  really are, so the status readout no longer puts you in the mountains where
+  no Texan would. The real climbs you brace for still call out as mountain
+  grades, and every famous grade -- the Grapevine, Monteagle, the Siskiyous,
+  the run up to the Continental Divide -- keeps its name.
+
 ## 1.8.5 - 2026-07-22
 
 ### Added


### PR DESCRIPTION
## What changed and why

The terrain labels on the map now read real relief, not a lone steep number.
The old enrichment called any grade over 3% "mountain" from point steepness
alone, so a single creek-crossing roller in the East Texas piney woods or a
Hill Country dip read as mountain -- and the status readout put a driver in
the mountains where no Texan would say so.

This ports the verified relief-aware reclassification (computed on the 1.9
line, where the dense elevation archive lives) onto dev's `world.json`. It is
**labels only** -- `avg_grade_pct` and every number a physics model reads are
untouched. dev and the 1.9 line share the same 1,287 legs with identical
grade-segment boundaries, so the labels copy across exactly.

- **743** East Texas / Hill Country grade segments that falsely said mountain
  are corrected (18,638 false-mountain segments network-wide); 1,667 genuinely
  steep segments are correctly mountain.
- Leg summaries only firm up: **166 promotions** (flat->hills, flat/hills->
  mountain), **no curated label downgraded** -- the two dozen famous corridors
  pinned in `test_world` still pass.

## What players will notice

Flat and rolling country stops announcing itself as mountains. The real climbs
you brace for -- the Grapevine, Monteagle, the Siskiyous, the run up to the
Continental Divide -- still call out as mountain grades and keep their names.

## Tests run

- `tools/index_world.py --check` -- clean.
- `pytest tests/test_world.py tests/test_world_overlay.py tests/test_regions.py
  tests/test_route_coverage_tool.py` -- green (incl. the pinned famous-corridors
  terrain test).
- Full suite -- green.

## Accessibility impact

The change is to spoken status text: `Trip.terrain_at()` reads the segment
label, so a driver hears "terrain flat/hills/mountain" that matches the real
ground. No visual-only cues; nothing else in the spoken flow changes.

## Changelog

- [x] Player-facing entry added under `## Unreleased` / `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
