### PR TITLE
Backport: keep facility gates audible when the truck rolls past them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,20 @@ tools/_entry.py
 src/freight_fate/data/_baked_world.py
 src/freight_fate/sounds.pak
 
+# Purchased SFX libraries (Big Fish Audio / Pro Sound Effects and similar)
+# grant synchronization rights -- the right to use the audio inside a finished
+# production. That covers shipping them inside the game. It does not cover
+# redistributing the source files, and a public repo does exactly that. The
+# licence is also per-seat and non-transferable, so a file in this tree would
+# be handing a copy to everyone who clones.
+#
+# Drop purchased material in assets/sounds-licensed/ and it stays local. The
+# release packer overlays it on top of assets/sounds/, so a build made on a
+# machine that owns the library gets the licensed audio while a clean clone
+# still builds and runs on the synthesized fallbacks.
+src/freight_fate/assets/sounds-licensed/
+sound-source/
+
 # Portable save data (lives in the game directory)
 saves/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@
 
 ### Fixed
 
+- **Driving past a pickup or delivery entrance no longer goes silent.**
+  Arriving at a facility used to announce itself once; if you rolled on --
+  easy to do with cruise re-engaged -- the game said nothing more for the
+  rest of the drive, and the delivery quietly went late. Now the gate
+  repeats its instruction every ten seconds while you are still moving,
+  cruise drops each time so the truck is never held at speed past a dead
+  end, and the S key answers with the gate itself -- "At the receiver.
+  Stop to dock." -- instead of a speed limit that stopped mattering when
+  the route ended.
+
 - **Each extracted copy of the game now keeps its saves strictly to itself.**
   Previously, a copy of the game could look one folder up on its first run
   and adopt the saves it found there, so keeping two versions side by side,

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -151,6 +151,7 @@ class DrivingState(
         self._arrival_stop_said = False
         self._arrival_full_stop_said = False
         self._arrival_menu_open = False
+        self._gate_reminder_s = 0.0
         self._air_ready_said = self.truck.air_ready
         self._low_air_said = self.truck.air_low_warning
         self._spring_brake_said = self.truck.spring_brakes_active

--- a/src/freight_fate/states/driving_controls.py
+++ b/src/freight_fate/states/driving_controls.py
@@ -418,6 +418,15 @@ class DrivingControlsMixin:
 
     def _speak_speed_limit(self) -> None:
         """S: the posted limit here, the zone if any, and how far over you are."""
+        # At a facility gate the posted limit stopped mattering when the
+        # route ended -- the only thing S can honestly answer is the gate
+        # and what to do about it. Without this, a driver rolling past the
+        # entrance heard "limit 45" and nothing about the delivery behind
+        # them (playtest 2026-07-22).
+        gate = self._arrival_gate_query_text()
+        if gate is not None:
+            self.ctx.say(gate)
+            return
         limit, reason = self.trip.speed_limit_at(self.trip.position_mi)
         zone = f", in a {reason} zone" if reason else ""
         over = self.truck.speed_mph - limit

--- a/src/freight_fate/states/driving_core.py
+++ b/src/freight_fate/states/driving_core.py
@@ -99,6 +99,12 @@ ACC_LIMIT_COMFORT_DECEL_MPS2 = 1.0
 ENGINE_SHUTDOWN_SAFE_MPH = 5.0  # prevent accidental kill-switch use at speed
 DELIVERY_PARK_MPH = 3.0  # within this, the gate prompts you to stop
 DOCKING_MAX_MPH = 0.5  # dock/settle/rest actions need a complete stop
+# How often a facility gate re-speaks its stop instruction while the truck is
+# still rolling past it. The one-shot warnings latch, so without a cadence a
+# player who overshot the gate at speed heard them once, minutes ago, and got
+# silence for the rest of the drive (playtest 2026-07-22: six minutes and the
+# on-time bonus lost three miles past a delivery entrance).
+GATE_REMINDER_INTERVAL_S = 10.0
 
 
 def terse_hazard_message(message: str) -> str:

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -945,8 +945,18 @@ class DrivingEventMixin:
             self._handle_arrival_creep()
             return
         if self._arrival_stop_said:
+            self._remind_arrival_gate(
+                "Destination gate: stop to dock.",
+                f"At {self._destination_facility_text()}. Stop to dock."
+                if self._terse_speech()
+                else (
+                    f"Still at {self._destination_facility_text()}. The delivery "
+                    "is here, not ahead: slow down and stop to dock."
+                ),
+            )
             return
         self._arrival_stop_said = True
+        self._gate_reminder_s = GATE_REMINDER_INTERVAL_S
         self._cancel_cruise()
         self.ctx.audio.play("ui/warning")
         self._set_status("Destination ahead: slow down and come to a complete stop.")
@@ -959,6 +969,41 @@ class DrivingEventMixin:
             )
         )
         self.ctx.say_event(message, interrupt=True)
