### PR TITLE
docs(changelog): credit PR 114 contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 - **Tire sounds now react to your speed.** On supported audio systems, the tire
   hum rises and falls as you accelerate or brake. Above a crawl, soft road-seam
-  thumps add texture through sound and controller vibration.
+  thumps add texture through sound and controller vibration. Contributed by
+  Swarup Baral ([@swarup-developer](https://github.com/swarup-developer)) in
+  [PR #114](https://github.com/Orinks/Freight-Fate/pull/114).
 
 - **Linux players get an AppImage.** Alongside the tarball, each release now
   ships `FreightFate-<version>-linux-x86_64.AppImage`: one file you mark


### PR DESCRIPTION
## What changed and why

Added the required first-release credit for PR 114, naming Swarup Baral, linking `@swarup-developer`, and linking PR 114.

## What players or maintainers will notice

The road-feel release-note entry now credits its contributor. Gameplay is unchanged.

## Tests and checks run

- Passed 17 focused release-note tests.
- Passed the repository release-note pre-push gate.
- Passed `git diff --check`.

## Accessibility impact

The markdown accessibility review passed: the credit uses natural read-aloud wording, descriptive links, valid list/heading structure, and no emoji.

## Changelog

- [x] This pull request updates the existing player-facing `CHANGELOG.md` entry with required contributor credit.