### PR TITLE
Backport: order same-day stable and nightly by publish time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@
 
 ### Fixed
 
+- **The updater no longer hides a developer snapshot released the same
+  day as a stable build.** On the developer snapshots channel, a stable
+  release published in the small hours used to mask that morning's
+  snapshot -- even when the snapshot carried newer fixes -- because the
+  two were compared by date alone. Updates now compare by the actual
+  publish moment, so whichever build is genuinely newest is the one
+  offered.
+
 - **Driving past a pickup or delivery entrance no longer goes silent.**
   Arriving at a facility used to announce itself once; if you rolled on --
   easy to do with cruise re-engaged -- the game said nothing more for the

--- a/src/freight_fate/updater.py
+++ b/src/freight_fate/updater.py
@@ -286,26 +286,65 @@ def _build_date(build: BuildInfo | None) -> str:
     return _nightly_date(build.tag) or build.built_at.replace("-", "")
 
 
-def _stable_newer_than_build(release: dict, build: BuildInfo | None, build_date: str) -> bool:
+def _release_timestamp(release: dict | None) -> str:
+    """A release's full ``published_at`` (ISO 8601, sortable as text); ''
+    when unknown. Dates alone cannot order a same-day stable and nightly,
+    and both orderings really happen: the 04:00 UTC cron nightly precedes
+    an afternoon promotion, but a small-hours stable precedes that same
+    cron -- which then carries fixes merged in between (v1.8.5.1 day,
+    2026-07-23: stable 01:07, nightly 03:58 with two backports, and the
+    date tie hid the nightly from every dev-channel player)."""
+    if release is None:
+        return ""
+    return str(release.get("published_at") or "")
+
+
+def _build_timestamp(build: BuildInfo | None, releases: list[dict], stable: dict | None) -> str:
+    """The running build's publish moment, recovered from its own release.
+
+    build_info carries only a date, so the release list is the one source
+    of intra-day ordering for the copy the player is on."""
+    if build is None:
+        return ""
+    if stable is not None and stable.get("tag_name", "") == build.tag:
+        return _release_timestamp(stable)
+    for release in releases:
+        if release.get("tag_name", "") == build.tag:
+            return _release_timestamp(release)
+    return ""
+
+
+def _stable_newer_than_build(
+    release: dict, build: BuildInfo | None, build_date: str, build_ts: str = ""
+) -> bool:
     """Whether ``release`` (a stable build) is an upgrade for the running copy.
 
     A stable build compares by version (two builds can share a date but differ
-    in version); a nightly build compares by date, since the version number is
-    typically unchanged across the dev-to-stable promotion."""
+    in version); a nightly build compares by publish timestamp when both are
+    known, else by date, since the version number is typically unchanged
+    across the dev-to-stable promotion."""
     tag = release.get("tag_name", "")
     if build is not None and tag == build.tag:
         return False
     if build is not None and not _nightly_date(build.tag):
         return parse_version(tag) > parse_version(build.tag)
+    stable_ts = _release_timestamp(release)
+    if build_ts and stable_ts:
+        return stable_ts > build_ts
     stable_date = _release_date(release)
     return not (build_date and stable_date and stable_date <= build_date)
 
 
-def _nightly_newer_than_build(release: dict, build: BuildInfo | None, build_date: str) -> bool:
+def _nightly_newer_than_build(
+    release: dict, build: BuildInfo | None, build_date: str, build_ts: str = ""
+) -> bool:
     tag = release.get("tag_name", "")
     if build is not None:
         if tag == build.tag:
             return False
+        nightly_ts = _release_timestamp(release)
+        if build_ts and nightly_ts:
+            return nightly_ts > build_ts
         if build_date and _nightly_date(tag) <= build_date:
             return False
     return True
@@ -330,16 +369,29 @@ def dev_update_from(
         stable = _latest_stable_release(releases)
 
     build_date = _build_date(build)
+    build_ts = _build_timestamp(build, releases, stable)
     nightly_date = _release_date(latest_nightly)
     stable_date = _release_date(stable)
+    nightly_ts = _release_timestamp(latest_nightly)
+    stable_ts = _release_timestamp(stable)
 
-    if stable is not None and stable_date and stable_date >= nightly_date:
-        if _stable_newer_than_build(stable, build, build_date):
+    # Timestamps order a same-day stable and nightly; dates alone cannot,
+    # and a date tie wrongly favored a small-hours stable over the 04:00
+    # nightly that carried fixes merged between them (2026-07-23).
+    if nightly_ts and stable_ts:
+        stable_leads = stable_ts >= nightly_ts
+    else:
+        stable_leads = bool(stable_date) and stable_date >= nightly_date
+
+    if stable is not None and stable_leads:
+        if _stable_newer_than_build(stable, build, build_date, build_ts):
             tag = stable.get("tag_name", "")
             return _update_from_release(stable, f"Freight Fate version {tag.lstrip('v')}")
         return None  # already on the newest stable; nothing newer on dev
 
-    if latest_nightly is not None and _nightly_newer_than_build(latest_nightly, build, build_date):
+    if latest_nightly is not None and _nightly_newer_than_build(
+        latest_nightly, build, build_date, build_ts
+    ):
         date = _nightly_date(latest_nightly.get("tag_name", ""))
         spoken = f"{date[:4]}-{date[4:6]}-{date[6:]}"
         return _update_from_release(latest_nightly, f"Freight Fate developer snapshot {spoken}")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -616,6 +616,32 @@ def test_dev_on_promoted_stable_is_not_pulled_onto_equivalent_nightly():
     assert dev_update_from(releases, build, stable) is None
 
 
+def test_dev_offers_same_day_nightly_that_postdates_the_stable():
+    # The v1.8.5.1 morning, 2026-07-23: stable published 01:07 UTC, the
+    # 03:58 UTC cron nightly carried two fixes merged in between. The old
+    # date-granularity tie favored stable and hid the nightly from every
+    # dev-channel player (owner report, same day).
+    stable = release("v1.8.5.1", published="2026-07-23T01:07:34Z")
+    nightly = release("nightly-20260723", prerelease=True, published="2026-07-23T03:58:51Z")
+    build = BuildInfo(tag="v1.8.5.1", channel="stable", built_at="2026-07-23")
+    info = dev_update_from([stable, nightly], build, stable)
+    assert info is not None
+    assert info.tag == "nightly-20260723"
+
+
+def test_dev_morning_nightly_still_steered_to_same_day_afternoon_stable():
+    # Promotion day with real timestamps: the 04:00 UTC cron nightly
+    # predates the afternoon stable, so a player on that morning nightly
+    # converges onto the promoted stable -- the date tie used to block
+    # this direction too.
+    stable = release("v1.9.0", published="2026-08-01T15:00:00Z")
+    nightly = release("nightly-20260801", prerelease=True, published="2026-08-01T04:00:00Z")
+    build = BuildInfo(tag="nightly-20260801", channel="dev", built_at="2026-08-01")
+    info = dev_update_from([stable, nightly], build, stable)
+    assert info is not None
+    assert info.tag == "v1.9.0"
+
+
 def test_dev_resumes_nightlies_once_they_outpace_stable():
     # Days later dev advances past stable again; nightlies resume.
     stable = release("v1.7.0", published="2026-06-26T15:00:00Z")


### PR DESCRIPTION
## What changed and why

Backports the updater same-day ordering fix from the 1.9 line. Date-granularity comparison cannot order a stable and a nightly published the same UTC day, and both real orderings happen: the 04:00 UTC cron nightly precedes an afternoon promotion, but a small-hours stable precedes that same cron -- which then carries fixes merged in between. This morning (stable v1.8.5.1 published 01:07 UTC, nightly 03:58 UTC with two backported fixes) the date tie steered every dev-channel player to the stable they were already on and reported nothing newer (owner report, same morning).

The dev-channel steering, stable-vs-build, and nightly-vs-build comparisons now use full published_at timestamps when both sides are known, recovering the running build's publish moment from its own release entry. Date comparison remains the fallback, so behavior without timestamps is unchanged.

## What players or maintainers will notice

Developer-snapshot players are offered a same-day snapshot that genuinely postdates a stable release, and a player on the morning nightly is still steered onto a same-day afternoon promotion. Stable-channel behavior is unchanged.

## Tests and checks run

- `uv run pytest tests/test_updater.py` -- 57 passed on this branch, including two new tests pinning both same-day orderings.
- `uv run ruff check src tests tools` -- clean.

## Accessibility impact

None beyond the fix itself: update discovery only; all update flows keep their existing spoken menus.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
