### PR TITLE
Control state enter/exit behaviour on the stack

### DIFF
--- a/src/freight_fate/app.py
+++ b/src/freight_fate/app.py
@@ -155,17 +155,17 @@ class GameContext:
 
     # -- state stack ------------------------------------------------------------
 
-    def push_state(self, state: State) -> None:
-        self._app.push_state(state)
+    def push_state(self, state: State, should_enter: bool=True) -> None:
+        self._app.push_state(state, should_enter)
 
-    def pop_state(self) -> None:
-        self._app.pop_state()
+    def pop_state(self, should_exit: bool=True, reentry: bool=True) -> None:
+        self._app.pop_state(should_exit, reentry)
 
-    def replace_state(self, state: State) -> None:
-        self._app.replace_state(state)
+    def replace_state(self, state: State, should_exit: bool=True, reentry: bool=True) -> None:
+        self._app.replace_state(state, should_exit, reentry)
 
-    def reset_to(self, state: State) -> None:
-        self._app.reset_to(state)
+    def reset_to(self, state: State, should_exit: bool=True, reentry: bool=True) -> None:
+        self._app.reset_to(state, should_exit, reentry)
 
     def quit(self) -> None:
         self._app.running = False
@@ -410,27 +410,31 @@ class App:
     def state(self) -> State | None:
         return self.states[-1] if self.states else None
 
-    def push_state(self, state: State) -> None:
+    def push_state(self, state: State, should_enter: bool=True) -> None:
         self.states.append(state)
-        state.enter()
+        if should_enter:
+            state.enter()
 
-    def pop_state(self) -> None:
+    def pop_state(self, should_exit: bool=True, reentry: bool=True) -> None:
         if self.states:
-            self.states.pop().exit()
+            state = self.states.pop()
+            if should_exit:
+                state.exit()
         if self.state is not None:
-            self.state.enter()
+            if reentry:
+                self.state.enter()
         else:
             self.running = False
 
-    def replace_state(self, state: State) -> None:
+    def replace_state(self, state: State, should_exit: bool=True, reentry: bool=True) -> None:
         if self.states:
-            self.states.pop().exit()
-        self.push_state(state)
+            self.pop_state(should_exit, False)
+        self.push_state(state, reentry)
 
-    def reset_to(self, state: State) -> None:
+    def reset_to(self, state: State, should_exit: bool=True, reentry: bool=True) -> None:
         while self.states:
-            self.states.pop().exit()
-        self.push_state(state)
+            self.pop_state(should_exit, False)
+        self.push_state(state, reentry)
 
     def _dispatch_controller(self, event: pygame.event.Event) -> None:
         """Feed a controller event to the manager, then to the active state.

--- a/src/freight_fate/states/main_menu.py
+++ b/src/freight_fate/states/main_menu.py
@@ -754,9 +754,9 @@ class HomeCityState(MenuState):
         terminal = self.ctx.world.home_terminal(city)
         self.ctx.profile = profile
         profile.save()
-        self.ctx.pop_state()  # this city picker
-        self.ctx.pop_state()  # region picker
-        self.ctx.pop_state()  # name entry
+        self.ctx.pop_state(True, False)  # this city picker
+        self.ctx.pop_state(True, False)  # region picker
+        self.ctx.pop_state(True, False)  # name entry
         self.ctx.push_state(CityMenuState(self.ctx))
         loaded_over = (
             f"Loaded over existing driver named {name}. " if name.lower() in existing else ""


### PR DESCRIPTION
<!-- Thanks for contributing! See CONTRIBUTING.md for branch targets,
     test commands, and accessibility expectations. -->

## What changed and why
State stack management methods now contain boolean parameters controlling enter/exit behaviour.

This helps to fix the "new career" screen bug where popping all the states cause old states to retrigger several instances of interrupted speech and adding it to the history.

## What players or maintainers will notice
Players will notice a cleaner speech history.

Maintainers will notice the new code. The booleans are optional parameters and retain old behaviour where they are not supplied.

## Tests and checks run

<!-- e.g. uv run pytest, uv run ruff check src tests tools,
     plus any manual spoken-text or keyboard checks. -->

* uv run pytest
* uv run ruff check src tests tools
* Manually tested speech history after moving from new career screen to main game.

## Accessibility impact

<!-- Every gameplay path must stay usable by keyboard and screen reader.
     Say how you checked spoken text or keyboard flow, or why this change
     has no accessibility impact. -->

Biggest impact is a cleaner speech history.

## Changelog

CI requires a `CHANGELOG.md` entry when user-facing paths (such as `src/`
or `docs/`) change. Check one:

- [ ] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [x] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.