+
+    def _remind_arrival_gate(self, status: str, message: str, *, pickup: bool = False) -> None:
+        """Repeat a gate's stop instruction while the truck rolls past it.
+
+        The gate warnings latch after speaking once, which is right for a
+        driver who is slowing -- but a driver who rolls on hears nothing
+        again for the rest of the drive, with any re-armed cruise happily
+        holding highway speed at a dead-end. Re-speak on a calm cadence and
+        drop the cruise each time; the reminder stops the moment the truck
+        slows into the gate's own creep-and-dock flow.
+        """
+        if self._gate_reminder_s > 0.0:
+            return
+        self._gate_reminder_s = GATE_REMINDER_INTERVAL_S
+        if pickup:
+            self._pause_speed_control()
+        else:
+            self._cancel_cruise()
+        self.ctx.audio.play("ui/warning")
+        self._set_status(status)
+        self.ctx.say_event(message, interrupt=True)
+
+    def _arrival_gate_query_text(self) -> str | None:
+        """The gate's instruction when the trip has ended at one, else None.
+
+        Mirrors the update loop's gate dispatch so the info keys agree with
+        what the gate handlers are actually waiting for.
+        """
+        if not self.trip.finished or self._arrival_menu_open:
+            return None
+        if self.phase == DRIVE_PHASE_PICKUP:
+            return f"At {self._pickup_facility_text()}. Stop to check in."
+        if self._ramp_mi is not None or not self._destination_exit_taken:
+            return None
+        return f"At {self._destination_facility_text()}. Stop to dock."
 
     def _handle_arrival_creep(self) -> None:
         if self._arrival_full_stop_said:

--- a/src/freight_fate/states/driving_pickup.py
+++ b/src/freight_fate/states/driving_pickup.py
@@ -15,8 +15,14 @@ class DrivingPickupMixin:
             self._handle_pickup_creep()
             return
         if self._arrival_stop_said:
+            self._remind_arrival_gate(
+                "Pickup gate: stop to check in.",
+                f"Still at {self._pickup_facility_text()}. Slow down and stop to check in.",
+                pickup=True,
+            )
             return
         self._arrival_stop_said = True
+        self._gate_reminder_s = GATE_REMINDER_INTERVAL_S
         speed_control_paused = self._pause_speed_control()
         self.ctx.audio.play("ui/warning")
         self._set_status("Pickup ahead: slow down and come to a complete stop.")

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -179,6 +179,7 @@ class DrivingUpdateMixin:
         if self.tutorial:
             self.tutorial.update(dt, t)
         if self.trip.finished:
+            self._gate_reminder_s = max(0.0, self._gate_reminder_s - dt)
             if self.phase == DRIVE_PHASE_PICKUP:
                 self._handle_pickup_gate()
             elif self._ramp_mi is not None:

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -1065,6 +1065,55 @@ def test_delivery_requires_parking_at_destination(monkeypatch):
         app.shutdown()
 
 
