### PR TITLE
fix(driving): ACC brakes early for heavy traffic zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,12 @@
   announced and reaches the work-zone limit before the speed keeper takes over,
   so the game no longer fines you while its own controls are still slowing down.
 
+- **Automatic speed control now slows in time for heavy traffic zones.** The
+  same early braking that construction zones already received now applies to
+  heavy traffic zones. When the advance warning sounds, adaptive cruise begins
+  easing down to the posted limit and hands off to the speed keeper at the
+  zone boundary, so the transition is smooth and you enter at the right speed.
+
 - **The rest-stop arrival cue now leaves real time to set the brake.** Trip
   pacing no longer consumes the whole stopping buffer while even a slow voice
   is still speaking. Terse speech now says "Stop now." If you set the parking

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -878,9 +878,9 @@ class DrivingEventMixin:
             if limit < lowest_limit and probe - start <= braking_mi:
                 lowest_limit, lowest_reason = limit, reason
             probe += ACC_LIMIT_LOOKAHEAD_STEP_MI
-        construction_limit = self._construction_limit_ahead()
-        if construction_limit is not None and construction_limit <= lowest_limit:
-            return construction_limit, "construction"
+        restricted = self._restricted_zone_limit_ahead()
+        if restricted is not None and restricted[0] <= lowest_limit:
+            return restricted[0], restricted[1]
         return lowest_limit, lowest_reason
 
     def _update_cruise(
@@ -926,7 +926,11 @@ class DrivingEventMixin:
         # tickets, and trooper stops -- all of which now exist. The "Speed limit X"
         # cue still names the number; this cue says cruise is handling it.
         posted, limit_reason = self._acc_posted_limit_ahead()
-        cap_mph = posted if limit_reason == "construction" else posted + ACC_LIMIT_OFFSET_MPH
+        cap_mph = (
+            posted
+            if limit_reason in {"construction", "heavy traffic"}
+            else posted + ACC_LIMIT_OFFSET_MPH
+        )
         limit_capped = cap_mph < self._cruise_mph
         if limit_capped:
             # Take the lower of the two caps. A posted limit above ramp speed
@@ -934,11 +938,10 @@ class DrivingEventMixin:
             # ramp at the corridor limit.
             target_mph = min(target_mph, cap_mph)
             if not self._acc_limit_capped:
-                reason = (
-                    "Construction zone ahead"
-                    if limit_reason == "construction"
-                    else "Posted limit lower"
-                )
+                reason = {
+                    "construction": "Construction zone ahead",
+                    "heavy traffic": "Heavy traffic ahead",
+                }.get(limit_reason, "Posted limit lower")
                 self.ctx.say_event(
                     f"{reason}; adaptive cruise easing to {self.ctx.settings.speed_text(cap_mph)}.",
                     interrupt=False,

--- a/src/freight_fate/states/driving_speed_control.py
+++ b/src/freight_fate/states/driving_speed_control.py
@@ -99,13 +99,19 @@ class SpeedControlStateMixin:
         else:
             self._disarm_speed_control()
 
-    def _construction_limit_ahead(self) -> float | None:
-        """A lower work-zone limit inside the player's advance-warning window."""
+    def _restricted_zone_limit_ahead(self) -> tuple[float, str] | None:
+        """A lower restricted-zone limit inside the player's advance-warning window.
+
+        Returns ``(limit_mph, zone_reason)`` for the nearest construction or
+        heavy-traffic zone that is closer than the spoken advance-warning
+        distance and whose limit is lower than the current corridor limit.
+        Returns ``None`` when there is nothing to pre-brake for.
+        """
         if not self._speed_control_armed or not self.ctx.settings.speed_keeper:
             return None
         lookahead_mi = self.trip._zone_warning_lookahead_mi()
         zone = self.trip.next_zone_within(lookahead_mi)
-        if zone is None or zone.reason != "construction":
+        if zone is None or zone.reason not in {"construction", "heavy traffic"}:
             return None
         current_limit, _ = self.trip.speed_limit_at(self.trip.position_mi)
-        return zone.limit_mph if zone.limit_mph < current_limit else None
+        return (zone.limit_mph, zone.reason) if zone.limit_mph < current_limit else None

--- a/tests/playtest_harness.py
+++ b/tests/playtest_harness.py
@@ -37,6 +37,7 @@ class PlaytestResult:
     speed_control_transitions: list[str] = field(default_factory=list)
     max_speeding_timer_s: float = 0.0
     construction_entry_speed_mph: float | None = None
+    heavy_traffic_entry_speed_mph: float | None = None
     destination_exit_speed_mph: float | None = None
 
     @property
@@ -244,6 +245,8 @@ class PlaytestHarness:
             _, zone_reason = driving.trip.speed_limit_at(driving.trip.position_mi)
             if zone_reason == "construction" and self.result.construction_entry_speed_mph is None:
                 self.result.construction_entry_speed_mph = driving.truck.speed_mph
+            if zone_reason == "heavy traffic" and self.result.heavy_traffic_entry_speed_mph is None:
+                self.result.heavy_traffic_entry_speed_mph = driving.truck.speed_mph
             if driving.trip.position_mi >= end_mi:
                 break
         else:

--- a/tests/test_playtest_harness.py
+++ b/tests/test_playtest_harness.py
@@ -220,6 +220,22 @@ def test_realistic_speed_control_transitions_do_not_issue_speeding_fines(
         handoff = result.transcript_text.index("Speed keeper holding 45 miles per hour")
         resumed = result.transcript_text.index("Adaptive cruise resuming")
         assert warning < easing < handoff < resumed
+    if zone_reason == "heavy traffic":
+        assert result.heavy_traffic_entry_speed_mph is not None
+        assert result.heavy_traffic_entry_speed_mph <= 50.5
+        assert (
+            result.transcript_text.count(
+                "Heavy traffic ahead; adaptive cruise easing to 50 miles per hour"
+            )
+            == 1
+        )
+        warning = result.transcript_text.index("heavy traffic ahead. Speed limit 50")
+        easing = result.transcript_text.index(
+            "Heavy traffic ahead; adaptive cruise easing to 50 miles per hour"
+        )
+        handoff = result.transcript_text.index("Speed keeper holding 50 miles per hour")
+        resumed = result.transcript_text.index("Adaptive cruise resuming")
+        assert warning < easing < handoff < resumed
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## What changed and why

The `dev` branch already fixes adaptive cruise not braking early enough
for **construction** zones (commit 6a986a73) by adding a lookahead that
starts easing the truck to the work-zone limit when the advance warning
is announced. **Heavy traffic zones** were not receiving the same
treatment: `_construction_limit_ahead()` only matched zones whose
`reason == "construction"`, so ACC kept carrying the driver into heavy
traffic at approximately 55 mph (the 50 mph limit plus the usual 5 mph
offset), without any predictive braking at all.

The fix is a symmetric generalisation:

- Rename `_construction_limit_ahead()` to `_restricted_zone_limit_ahead()`, which now checks both `"construction"` and `"heavy traffic"` zones and returns `(limit_mph, reason) | None`.
- In `_acc_posted_limit_ahead()` consume the new return type.
- In `_update_cruise()` extend the exact-cap (no +5 mph offset) and spoken-cue branches to cover heavy traffic, using `"Heavy traffic ahead; adaptive cruise easing to X"` as the spoken message.

## What players or maintainers will notice

When automatic speed control is armed and a heavy traffic zone approaches,
adaptive cruise now begins easing to 50 mph when the advance warning is
spoken, hands off to the speed keeper at the zone boundary, and resumes
cruise on the open road — exactly the same behaviour construction zones
have had since the previous fix. Players will hear:

1. "In X miles, heavy traffic ahead. Speed limit 50."
2. "Heavy traffic ahead; adaptive cruise easing to 50 miles per hour."
3. (zone entry) "Entering heavy traffic zone. Speed limit 50 now. Speed keeper holding 50 miles per hour."
4. (zone exit) "Open road. Adaptive cruise resuming at …"

## Tests and checks run

- `uv run pytest tests/test_driving_cruise_weather.py tests/test_playtest_harness.py -q` — all passed
- `uv run pytest -q` — full suite passed (one pre-existing xdist timeout flake on `test_mapped_state_lines_are_authoritative` unrelated to this change; passes in isolation)
- `uv run ruff check src tests tools` — no issues

The existing parametrised test `test_realistic_speed_control_transitions_do_not_issue_speeding_fines` already had a `"heavy traffic"` case; this PR adds assertion parity: entry speed ≤ 50.5 mph, correct spoken-message order (warning → easing → keeper handoff → cruise resume), and a `heavy_traffic_entry_speed_mph` field in the playtest harness to record it.

## Accessibility impact

All spoken cues follow the existing pattern: no jargon, no visual-only
information, no symbols. The new "Heavy traffic ahead; adaptive cruise
easing to 50 miles per hour" message is structurally identical to the
construction zone message players already hear. No keyboard flow changes.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.