### PR TITLE
Refactor menu speech for review system

### DIFF
--- a/src/freight_fate/states/base.py
+++ b/src/freight_fate/states/base.py
@@ -197,7 +197,8 @@ class MenuState(State):
         self.announce_entry()
 
     def announce_entry(self) -> None:
-        self.ctx.say(f"{end_sentence(self.title)} {self.current_text()}", review=False)
+        self.ctx.say(f"{end_sentence(self.title)}")
+        self.ctx.say(f"{self.current_text()}", interrupt=False, review=False)
 
     def refresh(self, keep_index: bool = True) -> None:
         old = self.index
@@ -213,7 +214,7 @@ class MenuState(State):
         return f"{label} {self.index + 1} of {len(self.items)}."
 
     def speak_current(self) -> None:
-        self.ctx.say(self.current_text())
+        self.ctx.say(self.current_text(), review=False)
 
     def current_help(self) -> str:
         if not self.items:

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -98,8 +98,9 @@ class CityMenuState(MenuState):
         terminal = self.ctx.world.home_terminal(p.current_city)
         self.ctx.say(
             f"Parked at {terminal.spoken_name} in the {city.name} "
-            f"service area, {city.state}. You have {p.money:,.0f} dollars. "
-            f"{self.current_text()}"
+            f"service area, {city.state}. You have {p.money:,.0f} dollars.")
+        self.ctx.say(
+            f"{self.current_text()}", interrupt=False, review=False
         )
 
     def build_items(self) -> list[MenuItem]:

--- a/src/freight_fate/states/city_dispatch.py
+++ b/src/freight_fate/states/city_dispatch.py
@@ -107,8 +107,9 @@ class JobBoardState(MenuState):
             hos_note = self._hos_board_note()
             self.ctx.say(
                 f"Dispatch board. {n} dispatch{'es' if n != 1 else ''} available. "
-                f"{self.ctx.profile.market.summary()} {hos_note}" + self.current_text()
-            )
+                f"{self.ctx.profile.market.summary()} {hos_note}")
+            self.ctx.say(self.current_text(), interrupt=False, review=False)
+
 
     def build_items(self) -> list[MenuItem]:
         items = []

--- a/src/freight_fate/states/main_menu.py
+++ b/src/freight_fate/states/main_menu.py
@@ -192,8 +192,9 @@ class MainMenuState(MenuState):
             )
         self.ctx.say(
             f"Welcome to Freight Fate, version {updater.spoken_version(__version__)}. "
-            f"An audio trucking adventure across America. {warning}"
-            f"{self.current_text()}",
+            f"An audio trucking adventure across America. {warning}")
+        self.ctx.say(
+            f"{self.current_text()}", interrupt=False, review=False
         )
 
     def build_items(self) -> list[MenuItem]:
@@ -494,7 +495,7 @@ class CareerActionsState(MenuState):
 
     def announce_entry(self) -> None:
         self.ctx.say(
-            f"Actions for {_career_summary(self.path, self.profile)}. {self.current_text()}"
+            f"Actions for {_career_summary(self.path, self.profile)}. {self.current_text()}", interrupt=False, review=False
         )
 
     def build_items(self) -> list[MenuItem]:
@@ -549,7 +550,7 @@ class ConfirmCareerActionState(MenuState):
         else:
             detail = "Deleting permanently removes this saved career."
         self.ctx.say(
-            f"Confirm {self._action_label} for {self.profile.name}. {detail} {self.current_text()}"
+            f"Confirm {self._action_label} for {self.profile.name}. {detail} {self.current_text()}", review=False
         )
 
     def build_items(self) -> list[MenuItem]:
@@ -606,16 +607,16 @@ class NameEntryState(State):
         elif event.key == pygame.K_BACKSPACE:
             if self.name:
                 removed, self.name = self.name[-1], self.name[:-1]
-                self.ctx.say(f"Deleted {removed}. " + (self.name or "Empty."))
+                self.ctx.say(f"Deleted {removed}. " + (self.name or "Empty."), review=False)
             else:
                 self.ctx.audio.play("ui/error")
         elif event.key == pygame.K_F2:
-            self.ctx.say(self.name if self.name else "Empty.")
+            self.ctx.say(self.name if self.name else "Empty.", review=False)
         elif event.unicode and event.unicode.isprintable() and len(self.name) < self.MAX_LEN:
             self.name += event.unicode
             self.ctx.audio.play("ui/tick")
             spoken = "space" if event.unicode == " " else event.unicode
-            self.ctx.say(spoken)
+            self.ctx.say(spoken, review=False)
 
     def _confirm(self) -> None:
         name = self.name.strip() or "Driver"
@@ -678,7 +679,8 @@ class HomeTerminalState(MenuState):
     def announce_entry(self) -> None:
         self.ctx.say(
             "Home region. Pick the part of the country where your "
-            f"career starts. {self.current_text()}"
+            "career starts.")
+        self.ctx.say(f"{self.current_text()}", interrupt=False, review=False
         )
 
     def build_items(self) -> list[MenuItem]:
@@ -724,7 +726,8 @@ class HomeCityState(MenuState):
     def announce_entry(self) -> None:
         region = _region_menu_name(self.region)
         self.ctx.say(
-            f"{region} terminals. Pick the city where your career starts. {self.current_text()}"
+            f"{region} terminals. Pick the city where your career starts.")
+        self.ctx.say(f"{self.current_text()}", interrupt=False, review=False
         )
 
     def build_items(self) -> list[MenuItem]:

--- a/tests/test_home_terminal.py
+++ b/tests/test_home_terminal.py
@@ -174,7 +174,7 @@ def test_unreadable_save_is_spoken_and_omitted_from_main_menu(monkeypatch):
         app.push_state(MainMenuState(app.ctx))
         labels = [item.text for item in app.state.items]
         assert labels[0].startswith("Continue latest career: Honest")
-        assert "could not be read" in spoken[-1]
+        assert any("could not be read" in text for text in spoken)
         assert not bad_path.exists()
         assert bad_path.with_suffix(".ffsave.invalid").exists()
     finally:

--- a/tests/test_hos.py
+++ b/tests/test_hos.py
@@ -1333,7 +1333,10 @@ def test_dispatch_board_warns_when_all_generated_jobs_exceed_current_hos(monkeyp
 
         board.announce_entry()
 
-        assert "every listed dispatch would need an extra legal rest" in spoken[-1]
+        assert any(
+            "every listed dispatch would need an extra legal rest" in text
+            for text in spoken
+        )
         for job in jobs:
             board._accept(job)
             assert "Hours warning" in spoken[-1]


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for branch targets,
     test commands, and accessibility expectations. -->

## What changed and why
Menu items and navigation should not be logged in the speech review system. To combat this:
* most utterances of `self.current_text()` pass `review=False`, apart from achievements which users may want to navigate and/or copy for reference.
* `announce_entry` treats entry text and first menu item as two separate speech events in order to prevent the item making it into the speech review history and possibly causing confusion about what option was selected.
* Tests that rely on `spoken[-1]` now iterate through spoken items because of the multi-event refactor.

## What players or maintainers will notice
Players should notice that less garbage is being logged in the review.

Maintainers should notice the code changes listed above.

## Tests and checks run

<!-- e.g. uv run pytest, uv run ruff check src tests tools,
     plus any manual spoken-text or keyboard checks. -->

* uv run pytest
* uv run ruff check src tests tools
* Manual tests for start-of-game menus.


## Accessibility impact

<!-- Every gameplay path must stay usable by keyboard and screen reader.
     Say how you checked spoken text or keyboard flow, or why this change
     has no accessibility impact. -->

Less clutter in the review list.

## Changelog

CI requires a `CHANGELOG.md` entry when user-facing paths (such as `src/`
or `docs/`) change. Check one:

- [ ] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [x] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

### Note
Since this is an extension of the review feature which hasn't yet shipped in release I have treated this as a refactor/internals fix exercise rather than a player facing change.
