### PR TITLE
Warn before a redundant double-sleep at rest stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
 
 ### Changed
 
+- **Rest stops no longer let you sleep twice for nothing.** When you are
+  already fully rested at a rest stop, choosing a sleep option now warns you
+  that it would only move the clock and your deadline forward, and asks you to
+  press Enter again to confirm. This is the same safeguard the terminal bunk
+  room already had.
 - **Everything online now lives in one Online menu on the main menu.** The
   drivers board, orinks.net account setup, Profile sharing, cloud backup and
   restore, Mastodon sharing, and Discord presence moved out of Settings into

--- a/src/freight_fate/states/driving_rest_states.py
+++ b/src/freight_fate/states/driving_rest_states.py
@@ -175,10 +175,47 @@ class RestStopState(MenuState):
         super().__init__(ctx)
         self.driving = driving
         self.stop = stop
+        self._confirm_sleep_rested = False
 
     @property
     def title(self) -> str:  # type: ignore[override]
         return self.stop.spoken_name
+
+    def enter(self) -> None:
+        self._confirm_sleep_rested = False
+        super().enter()
+
+    # Moving off a sleep item withdraws its pending double-press confirmation,
+    # so a stale "press Enter again" can never sleep you silently later.
+    def move(self, delta: int) -> None:
+        self._confirm_sleep_rested = False
+        super().move(delta)
+
+    def jump(self, index: int) -> None:
+        self._confirm_sleep_rested = False
+        super().jump(index)
+
+    def _guard_double_sleep(self, *, fatigue_floor: float = 0.0) -> bool:
+        """Warn once before a redundant sleep, matching the terminal. A sleep
+        gains nothing when hours of service are already fresh and this rest
+        cannot lower fatigue any further -- for a proper berth that means zero
+        fatigue, for a lot's poor rest it bottoms out at the shoulder floor.
+        Returns True if this press should be blocked."""
+        p = self.ctx.profile
+        gains_nothing = (
+            p.hos.driving_min <= 0.0 and p.hos.duty_min <= 0.0 and p.fatigue <= fatigue_floor
+        )
+        if gains_nothing and not self._confirm_sleep_rested:
+            self._confirm_sleep_rested = True
+            self.ctx.audio.play("ui/warning")
+            self.ctx.say(
+                "You are already rested: fresh hours of service and no more "
+                "rest to gain here. Sleeping now would only move the clock and "
+                "your deadline forward. Press Enter again to sleep anyway."
+            )
+            return True
+        self._confirm_sleep_rested = False
+        return False
 
     def presence(self):
         from ..discord_presence import PresenceState
@@ -436,6 +473,8 @@ class RestStopState(MenuState):
         return f"{pair} The clock and your deadline advance {hours} hours."
 
     def _sleeper_split_rest(self, hours: int) -> None:
+        if self._guard_double_sleep():
+            return
         d = self.driving
         p = self.ctx.profile
         minutes = float(hours * 60)
@@ -459,6 +498,8 @@ class RestStopState(MenuState):
         self.refresh()
 
     def _sleep(self) -> None:
+        if self._guard_double_sleep():
+            return
         d = self.driving
         p = self.ctx.profile
         before_fatigue = p.fatigue
@@ -482,6 +523,8 @@ class RestStopState(MenuState):
         """Bed down in a break/fuel stop's lot when out of hours: a legal HOS
         reset, but cramped poor rest (no proper sleeper), so you wake still
         tired. No shoulder fine -- a lot is more legitimate than the freeway."""
+        if self._guard_double_sleep(fatigue_floor=hos.FATIGUE_SHOULDER_FLOOR):
+            return
         d = self.driving
         p = self.ctx.profile
         engine_off = _shut_down_engine(d)

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -1934,6 +1934,116 @@ def test_poi_menu_uses_curated_roadside_assistance_label():
 
 
 @pytest.mark.smoke
