### PR TITLE
fix: keep rest-stop arrival cues actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,13 @@
 
 ### Fixed
 
+- **The rest-stop arrival cue now leaves real time to set the brake.** Trip
+  pacing no longer consumes the whole stopping buffer while even a slow voice
+  is still speaking. Terse speech now says "Stop now." If you set the parking
+  brake when the stop announces your arrival, the truck can finish stopping
+  and open the rest-stop menu; continuing past without stopping still misses
+  the stop.
+
 - **Short hauls no longer pay several times more per mile than long ones.**
   A guaranteed minimum meant a fifty mile hop could pay over a thousand
   dollars, four to five times the per-mile rate of a real cross country run,

--- a/src/freight_fate/speech.py
+++ b/src/freight_fate/speech.py
@@ -299,6 +299,11 @@ class Speech:
         return self._any_supports("supports_set_rate")
 
     @property
+    def event_supports_rate(self) -> bool:
+        """Whether the dedicated event voice honors the in-game rate setting."""
+        return self._backend_supports(self._event_backend, "supports_set_rate")
+
+    @property
     def supports_pitch(self) -> bool:
         return self._any_supports("supports_set_pitch")
 

--- a/src/freight_fate/states/driving.py
+++ b/src/freight_fate/states/driving.py
@@ -128,6 +128,7 @@ class DrivingState(
         self._ramp_mi: float | None = None  # ramp distance left, once taken
         self._ramp_stop = None
         self._ramp_end_said = False
+        self._ramp_arrival_grace_s = 0.0
         self._destination_exit_taken = False
         self._missed_destination_exit_said = False
         self._destination_exit_announced_key = ""

--- a/src/freight_fate/states/driving_core.py
+++ b/src/freight_fate/states/driving_core.py
@@ -71,10 +71,15 @@ RAMP_MAX_MPH = 45.0  # any faster and you blow past the exit
 RAMP_CRUISE_TARGET_MPH = 40.0  # leave control-loop headroom below the hard ramp limit
 RAMP_LENGTH_MI = 0.5  # deceleration lane plus ramp to the stop
 # Grace past the end of the ramp before a taken-but-never-stopped exit counts
-# as blown. The driver gets the "come to a complete stop" nudge at the ramp
-# end; roll this much further without stopping and the exit is missed, so the
-# stuck ramp doesn't linger for miles (unpatrolled, off the plan) once passed.
+# as blown. Distance alone is not enough under trip pacing: at 40 mph the same
+# half mile can pass in barely a second, before the driver can hear the arrival
+# cue and set the brake. Require both this distance and a real-time reaction
+# window. A driver who keeps rolling still misses the stop promptly.
 RAMP_OVERSHOOT_MI = 0.5
+RAMP_SPEECH_WPM_MIN = 30.0
+RAMP_SPEECH_WPM_MAX = 60.0
+RAMP_ARRIVAL_REACTION_S = 3.0
+RAMP_ARRIVAL_GRACE_MIN_S = 8.0
 DESTINATION_EXIT_BEFORE_END_MI = 1.0
 # A real interchange counts as the destination exit only inside this final
 # approach window. Routes that finish on rural highways carry no baked
@@ -108,6 +113,21 @@ DOCKING_MAX_MPH = 0.5  # dock/settle/rest actions need a complete stop
 # silence for the rest of the drive (playtest 2026-07-22: six minutes and the
 # on-time bonus lost three miles past a delivery entrance).
 GATE_REMINDER_INTERVAL_S = 10.0
+
+
+def ramp_arrival_grace_seconds(message: str, speech_rate: float = 0.5) -> float:
+    """Conservatively cover the spoken cue plus a real response window.
+
+    Screen-reader speech completion is not observable through every Prism
+    backend, so model a deliberately slow 30-to-60 WPM voice, scaled by the
+    player's event-voice rate, instead of starting a fixed timer when the
+    utterance is merely queued. Once the player sets the parking brake, the stop
+    remains accepted while the truck finishes decelerating.
+    """
+    rate = max(0.0, min(1.0, float(speech_rate)))
+    modeled_wpm = RAMP_SPEECH_WPM_MIN + (RAMP_SPEECH_WPM_MAX - RAMP_SPEECH_WPM_MIN) * rate
+    spoken_seconds = len(message.split()) * 60.0 / modeled_wpm
+    return max(RAMP_ARRIVAL_GRACE_MIN_S, spoken_seconds + RAMP_ARRIVAL_REACTION_S)
 
 
 def terse_hazard_message(message: str) -> str:

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -513,7 +513,7 @@ class DrivingEventMixin:
         self.ctx.audio.play("ui/notify", volume=0.6)
         self.ctx.say_event(f"{name} in {distance}.", interrupt=False)
 
-    def _update_exit(self, moved_mi: float) -> None:
+    def _update_exit(self, moved_mi: float, dt: float = 0.0) -> None:
         """Advance an armed exit or an active ramp; opens the stop menu."""
         if self._ramp_mi is not None:
             self._ramp_mi -= moved_mi
@@ -531,14 +531,52 @@ class DrivingEventMixin:
                     self._open_poi_stop(stop)
                 return
             stop = self._ramp_stop
+            if not self._ramp_end_said:
+                self._ramp_end_said = True
+                if stop.type != "delivery_destination":
+                    place = stop.spoken_name
+                    message = (
+                        f"At {place}. Stop now."
+                        if self._terse_speech()
+                        else f"You are at {place}. Come to a complete stop."
+                    )
+                    speech_rate = (
+                        self.ctx.settings.speech_rate
+                        if self.ctx.settings.sapi_events
+                        and getattr(self.ctx.speech, "event_supports_rate", False)
+                        else 0.0
+                    )
+                    self._ramp_arrival_grace_s = ramp_arrival_grace_seconds(
+                        message,
+                        speech_rate,
+                    )
+                else:
+                    place = stop.name
+                    message = (
+                        f"At {place}."
+                        if self._terse_speech()
+                        else f"You are at {place}. Come to a complete stop."
+                    )
+                self.ctx.say_event(message, interrupt=True)
+                return
+            if stop.type != "delivery_destination":
+                self._ramp_arrival_grace_s = max(0.0, self._ramp_arrival_grace_s - dt)
             # Rolled clear past the end of the ramp without ever stopping. A
             # destination exit keeps waiting (missing it drives its own reroute);
             # a route POI is blown, so give the highway back instead of leaving a
-            # stuck, unpatrolled ramp lingering for miles.
-            if stop.type != "delivery_destination" and self._ramp_mi <= -RAMP_OVERSHOOT_MI:
+            # stuck, unpatrolled ramp lingering for miles. Both the distance and
+            # real-time grace must expire, so trip pacing cannot consume the
+            # player's spoken-cue reaction window.
+            if (
+                stop.type != "delivery_destination"
+                and self._ramp_mi <= -RAMP_OVERSHOOT_MI
+                and self._ramp_arrival_grace_s <= 0.0
+                and not self.truck.parking_brake
+            ):
                 self._ramp_mi = None
                 self._ramp_stop = None
                 self._ramp_end_said = False
+                self._ramp_arrival_grace_s = 0.0
                 planned = self.trip.is_planned(stop)
                 if planned:
                     self.trip.planned_stop_key = None
@@ -556,19 +594,6 @@ class DrivingEventMixin:
                     line += " Plan cancelled."
                 self.ctx.say_event(line, interrupt=True)
                 return
-            if not self._ramp_end_said:
-                self._ramp_end_said = True
-                place = (
-                    self._ramp_stop.name
-                    if self._ramp_stop.type == "delivery_destination"
-                    else self._ramp_stop.spoken_name
-                )
-                message = (
-                    f"At {place}."
-                    if self._terse_speech()
-                    else f"You are at {place}. Come to a complete stop."
-                )
-                self.ctx.say_event(message, interrupt=True)
             return
         stop = self._exit_stop
         if stop is None:
@@ -585,6 +610,7 @@ class DrivingEventMixin:
             self._ramp_mi = RAMP_LENGTH_MI
             self._ramp_stop = stop
             self._ramp_end_said = False
+            self._ramp_arrival_grace_s = 0.0
             self._destination_exit_taken = stop.type == "delivery_destination"
             self._cancel_cruise()
             self._cancel_keeper()

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -166,7 +166,7 @@ class DrivingUpdateMixin:
         for event in self.trip.update(dt):
             self._handle_trip_event(event)
         self._check_destination_exit()
-        self._update_exit(self.trip.last_moved_mi)
+        self._update_exit(self.trip.last_moved_mi, dt)
 
         self._update_hours_and_fatigue(dt)
         self._update_audio(dt)

--- a/tests/test_playtest_harness.py
+++ b/tests/test_playtest_harness.py
@@ -275,6 +275,77 @@ def test_signaled_downhill_exit_keeps_cruise_below_ramp_limit(monkeypatch):
 
 
 @pytest.mark.smoke
+def test_rest_stop_arrival_cue_allows_immediate_parking_brake_stop(monkeypatch):
+    """The spoken arrival point must leave enough real time to stop from 40 mph."""
+    import pygame
+
+    from freight_fate.sim.trip_models import RoadStop
+    from freight_fate.states.driving import RestStopState
+
+    with PlaytestHarness(monkeypatch) as harness:
+        harness.app.ctx.settings.automatic_transmission = True
+        harness.app.ctx.settings.time_scale = 40.0
+        harness.start_route("Chicago", "Indianapolis", trip_seed=0)
+        driving = harness.driving
+        assert driving is not None
+        driving.tutorial = None
+        driving.trip.patrols = []
+        driving.truck.start_engine()
+        driving.truck.set_air_ready(parking_brake=False)
+        driving.truck.transmission.automatic = True
+        driving.truck.transmission.gear = 10
+        driving.truck.velocity_mps = 40.0 / 2.23694
+
+        stop = RoadStop(
+            "Prairie View Rest Area",
+            driving.trip.position_mi + 0.1,
+            actions=("fuel", "break"),
+            parking="confirmed",
+            exit_label="exit 99",
+        )
+        monkeypatch.setattr(driving, "_upcoming_exit_stop", lambda: stop)
+
+        # Use the same real keyboard path as the report: X takes the exit, then
+        # P is pressed as soon as the spoken arrival point is heard.
+        driving.handle_event(key_event(pygame.K_x))
+        driving.trip.position_mi = stop.at_mi
+        for _frame in range(10_000):
+            driving.update(1 / 60)
+            if any(
+                "Prairie View Rest Area. Come to a complete stop." in line
+                for line in harness.result.transcript
+            ):
+                break
+        else:
+            raise AssertionError(
+                f"rest-stop arrival cue never played\n{harness.result.transcript_text}"
+            )
+
+        # Exercise nearly the whole modeled slow-voice-plus-reaction interval.
+        # Once P is pressed, that explicit stop action remains accepted while
+        # the real truck physics finishes the deceleration.
+        reaction_frames = int((driving._ramp_arrival_grace_s - 0.5) * 60)
+        for _frame in range(reaction_frames):
+            driving.update(1 / 60)
+        assert driving._ramp_stop is stop
+        driving.handle_event(key_event(pygame.K_p))
+        for _frame in range(2_000):
+            driving.update(1 / 60)
+            if isinstance(harness.app.state, RestStopState):
+                break
+        else:
+            raise AssertionError(
+                "parking at the spoken arrival point did not open the rest-stop menu\n"
+                f"{harness.result.transcript_text}"
+            )
+
+        transcript = harness.result.transcript_text
+        assert "Parking brake set." in transcript
+        assert "never stopped" not in transcript
+        assert "drove past" not in transcript.lower()
+
+
+@pytest.mark.smoke
 def test_delivery_publication_is_queued_without_spoken_interruption(monkeypatch):
     from freight_fate.online_presence import OnlineIdentity
 

--- a/tests/test_stop_detail.py
+++ b/tests/test_stop_detail.py
@@ -428,6 +428,7 @@ def test_taken_exit_blown_when_never_stopping(monkeypatch):
         d.trip.stops = _stops(d.trip.position_mi)
         stop = d.trip.stops[0]
         d.trip.planned_stop_key = stop.key
+        d.truck.set_air_ready(parking_brake=False)
 
         # Signal and make the ramp: slow enough at the marker, but never stop.
         d._exit_stop = stop
@@ -440,13 +441,80 @@ def test_taken_exit_blown_when_never_stopping(monkeypatch):
         # Roll to the ramp end (nudge) then past it without ever slowing.
         d._update_exit(RAMP_LENGTH_MI)
         assert d.trip.planned_stop_key == stop.key  # still nudging, not blown
-        d._update_exit(RAMP_OVERSHOOT_MI)
+        grace_s = d._ramp_arrival_grace_s
+        d._update_exit(RAMP_OVERSHOOT_MI, grace_s - 0.1)
+        assert d._ramp_stop is stop  # distance alone cannot consume the spoken grace
+        d._update_exit(0.0, 0.2)
 
         assert d._ramp_mi is None
         assert d._ramp_stop is None
         assert d.trip.planned_stop_key is None
         assert "never stopped" in said[-1]
         assert "Plan cancelled." in said[-1]
+    finally:
+        app.shutdown()
+
+
+def test_rest_stop_arrival_grace_scales_for_slow_long_speech():
+    from freight_fate.states.driving_core import (
+        RAMP_ARRIVAL_GRACE_MIN_S,
+        ramp_arrival_grace_seconds,
+    )
+
+    short = ramp_arrival_grace_seconds("At Rest Area. Stop now.")
+    long = ramp_arrival_grace_seconds(
+        "You are at the Northbound Welcome Center and Scenic Travel Plaza. Come to a complete stop."
+    )
+    slowest = ramp_arrival_grace_seconds("At Rest Area. Stop now.", speech_rate=0.0)
+    fastest = ramp_arrival_grace_seconds("At Rest Area. Stop now.", speech_rate=1.0)
+
+    assert short >= RAMP_ARRIVAL_GRACE_MIN_S
+    assert long > short
+    assert slowest > fastest
+
+
+def test_terse_rest_stop_arrival_names_the_stop_action(monkeypatch):
+    from freight_fate.app import App
+    from freight_fate.states.driving_core import RAMP_ARRIVAL_GRACE_MIN_S
+
+    app = App()
+    said = []
+    monkeypatch.setattr(app.ctx, "say_event", lambda text, interrupt=True: said.append(text))
+    try:
+        app.ctx.settings.speech_verbosity = 0
+        d = _driving(app)
+        stop = _stops(d.trip.position_mi)[0]
+        d._ramp_mi = 0.0
+        d._ramp_stop = stop
+        d.truck.velocity_mps = 18.0
+
+        d._update_exit(0.0)
+
+        assert said[-1] == f"At {stop.spoken_name}. Stop now."
+        assert d._ramp_arrival_grace_s >= RAMP_ARRIVAL_GRACE_MIN_S
+    finally:
+        app.shutdown()
+
+
+def test_screen_reader_owned_rate_uses_slowest_arrival_grace(monkeypatch):
+    from freight_fate.app import App
+    from freight_fate.states.driving_core import ramp_arrival_grace_seconds
+
+    app = App()
+    said = []
+    monkeypatch.setattr(app.ctx, "say_event", lambda text, interrupt=True: said.append(text))
+    try:
+        app.ctx.settings.sapi_events = False
+        app.ctx.settings.speech_rate = 1.0  # stale for a screen-reader-owned voice
+        d = _driving(app)
+        stop = _stops(d.trip.position_mi)[0]
+        d._ramp_mi = 0.0
+        d._ramp_stop = stop
+        d.truck.velocity_mps = 18.0
+
+        d._update_exit(0.0)
+
+        assert d._ramp_arrival_grace_s == ramp_arrival_grace_seconds(said[-1], speech_rate=0.0)
     finally:
         app.shutdown()
 


### PR DESCRIPTION
## What changed and why

Fixes #115. Rest-stop ramp overshoot was judged in compressed trip miles, so on fast pacing the half-mile buffer could expire while the arrival cue was still speaking. A player who pressed the parking brake after hearing the cue could be told they never tried to stop.

This change:

- gives ordinary rest stops a real-time response window derived from cue length and speech rate;
- uses the configured rate for controllable SAPI/OneCore event voices and a conservative 30-WPM fallback for screen-reader-owned speech;
- treats setting the parking brake inside that window as a committed stop while the truck finishes decelerating;
- keeps the existing distance and timing consequences for drivers who continue without stopping;
- leaves destination-exit handling unchanged.

## What players or maintainers will notice

At a rest-stop arrival, pressing `P` after the spoken cue now lets the truck finish braking and opens the rest-stop menu instead of immediately reporting an overshoot. Terse speech gives the explicit instruction, “Stop now.” Genuine pass-throughs still cancel the planned stop.

## Tests and checks run

- Passed focused stop-detail, playtest-harness, driving, and speech suites, including real pygame `X` and `P` events at about 40 mph on fast pacing.
- Passed the complete smoke suite serially.
- Passed the full pytest suite with four workers.
- Passed repository-wide Ruff, Python byte-compilation, diff checks, release-note gate, and pre-commit hooks.
- Accessibility Agents final lead review: **SHIP**, with zero remaining findings across desktop, ARIA/AT, keyboard, forms, dynamic announcements, content structure, contrast, modal, table, and link reviews.
- Manual desktop verification was deferred at the user’s request. Transcript tests prove speech dispatch and state behavior; physical NVDA/SAPI utterance completion remains a non-blocking follow-up.

## Accessibility impact

The production keyboard path remains `X` to take the exit and `P` to set the parking brake. Normal and terse speech both name the stop and provide an actionable instruction. The timing model protects slow controllable voices and conservatively handles independently configured screen readers. No visual-only cue, web UI, form, modal, table, or link behavior changed.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`, written in plain player language and matching the existing style.
- [ ] This change is not player-facing, and every commit message includes `[skip changelog]`.