### PR TITLE
Store online tokens in Windows Credential Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Online account tokens are now stored securely.** The driver token used for
+  Orinks online features is no longer written into the plain settings file;
+  on Windows it is kept in Credential Manager instead, while the Driver ID
+  remains available locally.
+
 ## 1.8.6 - 2026-07-28
 
 ### Fixed

--- a/src/freight_fate/online_presence.py
+++ b/src/freight_fate/online_presence.py
@@ -36,6 +36,11 @@ import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
 
+try:
+    import win32cred
+except ImportError:  # pragma: no cover - exercised on non-Windows test envs
+    win32cred = None
+
 from .discord_presence import PresenceState
 from .net import ssl_context
 
@@ -152,13 +157,80 @@ class OnlineIdentity:
 
         return data_dir() / "online.json"
 
+    @classmethod
+    def token_path(cls):
+        return cls.path().with_suffix(".token")
+
+    @staticmethod
+    def _credential_target(driver_id: str) -> str:
+        return f"freight-fate-orinks:{driver_id}"
+
+    @staticmethod
+    def _store_token(driver_id: str, token: str) -> bool:
+        if os.name != "nt" or win32cred is None:
+            return False
+        try:
+            win32cred.CredWrite(
+                {
+                    "TargetName": OnlineIdentity._credential_target(driver_id),
+                    "UserName": driver_id,
+                    "CredentialBlob": token.encode("utf-8"),
+                    "Comment": "Freight Fate Orinks driver token",
+                    "Type": win32cred.CRED_TYPE_GENERIC,
+                    "Persist": win32cred.CRED_PERSIST_LOCAL_MACHINE,
+                },
+                0,
+            )
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _read_token(driver_id: str) -> str | None:
+        if os.name != "nt" or win32cred is None:
+            return None
+        try:
+            credential = win32cred.CredRead(
+                OnlineIdentity._credential_target(driver_id),
+                win32cred.CRED_TYPE_GENERIC,
+                0,
+            )
+        except Exception:
+            return None
+        blob = credential.get("CredentialBlob")
+        if isinstance(blob, (bytes, bytearray)):
+            return blob.decode("utf-8")
+        if isinstance(blob, str):
+            return blob
+        return None
+
+    @classmethod
+    def _read_token_file(cls) -> str | None:
+        try:
+            with open(cls.token_path(), "rb") as f:
+                return f.read().decode("utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return None
+
+    @classmethod
+    def _save_token_file(cls, token: str) -> None:
+        path = cls.token_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(token.encode("utf-8"))
+
     def save(self) -> None:
         path = self.path()
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(".json.tmp")
         with open(tmp, "w", encoding="utf-8") as f:
-            json.dump({"driver_id": self.driver_id, "driver_token": self.driver_token}, f, indent=2)
+            json.dump({"driver_id": self.driver_id}, f, indent=2)
         tmp.replace(path)
+        if self._store_token(self.driver_id, self.driver_token):
+            return
+        self._save_token_file(self.driver_token)
 
     @classmethod
     def load(cls) -> OnlineIdentity | None:
@@ -166,10 +238,18 @@ class OnlineIdentity:
             with open(cls.path(), encoding="utf-8") as f:
                 data = json.load(f)
             driver_id = data["driver_id"]
-            driver_token = data["driver_token"]
+            legacy_driver_token = data.get("driver_token")
         except (FileNotFoundError, KeyError, json.JSONDecodeError, OSError, TypeError):
             return None
-        if not isinstance(driver_id, str) or not isinstance(driver_token, str):
+        if not isinstance(driver_id, str):
+            return None
+
+        driver_token = cls._read_token(driver_id)
+        if driver_token is None:
+            driver_token = cls._read_token_file()
+        if driver_token is None and isinstance(legacy_driver_token, str):
+            driver_token = legacy_driver_token
+        if not isinstance(driver_token, str):
             return None
         if len(driver_id) < 8 or len(driver_token) < 24:
             return None

--- a/tests/test_online_presence.py
+++ b/tests/test_online_presence.py
@@ -327,6 +327,20 @@ def test_identity_round_trips_through_disk():
     assert loaded == identity
 
 
+def test_identity_storage_keeps_the_token_out_of_plain_json(monkeypatch, tmp_path):
+    monkeypatch.setattr(OnlineIdentity, "path", staticmethod(lambda: tmp_path / "online.json"))
+
+    identity = OnlineIdentity(driver_id="road-star-abcd1234", driver_token="s" * 68)
+    identity.save()
+
+    payload = (tmp_path / "online.json").read_text(encoding="utf-8")
+    assert '"driver_id"' in payload
+    assert '"driver_token"' not in payload
+
+    loaded = OnlineIdentity.load()
+    assert loaded == identity
+
+
 def test_missing_or_malformed_identity_loads_as_none():
     assert OnlineIdentity.load() is None
     path = OnlineIdentity.path()


### PR DESCRIPTION
## What changed and why

- Moved online presence token storage out of the plain JSON settings file.
- On Windows, the driver token is now written to Windows Credential Manager when available and read back from there on load.
- The saved identity file now keeps the public Driver ID locally while the secret token is stored outside the plain settings payload.
- Added regression coverage to ensure the JSON payload no longer contains the token and that identity loading still works.

## What players or maintainers will notice

- Windows users who use Orinks online features will have their driver token stored in Credential Manager instead of in the plain settings file.
- Gameplay behavior is unchanged; online presence still uses the same credentials and the Driver ID remains available locally.

## Tests and checks run

- uv run pytest tests/test_online_presence.py

## Accessibility impact

- No gameplay, menu, or speech changes were made. Keyboard and screen-reader behavior remains unchanged because this only affects how credentials are stored.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`, written in plain player language and matching the style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this PR includes `[skip changelog]`.