+def test_rest_stop_sleep_warns_before_redundant_double_sleep():
+    from freight_fate.app import App
+    from freight_fate.sim.trip import RoadStop
+    from freight_fate.states.career_stats import fully_rested
+    from freight_fate.states.driving import RestStopState
+
+    app = App()
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        stop = RoadStop(
+            "Example Turnpike Service Plaza",
+            driving.trip.position_mi,
+            "service_plaza",
+            ("park", "sleep", "save"),
+            ("parking",),
+        )
+        state = RestStopState(app.ctx, driving, stop)
+
+        # Force the driver fully rested: sleeping would gain nothing but time.
+        profile = app.ctx.profile
+        profile.hos.driving_min = 0.0
+        profile.hos.duty_min = 0.0
+        profile.fatigue = 0.0
+        assert fully_rested(profile)
+
+        def find(label):
+            for item in state.build_items():
+                text = item.text if isinstance(item.text, str) else item.text()
+                if text == label:
+                    return item.action
+            raise AssertionError(f"no {label!r} item")
+
+        sleep_10 = find("Sleep 10 hours")
+        before = driving.trip.game_minutes
+
+        # First press only warns; the clock must not move.
+        sleep_10()
+        assert driving.trip.game_minutes == before
+        assert state._confirm_sleep_rested is True
+
+        # Second consecutive press sleeps the full 10 hours.
+        sleep_10()
+        assert driving.trip.game_minutes == pytest.approx(before + 600.0)
+        assert state._confirm_sleep_rested is False
+
+        # The guard covers sleeper-split rests too: a fresh visit warns first.
+        state._confirm_sleep_rested = False
+        profile.hos.driving_min = 0.0
+        profile.hos.duty_min = 0.0
+        profile.fatigue = 0.0
+        split_before = driving.trip.game_minutes
+        find("Sleep 2 hours in sleeper berth")()
+        assert driving.trip.game_minutes == split_before
+        assert state._confirm_sleep_rested is True
+    finally:
+        app.shutdown()
+
+
+@pytest.mark.smoke
+def test_lot_sleep_warns_before_redundant_double_sleep():
+    # A non-sleeper stop only offers the poor-rest lot sleep, which floors
+    # fatigue at the shoulder value -- so the guard must key off "hours fresh
+    # and no more rest to gain", not full restedness, or it never fires.
+    from freight_fate.app import App
+    from freight_fate.sim import hos
+    from freight_fate.sim.trip import RoadStop
+    from freight_fate.states.driving import RestStopState
+
+    app = App()
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        stop = RoadStop(
+            "Test Fuel Stop",
+            driving.trip.position_mi,
+            "fuel_stop",
+            ("park", "fuel", "break"),
+            ("parking",),
+        )
+        state = RestStopState(app.ctx, driving, stop)
+
+        # Simulate a drive, then a first lot sleep so hours are fresh but
+        # fatigue is stuck at the shoulder floor -- the state a driver is in
+        # right after bedding down once.
+        profile = app.ctx.profile
+        profile.hos.driving_min = 0.0
+        profile.hos.duty_min = 0.0
+        profile.fatigue = hos.FATIGUE_SHOULDER_FLOOR
+
+        lot_sleep = None
+        for item in state.build_items():
+            text = item.text if isinstance(item.text, str) else item.text()
+            if text == "Sleep 10 hours in the lot":
+                lot_sleep = item.action
+                break
+        assert lot_sleep is not None
+
+        before = driving.trip.game_minutes
+        lot_sleep()  # first press only warns
+        assert driving.trip.game_minutes == before
+        assert state._confirm_sleep_rested is True
+
+        lot_sleep()  # second press sleeps anyway
+        assert driving.trip.game_minutes == pytest.approx(before + 600.0)
+    finally:
+        app.shutdown()
+
+
+@pytest.mark.smoke
 def test_status_map_screen_describes_source_backed_poi_services():
     from freight_fate.app import App
     from freight_fate.models.jobs import CARGO_CATALOG, Job


### PR DESCRIPTION
## What changed and why

Company terminals already guard against a pointless "double sleep": if you're
already rested, choosing *Sleep 10 hours* warns you and requires a second Enter
to confirm. On-the-road rest stops had no such guard, so a driver could sleep
over and over, burning the clock (and the delivery deadline) for nothing.

This ports that safeguard into `RestStopState`, covering **every** sleep option
— the sleeper-split rests (2/3/7/8 hrs), the full 10-hour berth sleep, and the
poor-rest lot sleep.

The check keys off *"hours of service already fresh **and** no more rest to gain
here"* rather than strict full-restedness. That distinction matters for the lot
sleep: its rest floors fatigue at the shoulder value (30) and so never reads as
"fully rested" — an earlier `fully_rested()`-only version silently let you
lot-sleep unlimited times. The guard now fires there too.

## What players will notice

At a rest stop, if sleeping again would only move the clock forward, you'll hear
a warning that you're already rested with no more rest to gain, and you must
press Enter again to sleep anyway — exactly like the terminal bunk room. This
holds for the sleeper berth, the full 10-hour sleep, and the lot sleep.

## Tests run

- `uv run pytest tests/test_driving_features.py tests/test_hos.py` — passing,
  including two new smoke tests:
  - `test_rest_stop_sleep_warns_before_redundant_double_sleep` (berth + split)
  - `test_lot_sleep_warns_before_redundant_double_sleep` (poor-rest lot path)
- `uv run ruff check src tests tools` — clean
- `uv run python -m compileall src tests tools` — clean

## Accessibility impact

The guard is spoken, not visual: a screen-reader/TTS warning line plus the
existing `ui/warning` cue, and it reuses the standard menu flow. No new
visual-only information. Wording mirrors the terminal's spoken warning.

## Changelog

- [x] Player-facing — added a bullet under `## Unreleased` → `### Changed` in
  `CHANGELOG.md`.
