### PR TITLE
Backport: armed exits count themselves down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **An armed exit now counts itself down.** Once your signal is on, the
+  exit calls out again at two miles, one mile, and half a mile. No more
+  hearing about an exit once, five miles early, and never again until
+  you have missed it.
+
 - **Delete a career's cloud backups.** Each career in the Cloud backup menu
   now has a Delete item that removes every kept backup of that career from
   your orinks.net account, after a spoken confirmation. Your saves on this

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -124,6 +124,7 @@ class DrivingState(
         self._rescue_offered = False
         self._signal_timer = 0.0
         self._exit_stop = None  # armed exit, set with X
+        self._exit_countdown_said: set[float] = set()
         self._ramp_mi: float | None = None  # ramp distance left, once taken
         self._ramp_stop = None
         self._ramp_end_said = False

--- a/src/freight_fate/states/driving_core.py
+++ b/src/freight_fate/states/driving_core.py
@@ -64,6 +64,9 @@ OUT_OF_SERVICE_MIN = hos.SLEEP_MIN
 EXIT_WINDOW_MI = 5.0  # how far out X can arm the upcoming exit, at minimum
 EXIT_WARNING_REAL_S = 25.0  # target real seconds from callout to the ramp
 EXIT_WINDOW_MAX_MI = 20.0
+# Spoken distance anchors for an armed exit; a signal-on announcement miles
+# out gets buried under limit changes and scenery chatter without them.
+EXIT_COUNTDOWN_MILESTONES_MI = (2.0, 1.0, 0.5)
 RAMP_MAX_MPH = 45.0  # any faster and you blow past the exit
 RAMP_CRUISE_TARGET_MPH = 40.0  # leave control-loop headroom below the hard ramp limit
 RAMP_LENGTH_MI = 0.5  # deceleration lane plus ramp to the stop

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -261,6 +261,7 @@ class DrivingEventMixin:
             self.ctx.say("No exit coming up. Exits are announced as you approach them.")
             return
         self._exit_stop = stop
+        self._exit_countdown_said = set()
         self.ctx.audio.play("ui/notify", volume=0.5)
         ahead = stop.at_mi - self.trip.position_mi
         if stop.type == "delivery_destination":
@@ -469,6 +470,44 @@ class DrivingEventMixin:
         candidates.sort()
         return candidates[0][3], candidates[0][4], candidates[0][5]
 
+    def _update_exit_countdown(self, stop) -> None:
+        """Distance reminders for an armed exit as it closes.
+
+        A single signal-on announcement miles out gets buried under limit
+        changes and scenery chatter, and the driver hears nothing again
+        until the miss. The countdown re-anchors the exit at two miles, one
+        mile, and half a mile. Ported from the 1.9 line without its
+        exit-lane readiness hint -- this line has no lane tracker."""
+        ahead = stop.at_mi - self.trip.position_mi
+        if ahead <= 0:
+            return
+        crossed = [
+            m
+            for m in EXIT_COUNTDOWN_MILESTONES_MI
+            if ahead <= m and m not in self._exit_countdown_said
+        ]
+        if not crossed:
+            return
+        # Time compression can cross several milestones in one frame:
+        # mark them all, speak only the nearest.
+        self._exit_countdown_said.update(crossed)
+        nearest = min(crossed)
+        if nearest >= 1.0:
+            distance = self.ctx.settings.distance_text(nearest)
+        elif self.ctx.settings.imperial_units:
+            # spoken_distance rounds to whole units; the half-mile anchor
+            # needs its own words on both unit settings.
+            distance = "half a mile"
+        else:
+            distance = "800 meters"
+        name = (
+            "Destination exit"
+            if stop.type == "delivery_destination"
+            else f"Exit for {stop.spoken_name}"
+        )
+        self.ctx.audio.play("ui/notify", volume=0.6)
+        self.ctx.say_event(f"{name} in {distance}.", interrupt=False)
+
     def _update_exit(self, moved_mi: float) -> None:
         """Advance an armed exit or an active ramp; opens the stop menu."""
         if self._ramp_mi is not None:
@@ -527,7 +566,10 @@ class DrivingEventMixin:
                 self.ctx.say_event(message, interrupt=True)
             return
         stop = self._exit_stop
-        if stop is None or self.trip.position_mi < stop.at_mi:
+        if stop is None:
+            return
+        if self.trip.position_mi < stop.at_mi:
+            self._update_exit_countdown(stop)
             return
         self._exit_stop = None
         # The exit is settled either way now, so the ramp cap comes off: taking

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -1065,6 +1065,47 @@ def test_delivery_requires_parking_at_destination(monkeypatch):
         app.shutdown()
 
 
+def test_armed_exit_counts_down(monkeypatch):
+    """An armed exit re-anchors itself at two miles, one mile, half a mile.
+
+    Backport of the 1.9-line countdown: a signal-on announcement miles out
+    was the last word before the miss -- 1.8 players kept losing exits
+    armed under scenery chatter."""
+    from types import SimpleNamespace
+
+    from freight_fate.app import App
+
+    app = App()
+    events = []
+    monkeypatch.setattr(app.ctx, "say_event", lambda text, interrupt=True: events.append(text))
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        stop = SimpleNamespace(
+            at_mi=driving.trip.position_mi + 3.0,
+            type="delivery_destination",
+            spoken_name="Test Plaza",
+            name="Test Receiver",
+            exit_label="",
+            exit_phrase="",
+        )
+        driving._exit_stop = stop
+        driving._exit_countdown_said = set()
+
+        for ahead in (2.5, 1.9, 1.9, 0.9, 0.4, 0.3):
+            driving.trip.position_mi = stop.at_mi - ahead
+            driving._update_exit(0.0)
+
+        calls = [t for t in events if t.startswith("Destination exit in")]
+        assert calls == [
+            "Destination exit in 2 miles.",
+            "Destination exit in 1 mile.",
+            "Destination exit in half a mile.",
+        ]
+    finally:
+        app.shutdown()
+
+
 def test_arrival_gate_repeats_after_overshoot(monkeypatch):
     """Rolling past the destination gate keeps the stop instruction alive.
 


### PR DESCRIPTION
## What changed and why

Backports the 1.9-line armed-exit countdown for the 1.8 players who keep missing exits. Arming an exit spoke one announcement -- often five miles out -- and then nothing again until the miss; under limit changes and scenery chatter the exit vanished from the player's mental map. An armed exit now re-anchors itself at two miles, one mile, and half a mile.

Ported without the 1.9 exit-lane readiness hint (this line has no lane tracker), and with dedicated half-mile wording since `spoken_distance` rounds 0.5 to zero.

## What players or maintainers will notice

After pressing X to signal for an exit, the exit calls out again as it closes: "Destination exit in 2 miles." / "in 1 mile." / "in half a mile." -- or, for a rest stop or fuel exit, named by the stop itself: "Exit for Love's Travel Stop in 1 mile." Each call comes with a soft notify tone. Nothing changes for unarmed exits.

## Tests and checks run

- `uv run pytest tests/test_driving_features.py tests/test_smoke.py` -- 83 passed, including a new test pinning the three milestones, spoken once each, with correct singular/plural and half-mile wording.
- `uv run ruff check src tests tools` -- clean.

## Accessibility impact

This is an accessibility feature: the countdown exists precisely because a blind driver cannot glance at a nav screen to re-check a distance. All text rides the existing event-speech channel; milestone wording avoids "1 miles" and "0 miles".

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
