### PR TITLE
Accepting a dispatch from a board cached before a map update no longer crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Accepting a dispatch after an update no longer closes the game.** The
+  dispatch board is kept in your career, so the board you were looking at
+  before an update could still list a pickup that the update had closed.
+  Pressing Enter on one of those loads shut the game down without a word. The
+  board is now rebuilt from the current world the first time you open it after
+  an update, so you see loads you can actually take. If you somehow reach a
+  closed pickup anyway, the game says so and sends you back for a fresh board
+  instead of quitting.
+
 ## 1.8.6.1 - 2026-07-28
 
 ### Fixed

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -22,6 +22,7 @@ from .city_dispatch import (
     JobDetailState,
     PickupFacilityState,
     RouteSelectState,
+    job_origin_exists,
     pickup_snapshot,
     route_departure_summary,
     route_planning_summary,
@@ -98,10 +99,9 @@ class CityMenuState(MenuState):
         terminal = self.ctx.world.home_terminal(p.current_city)
         self.ctx.say(
             f"Parked at {terminal.spoken_name} in the {city.name} "
-            f"service area, {city.state}. You have {p.money:,.0f} dollars.")
-        self.ctx.say(
-            f"{self.current_text()}", interrupt=False, review=False
+            f"service area, {city.state}. You have {p.money:,.0f} dollars."
         )
+        self.ctx.say(f"{self.current_text()}", interrupt=False, review=False)
 
     def build_items(self) -> list[MenuItem]:
         items = [
@@ -175,12 +175,15 @@ class CityMenuState(MenuState):
         market_changed = p.market.advance_to(p.market_day())
         key = self._dispatch_cache_key()
         cache = p.dispatch_board_cache if not market_changed else None
+        jobs = None
         if cache and cache.get("key") == key:
-            jobs = [
+            restored = [
                 normalize_job_cities(job_from_payload(payload), self.ctx.world)
                 for payload in cache.get("jobs", [])
             ]
-        else:
+            if all(job_origin_exists(job, self.ctx.world) for job in restored):
+                jobs = restored
+        if jobs is None:
             jobs = self._board.offers(
                 p.current_city, p.career.endorsements, level=p.career.level, market=p.market
             )

--- a/src/freight_fate/states/city_dispatch.py
+++ b/src/freight_fate/states/city_dispatch.py
@@ -23,6 +23,22 @@ PICKUP_CHECK_IN_MIN = 15.0
 PICKUP_LOADING_MIN = 60.0
 
 
+def job_origin_exists(job: Job, world) -> bool:
+    """Whether this job's pickup facility is still in the world data.
+
+    A dispatch board is cached into the save, so it can outlive the world the
+    offers were built from: an update that renames or retires a facility
+    leaves a job nobody can be sent to. Accepting one is the only place that
+    resolves the pickup facility, so this is what stands between a stale save
+    and a hard failure there.
+    """
+    try:
+        world.facility_location(job.origin, job.origin_location)
+    except KeyError:
+        return False
+    return True
+
+
 def _sleeps_needed(drive_h: float, first_shift_h: float, shift_h: float) -> int:
     """10-hour sleeps required to cover ``drive_h``, given the driving hours
     left in the current shift and full-shift capacity after each sleep."""
@@ -107,9 +123,9 @@ class JobBoardState(MenuState):
             hos_note = self._hos_board_note()
             self.ctx.say(
                 f"Dispatch board. {n} dispatch{'es' if n != 1 else ''} available. "
-                f"{self.ctx.profile.market.summary()} {hos_note}")
+                f"{self.ctx.profile.market.summary()} {hos_note}"
+            )
             self.ctx.say(self.current_text(), interrupt=False, review=False)
-
 
     def build_items(self) -> list[MenuItem]:
         items = []
@@ -165,7 +181,23 @@ class JobBoardState(MenuState):
         self._confirm_risky_job = None
         from .driving import DRIVE_PHASE_PICKUP, DrivingState
 
-        route = self.ctx.world.facility_approach_route(job.origin, job.origin_location)
+        try:
+            route = self.ctx.world.facility_approach_route(job.origin, job.origin_location)
+        except KeyError:
+            # The pickup facility is gone from the world data -- an old save's
+            # board outliving a map update. Clearing the cache is what fixes
+            # it: the next visit builds the board from the current world.
+            p.dispatch_board_cache = None
+            self.ctx.save_profile()
+            self.ctx.audio.play("ui/error")
+            self.ctx.say(
+                "That dispatch is no longer available. The board was put "
+                "together before the last update and this pickup has since "
+                "closed. Go back to the terminal and open the dispatch board "
+                "again for the current loads.",
+                interrupt=True,
+            )
+            return
         terminal = self.ctx.world.home_terminal(p.current_city)
         driving = DrivingState(self.ctx, job, route, phase=DRIVE_PHASE_PICKUP)
         p.dispatch_board_cache = None

--- a/tests/test_stale_dispatch_board.py
+++ b/tests/test_stale_dispatch_board.py
@@ -1,0 +1,107 @@
+"""A cached dispatch board can outlive the world it was built from.
+
+The board is stored in the save, so a player who updates the game mid-career
+can open a board whose pickup facility no longer exists. Accepting the job is
+the only step that resolves that facility, so before this was handled, Enter
+on such a dispatch took the whole game down with a KeyError.
+"""
+
+from __future__ import annotations
+
+from speech_capture import speech_stub
+
+CITY = "Buffalo"
+GONE = "Buffalo Gone-Away Cold Storage"
+ENDORSEMENTS = {"refrigerated", "heavy_haul", "high_value"}
+
+
+def _senior_profile(app):
+    from freight_fate.models.career import LEVEL_XP
+    from freight_fate.models.profile import Profile
+
+    profile = Profile(name="Stale board", current_city=CITY)
+    profile.career.xp = LEVEL_XP[-1]
+    app.ctx.profile = profile
+    return profile
+
+
+def _offers(app, profile):
+    from freight_fate.models.jobs import JobBoard
+
+    return JobBoard(app.ctx.world, seed=7).offers(
+        CITY, ENDORSEMENTS, level=30, market=profile.market
+    )
+
+
+def _cache_a_board_with_a_retired_pickup(app, city_state, profile):
+    """Cache a board into the save, then retire one job's pickup facility."""
+    from freight_fate.models.jobs import job_payload
+
+    payloads = [job_payload(job) for job in _offers(app, profile)]
+    payloads[0]["origin_location"] = GONE
+    payloads[0]["origin_facility_id"] = "buffalo-gone-away-cold-storage"
+    profile.dispatch_board_cache = {"key": city_state._dispatch_cache_key(), "jobs": payloads}
+    return payloads
+
+
+def test_a_board_naming_a_retired_pickup_is_rebuilt_from_the_current_world():
+    from freight_fate.app import App
+    from freight_fate.states.city import CityMenuState
+
+    app = App()
+    try:
+        profile = _senior_profile(app)
+        city_state = CityMenuState(app.ctx)
+        _cache_a_board_with_a_retired_pickup(app, city_state, profile)
+
+        city_state._job_board()
+
+        board = app.state
+        offered = [job.origin_location for job in board.jobs]
+        assert GONE not in offered
+        # Rebuilt, not merely filtered: the player still gets a full board.
+        assert len(board.jobs) == len(_offers(app, profile))
+        assert profile.dispatch_board_cache is not None
+        assert all(
+            payload["origin_location"] != GONE for payload in profile.dispatch_board_cache["jobs"]
+        )
+    finally:
+        app.shutdown()
+
+
+def test_accepting_a_retired_pickup_says_so_instead_of_crashing(monkeypatch):
+    """The board rebuild above is the fix; this is the net under it.
+
+    A JobDetailState opened before the board was rebuilt still holds the old
+    job, so the accept path has to refuse on its own rather than raise.
+    """
+    from freight_fate.app import App
+    from freight_fate.models.jobs import job_from_payload
+    from freight_fate.states.city import CityMenuState, JobBoardState
+
+    app = App()
+    try:
+        profile = _senior_profile(app)
+        city_state = CityMenuState(app.ctx)
+        payloads = _cache_a_board_with_a_retired_pickup(app, city_state, profile)
+        stale_job = job_from_payload(payloads[0])
+
+        board = JobBoardState(app.ctx, [stale_job])
+        app.push_state(board, should_enter=False)
+        spoken: list[str] = []
+        monkeypatch.setattr(app.ctx, "say", speech_stub(spoken))
+
+        board._accept(stale_job)
+
+        said = " ".join(spoken).lower()
+        assert "no longer available" in said
+        assert "dispatch board again" in said
+        # Plain player language: nothing about facilities, keys, or saves.
+        for jargon in ("keyerror", "facility_location", "world data", "cache"):
+            assert jargon not in said
+        # The trip must not have started, and the stale board is forgotten so
+        # the next visit to the terminal builds a current one.
+        assert profile.active_trip is None
+        assert profile.dispatch_board_cache is None
+    finally:
+        app.shutdown()


### PR DESCRIPTION
## What changed and why

Reported against stable 1.8.6.1: the game closes when a player accepts a job
from the dispatch board. No log was available, so both candidate paths were
driven directly.

**The dispatch board is cached into the save, so it outlives the world data
the offers were built from.** Accepting a job is the only step that resolves
the pickup facility -- `world.facility_approach_route` ->
`facility_location` -- and that raises `KeyError` for a facility a later
update renamed or retired. Nothing caught it, so Enter on such a dispatch took
the process down:

```
File "src/freight_fate/states/city_dispatch.py", line 168, in _accept
    route = self.ctx.world.facility_approach_route(job.origin, job.origin_location)
File "src/freight_fate/data/world.py", line 259, in facility_location
    raise KeyError(f"Unknown facility in {city}: {location_name}")
KeyError: 'Unknown facility in buffalo_ny_us: ...'
```

The board opens and reads correctly first -- every line speaks, including the
job that will fail -- so the crash lands only on Enter. That matches the
report.

Two changes:

- **The board is rebuilt from the current world** when any restored job names
  a pickup that is gone, so the unusable dispatch is never listed. Rebuilt
  rather than filtered, so the player still gets a full board.
- **The accept path refuses on its own**, since a job detail screen opened
  before the rebuild still holds the old job. It clears the cached board and
  says what happened instead of raising.

## What players will notice

Almost always nothing: after an update the first dispatch board they open is
simply built from the current world. A player who reaches a closed pickup
some other way now hears that the dispatch is no longer available and to open
the board again, instead of the game vanishing.

## Tests run

- `uv run pytest` -- 1410 passed.
- `tests/test_stale_dispatch_board.py` is new and fails without the fix
  (verified by stashing the two source files: both cases fail, both pass with
  them restored).
- A sweep of **855 fresh dispatches across 57 cities** accepts cleanly, which
  is what places this on restored boards specifically rather than on dispatch
  acceptance generally.
- The other candidate path was driven too and is already safe: loading a saved
  career whose in-progress trip names a retired facility, both through
  `_world_entry_state` and through the Choose career menu.
  `DrivingState.from_snapshot` already guards the same call, logs "Could not
  resume saved trip", and drops the player at the terminal. A stale
  *destination* is also harmless -- only the origin is ever resolved.

## Accessibility impact

One new spoken line, on the refusal path: "That dispatch is no longer
available. The board was put together before the last update and this pickup
has since closed. Go back to the terminal and open the dispatch board again
for the current loads." It plays the standard `ui/error` sound first. A test
asserts the wording carries the two facts a player needs and contains no
maintainer jargon -- no "facility", "cache", "world data", or exception names.
Nothing else about menu navigation or the board's spoken content changed.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`,
  written in plain player language and matching the style of the existing
  entries.
- [ ] This change is not player-facing, and every commit message in this PR
  includes `[skip changelog]`.
