### PR TITLE
ci: hide nightly recovery from pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, changelog]
+    if: ${{ !cancelled() && needs.test.result == 'success' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -94,14 +95,12 @@ jobs:
           name: dist
           path: dist/
 
-  recover-nightly:
-    name: Recover failed nightly
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-    needs: [test, changelog]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
       - name: Retry today's failed snapshot
+        if: >-
+          ${{ !cancelled() &&
+              github.event_name == 'push' &&
+              github.ref == 'refs/heads/dev' &&
+              needs.changelog.result == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load_ci_workflow() -> dict:
+    return yaml.load(CI_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def test_nightly_recovery_is_not_a_pull_request_check() -> None:
+    workflow = _load_ci_workflow()
+
+    assert "recover-nightly" not in workflow["jobs"]
+    build = workflow["jobs"]["build"]
+    assert build["needs"] == ["test", "changelog"]
+    assert "needs.test.result == 'success'" in build["if"]
+
+
+def test_build_keeps_dev_push_nightly_recovery() -> None:
+    workflow = _load_ci_workflow()
+    steps = workflow["jobs"]["build"]["steps"]
+    recovery = next(step for step in steps if step.get("name") == "Retry today's failed snapshot")
+
+    condition = recovery["if"]
+    assert "github.event_name == 'push'" in condition
+    assert "github.ref == 'refs/heads/dev'" in condition
+    assert "needs.changelog.result == 'success'" in condition
+    assert "!cancelled()" in condition
+
+    script = recovery["run"]
+    assert 'gh run list --repo "$GITHUB_REPOSITORY"' in script
+    assert "--workflow Build --event schedule" in script
+    assert '"$CONCLUSION" != "failure"' in script
+    assert 'gh workflow run Build --repo "$GITHUB_REPOSITORY" --ref dev -f dry_run=false' in script


### PR DESCRIPTION
## What changed and why

Removed the standalone `Recover failed nightly` CI job so pull requests no longer show an irrelevant skipped check. The unchanged recovery script now runs as a dev-push-only final step of the existing Build job after the same test and changelog gates.

## What players or maintainers will notice

Maintainers will see a cleaner pull-request check list. Failed nightly recovery behavior on `dev` remains guarded by the existing tag, active-build, scheduled-failure, and same-day checks.

## Tests and checks run

- Passed `actionlint` against the modified CI workflow.
- Passed 19 focused workflow and release-note tests.
- Passed repository Ruff checks.
- Passed Python byte-compilation and `git diff --check`.

## Accessibility impact

No player-facing UI, spoken output, keyboard path, forms, headings, or live-region behavior changes. The Accessibility Agents lead and required specialists passed the exact diff; removing the skipped check reduces screen-reader navigation noise in GitHub's checks list.

## Changelog

- [x] This change is not player-facing. The commit includes `changelog: none`, which is accepted by the repository changelog gate.