+def test_arrival_gate_repeats_after_overshoot(monkeypatch):
+    """Rolling past the destination gate keeps the stop instruction alive.
+
+    Backport of the 1.9-line fix (playtest 2026-07-22): the gate warnings
+    latched after one announcement, so a driver who overshot the entrance
+    at speed -- with cruise re-armed -- heard silence for six minutes and
+    lost the on-time bonus, with S still answering speed limits for a
+    route that had already ended."""
+    from freight_fate.app import App
+    from freight_fate.states.driving import DrivingState
+
+    app = App()
+    events = []
+    monkeypatch.setattr(app.ctx, "say_event", lambda text, interrupt=True: events.append(text))
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        mark_destination_exit_taken(driving)
+        driving.truck.velocity_mps = 26.8  # ~60 mph, blowing past the gate
+
+        driving.update(1 / 60)
+        assert isinstance(app.state, DrivingState)
+        assert "Destination ahead" in events[-1]
+        announced = len(events)
+
+        # Inside the reminder interval the gate stays quiet.
+        for _ in range(30):
+            driving.update(1 / 60)
+        assert len(events) == announced
+
+        # Interval elapsed and cruise re-armed: the reminder re-speaks the
+        # instruction and drops the cruise again.
+        driving._cruise_mph = 41.0
+        driving._gate_reminder_s = 0.0
+        driving.update(1 / 60)
+        assert "Still at" in events[-1]
+        assert "stop to dock" in events[-1].lower()
+        assert driving._cruise_mph is None
+
+        # S answers with the gate, not the posted limit of the ended route.
+        spoken = []
+        monkeypatch.setattr(app.ctx, "say", lambda text, interrupt=True: spoken.append(text))
+        driving._speak_speed_limit()
+        assert "Stop to dock" in spoken[-1]
+        assert "Speed limit" not in spoken[-1]
+    finally:
+        app.shutdown()
+
+
 def test_cargo_mass_is_loaded_on_delivery_and_empty_on_pickup():
     from freight_fate.app import App
     from freight_fate.models.jobs import CARGO_CATALOG, Job


### PR DESCRIPTION
## What changed and why

Backports the arrival-overshoot fix to dev for the 1.8 line. The pickup and delivery gates spoke their stop instruction exactly once and latched: a driver who rolled past a facility entrance -- easy to do with cruise re-engaged -- heard nothing more for the rest of the drive while speed control held highway speed at a dead end. Found in a 2026-07-22 playtest where the trap silently cost six minutes and the on-time delivery bonus.

Both gates now repeat their stop instruction every ten seconds while the truck is above parking speed, cancel any re-armed speed control on each repeat, and the S info key answers with the gate instruction instead of a posted limit for a route that has already ended.

Also brings the `sounds-licensed/` gitignore block to dev so a checkout carrying the licensed audio overlay can never sweep it into a commit on this line.

## What players or maintainers will notice

Rolling past a pickup or delivery entrance now nags every ten seconds ("Still at the receiver. The delivery is here, not ahead: slow down and stop to dock."), drops cruise so the truck cannot be held at speed past the entrance, and pressing S at the gate answers with what to do instead of an irrelevant speed limit. Drivers who stop normally hear exactly what they heard before.

## Tests and checks run

- `uv run pytest tests/test_driving_features.py tests/test_smoke.py` -- 82 passed, including a new regression test covering the repeat cadence, the cruise drop, and the S answer.
- `uv run ruff check src tests tools` -- clean.
- Spoken flow verified in live 1.9-line playtests of the same change (three sessions, 2026-07-22).

## Accessibility impact

This is an accessibility fix: the overshoot trap was invisible to a screen-reader player -- one announcement, then silence with no way to ask where the delivery went. The repeating instruction and the S-key gate answer give the player two audible ways back. All new text is spoken via the existing event-speech channel; no visual-only cues.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)