### PR TITLE
fix: keep announced destination exits actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,12 @@
 
 ### Fixed
 
+- **A destination exit stays ready after it is announced.** On Standard or
+  Fast trip pacing, slowing down while the callout spoke could shrink the
+  action window, so pressing X answered "No exit coming up." The exact
+  announced exit now remains available through a human reaction window, while
+  expired and already-passed exits still cannot be armed.
+
 - **Short hauls no longer pay several times more per mile than long ones.**
   A guaranteed minimum meant a fifty mile hop could pay over a thousand
   dollars, four to five times the per-mile rate of a real cross country run,

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -377,12 +377,12 @@ brake to a stop at the end of the ramp.
 Destination exits work the same way. When your delivery exit is ahead, the game
 announces the signed exit and toward cities, marks it as the destination exit,
 and tells you to press X. If adaptive cruise is active, it eases the truck to
-45 miles per hour or your lower cruise target so you can reach ramp speed
-without an abrupt handoff. Press X to take the exit; automatic speed control
-releases as you enter the ramp, then you brake to the stop. If you miss the
-destination exit, continue to the next safe turnaround. Dispatch loops you
-back onto the approach so you can hear the exit call again and press X to take
-it.
+40 miles per hour or your lower cruise target, below the 45 mile-per-hour ramp
+limit, so you can reach ramp speed without an abrupt handoff. Press X to take
+the exit; automatic speed control releases as you enter the ramp, then you
+brake to the stop. If you miss the destination exit, continue to the next safe
+turnaround. Dispatch loops you back onto the approach so you can hear the exit
+call again and press X to take it.
 
 Ordinary highway exits that do not lead to a current action are not announced
 during the drive. Press Shift+R if you want the next listed exit for route

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -131,6 +131,7 @@ class DrivingState(
         self._destination_exit_taken = False
         self._missed_destination_exit_said = False
         self._destination_exit_announced_key = ""
+        self._destination_exit_response_s = 0.0
         # (position when computed, scan result) -- see _destination_exit_details
         self._destination_exit_cache: tuple[float, tuple[float, str, str] | None] | None = None
         self._cruise_mph: float | None = None

--- a/src/freight_fate/states/driving_core.py
+++ b/src/freight_fate/states/driving_core.py
@@ -64,6 +64,9 @@ OUT_OF_SERVICE_MIN = hos.SLEEP_MIN
 EXIT_WINDOW_MI = 5.0  # how far out X can arm the upcoming exit, at minimum
 EXIT_WARNING_REAL_S = 25.0  # target real seconds from callout to the ramp
 EXIT_WINDOW_MAX_MI = 20.0
+# Keep the exact announced destination exit available for the same real-time
+# budget even if coasting or automatic braking shrinks the dynamic window.
+DESTINATION_EXIT_RESPONSE_GRACE_S = EXIT_WARNING_REAL_S
 # Spoken distance anchors for an armed exit; a signal-on announcement miles
 # out gets buried under limit changes and scenery chatter without them.
 EXIT_COUNTDOWN_MILESTONES_MI = (2.0, 1.0, 0.5)

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -254,12 +254,24 @@ class DrivingEventMixin:
         if self._exit_stop is not None:
             self._exit_stop = None
             self._cruise_exit_mph = None
+            self._destination_exit_response_s = 0.0
             self.ctx.say("Exit canceled. Staying on the highway.")
             return
         stop = self._upcoming_exit_stop()
         if stop is None:
             self.ctx.say("No exit coming up. Exits are announced as you approach them.")
             return
+        responding_to_destination_callout = (
+            stop.type == "delivery_destination"
+            and self._destination_exit_response_s > 0.0
+            and self._destination_exit_key(stop) == self._destination_exit_announced_key
+        )
+        if responding_to_destination_callout:
+            # Dedicated event speech can still be reading the callout when the
+            # player reacts. The success message repeats the needed details, so
+            # replace the old instruction instead of speaking over it.
+            self.ctx.stop_event_speech()
+            self._destination_exit_response_s = 0.0
         self._exit_stop = stop
         self._exit_countdown_said = set()
         self.ctx.audio.play("ui/notify", volume=0.5)
@@ -335,7 +347,16 @@ class DrivingEventMixin:
         if destination is None:
             return stop
         ahead = destination.at_mi - self.trip.position_mi
-        if not (0 <= ahead <= window):
+        announced_destination_is_actionable = (
+            ahead > 0.0
+            and self._destination_exit_response_s > 0.0
+            and self._destination_exit_key(destination) == self._destination_exit_announced_key
+        )
+        if announced_destination_is_actionable:
+            # X responds to the exit just named, even if an optional stop has
+            # since entered the ordinary lookahead window.
+            return destination
+        if not 0 < ahead <= window:
             return stop
         if stop is None or destination.at_mi <= stop.at_mi:
             return destination
@@ -401,6 +422,7 @@ class DrivingEventMixin:
         if key == self._destination_exit_announced_key:
             return
         self._destination_exit_announced_key = key
+        self._destination_exit_response_s = DESTINATION_EXIT_RESPONSE_GRACE_S
         message = self._destination_exit_announcement(stop, ahead) + self._cap_cruise_for_ramp()
         self.ctx.audio.play("ui/notify", volume=0.7)
         self.ctx.say_event(message, interrupt=True)
@@ -967,6 +989,7 @@ class DrivingEventMixin:
             self.trip.game_minutes += 20.0
             self.trip.position_mi = max(0.0, exit_details[0] - self._exit_window_mi())
             self._destination_exit_announced_key = None
+            self._destination_exit_response_s = 0.0
             if self._terse_speech():
                 reroute_text = "Safe turnaround. Destination exit ahead again."
             else:

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -38,6 +38,15 @@ class DrivingUpdateMixin:
         # pacing can be changed from the pause menu mid-trip; keep the trip's
         # clock compression in step with the setting
         self.trip.time_scale = self.ctx.settings.time_scale
+        if self._destination_exit_response_s > 0.0:
+            self._destination_exit_response_s = max(
+                0.0,
+                self._destination_exit_response_s - dt,
+            )
+            if self._destination_exit_response_s == 0.0 and self._exit_stop is None:
+                # A driver who stopped after the early callout must still get a
+                # fresh, closer instruction once the normal window reaches them.
+                self._destination_exit_announced_key = ""
         self._sync_weather_source()
         keys = pygame.key.get_pressed()
         ramp = dt * 2.2

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -2440,6 +2440,143 @@ def test_destination_exit_announced_within_scaled_window(monkeypatch):
         app.shutdown()
 
 
+@pytest.mark.parametrize(
+    ("time_scale", "approach_mph"),
+    [(20.0, 54.0), (40.0, 56.0)],
+    ids=["standard", "fast"],
+)
+def test_announced_destination_exit_stays_actionable_when_window_shrinks(
+    monkeypatch,
+    time_scale,
+    approach_mph,
+):
+    """The spoken X instruction remains true through a human reaction delay."""
+    from freight_fate.app import App
+
+    app = App()
+    transcript = []
+    stopped_event_speech = []
+    monkeypatch.setattr(app.ctx, "say", lambda text, **k: transcript.append(text))
+    monkeypatch.setattr(app.ctx, "say_event", lambda text, **k: transcript.append(text))
+    monkeypatch.setattr(
+        app.ctx,
+        "stop_event_speech",
+        lambda: stopped_event_speech.append(True),
+    )
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        monkeypatch.setattr(driving.trip, "upcoming_stop", lambda _window: None)
+        driving.trip.time_scale = time_scale
+        driving.truck.velocity_mps = approach_mph / 2.23694
+        destination = driving._destination_exit_stop()
+        announced_window = driving._exit_window_mi()
+        driving.trip.position_mi = destination.at_mi - announced_window + 0.01
+
+        driving._check_destination_exit()
+
+        assert "destination exit" in transcript[-1]
+        assert driving._cruise_mph is None  # reported case: automatic control is off
+
+        # Coasting while the player listens makes the dynamic window contract
+        # below the still-ahead exit. Before the fix, the real X path answered
+        # "No exit coming up" here.
+        driving.truck.velocity_mps = 30.0 / 2.23694
+        ahead = destination.at_mi - driving.trip.position_mi
+        assert driving._exit_window_mi() < ahead
+        driving.handle_event(key_event(pygame.K_x))
+
+        assert driving._exit_stop is not None
+        assert driving._exit_stop.type == "delivery_destination"
+        assert "Signaling for" in transcript[-1]
+        assert "No exit coming up" not in "\n".join(transcript)
+        assert stopped_event_speech == [True]
+    finally:
+        app.shutdown()
+
+
+def test_announced_destination_exit_grace_rejects_expired_and_passed_exit(monkeypatch):
+    """The reaction buffer never turns an old or passed announcement into an exit."""
+    from freight_fate.app import App
+
+    app = App()
+    transcript = []
+    monkeypatch.setattr(app.ctx, "say", lambda text, **k: transcript.append(text))
+    monkeypatch.setattr(app.ctx, "say_event", lambda text, **k: transcript.append(text))
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        monkeypatch.setattr(driving.trip, "upcoming_stop", lambda _window: None)
+        driving.trip.time_scale = 40.0
+        driving.truck.velocity_mps = 56.0 / 2.23694
+        destination = driving._destination_exit_stop()
+        driving.trip.position_mi = destination.at_mi - driving._exit_window_mi() + 0.01
+        driving._check_destination_exit()
+
+        driving.truck.velocity_mps = 0.0
+        driving._destination_exit_response_s = 1 / 120
+        driving.update(1 / 60)
+        assert driving._destination_exit_response_s == 0.0
+        assert driving._destination_exit_announced_key == ""
+        driving.handle_event(key_event(pygame.K_x))
+        assert driving._exit_stop is None
+        assert transcript[-1].startswith("No exit coming up")
+
+        # Once the normal window catches up, the destination is announced
+        # again instead of leaving the player with a permanently stale cue.
+        driving.trip.position_mi = destination.at_mi - 4.0
+        driving._check_destination_exit()
+        assert driving._destination_exit_announced_key
+        assert sum("destination exit" in line for line in transcript) == 2
+
+        # Even a live response timer cannot resurrect an exit behind the truck.
+        driving._destination_exit_response_s = 10.0
+        driving.trip.position_mi = destination.at_mi + 0.1
+        monkeypatch.setattr(driving, "_destination_exit_stop", lambda: destination)
+        driving.handle_event(key_event(pygame.K_x))
+        assert driving._exit_stop is None
+        assert transcript[-1].startswith("No exit coming up")
+    finally:
+        app.shutdown()
+
+
+def test_announced_destination_exit_wins_over_nearer_optional_stop(monkeypatch):
+    """X responds to the destination callout, not a newly nearby truck stop."""
+    from freight_fate.app import App
+    from freight_fate.states.driving_core import RoadStop
+
+    app = App()
+    transcript = []
+    monkeypatch.setattr(app.ctx, "say", lambda text, **k: transcript.append(text))
+    monkeypatch.setattr(app.ctx, "say_event", lambda text, **k: transcript.append(text))
+    monkeypatch.setattr(app.ctx, "stop_event_speech", lambda: None)
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        driving.trip.time_scale = 20.0
+        driving.truck.velocity_mps = 54.0 / 2.23694
+        destination = driving._destination_exit_stop()
+        driving.trip.position_mi = destination.at_mi - driving._exit_window_mi() + 0.01
+        nearer_stop = RoadStop(
+            "Nearby Travel Plaza",
+            driving.trip.position_mi + 2.0,
+            "truck_stop",
+            ("fuel", "sleep"),
+        )
+        monkeypatch.setattr(driving.trip, "upcoming_stop", lambda _window: nearer_stop)
+
+        driving._check_destination_exit()
+        driving.truck.velocity_mps = 30.0 / 2.23694
+        driving.handle_event(key_event(pygame.K_x))
+
+        assert driving._exit_stop is not None
+        assert driving._exit_stop.type == "delivery_destination"
+        assert "destination exit" in transcript[-1]
+        assert "Nearby Travel Plaza" not in transcript[-1]
+    finally:
+        app.shutdown()
+
+
 def test_exit_announcements_speak_each_name_once(monkeypatch):
     """Fallback phrasing must not repeat the facility or exit label -- the
     sentence is heard, not read."""

--- a/tests/test_playtest_harness.py
+++ b/tests/test_playtest_harness.py
@@ -227,6 +227,58 @@ def test_realistic_cruise_eases_for_destination_exit_without_speeding_fine(
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("time_scale", "approach_mph"),
+    [(20.0, 54.0), (40.0, 56.0)],
+    ids=["standard", "fast"],
+)
+def test_delayed_x_takes_announced_destination_exit_after_window_shrinks(
+    monkeypatch,
+    time_scale,
+    approach_mph,
+):
+    """Transcript proof for issue #113 using the real pygame X path."""
+    import pygame
+
+    with PlaytestHarness(monkeypatch) as harness:
+        harness.app.ctx.settings.time_scale = time_scale
+        harness.start_route("Chicago", "Indianapolis", trip_seed=0)
+        driving = harness.driving
+        assert driving is not None
+        driving.tutorial = None
+        driving.trip.time_scale = time_scale
+        driving.trip.patrols = []
+        driving.truck.velocity_mps = approach_mph / 2.23694
+        destination = driving._destination_exit_stop()
+        driving.trip.position_mi = destination.at_mi - driving._exit_window_mi() + 0.01
+
+        driving._check_destination_exit()
+        driving.truck.velocity_mps = 30.0 / 2.23694
+        # Give the player five real seconds to hear and react instead of
+        # repeating the former same-frame harness coverage that masked the bug.
+        response_before = driving._destination_exit_response_s
+        for _frame in range(5 * 60):
+            driving.update(1 / 60)
+        assert driving._destination_exit_response_s == pytest.approx(
+            response_before - 5.0,
+            abs=0.05,
+        )
+        assert driving._exit_window_mi() < destination.at_mi - driving.trip.position_mi
+
+        driving.handle_event(key_event(pygame.K_x))
+        result = harness.result
+
+    assert driving._exit_stop is not None
+    assert driving._exit_stop.type == "delivery_destination"
+    assert "destination exit" in result.transcript_text
+    assert "Signaling for" in result.transcript_text
+    assert "No exit coming up" not in result.transcript_text
+    assert "missed the destination exit" not in result.transcript_text.lower()
+    assert driving._cruise_mph is None
+    assert driving._cruise_exit_mph is None
+
+
+@pytest.mark.smoke
 def test_signaled_downhill_exit_keeps_cruise_below_ramp_limit(monkeypatch):
     import pygame
 


### PR DESCRIPTION
## What changed and why

Fixes #113.

Destination-exit speech and X eligibility both recalculated the same speed-dependent approach window. If the truck slowed while the callout was speaking, that window could contract before the player reacted, so the game announced an actionable destination exit and then answered "No exit coming up."

This change gives the exact announced destination exit a keyed 25-second real-time response window. The keyed destination takes priority over nearer optional stops, remains valid only while it is still ahead, and expires cleanly so a closer callout can be announced later. Successful input also stops unfinished event speech before the signaling confirmation. Existing automatic-speed-control behavior is unchanged: the automatic ramp target remains 40 mph, the hard ramp limit remains 45 mph, and control releases on ramp entry.

## What players or maintainers will notice

Players using Standard or Fast trip pacing can finish hearing a destination-exit callout and press X without the exit disappearing because their speed changed. Expired, mismatched, and already-passed exits still cannot be armed.

The player manual now correctly distinguishes the 40 mph automatic target from the 45 mph ramp limit.

## Tests and checks run

- Passed focused issue #113 regression coverage, including Standard at 54 mph and Fast at 56 mph, five real seconds of delayed real pygame X input, timer expiration and closer reannouncement, passed-exit rejection, competing-stop priority, automatic cruise, and downhill ramp entry.
- Passed the complete driving, playtest-harness, controller, player-manual, and release-note test slice.
- Passed 103 smoke tests.
- Passed the complete pytest suite serially on Windows.
- A parallel full run reached the end but four unrelated audio-heavy workers hit Windows `MemoryError`; the serial full rerun passed.
- Passed Ruff, byte compilation, `git diff --check`, and the release-note gate.
- Passed a visible desktop playtest with NVDA main speech and dedicated SAPI event speech: the five-mile exit callout was followed about three seconds later by a real X press, "Signaling for exit 116...", and successful ramp entry, with no "No exit coming up."

## Accessibility impact

Accessibility Agents lead plus ARIA, keyboard, headings/text, forms/input, live-region, contrast, modal, links, and tables specialists reviewed the final delta and returned SHIP with no open findings. Keyboard X and controller D-pad Down continue through the same exit action path. Spoken confirmation replaces the unfinished event callout instead of overlapping it.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`, written in plain player language and matching the style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this PR includes `[skip changelog]`.