### PR TITLE
Hotfix 1.8.6.2: accepting a dispatch after an update no longer crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Accepting a dispatch after an update no longer closes the game.** The
+  dispatch board is kept in your career, so the board you were looking at
+  before an update could still list a pickup that the update had closed.
+  Pressing Enter on one of those loads shut the game down without a word. The
+  board is now rebuilt from the current world the first time you open it after
+  an update, so you see loads you can actually take. If you somehow reach a
+  closed pickup anyway, the game says so and sends you back for a fresh board
+  instead of quitting.
+
 ## 1.8.6.1 - 2026-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.8.6.2 - 2026-07-29
+
 ### Fixed
 
 - **Accepting a dispatch after an update no longer closes the game.** The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freight-fate"
-version = "1.8.6.1"
+version = "1.8.6.2"
 description = "An accessible, audio-first cross-country trucking simulation game"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -22,6 +22,7 @@ from .city_dispatch import (
     JobDetailState,
     PickupFacilityState,
     RouteSelectState,
+    job_origin_exists,
     pickup_snapshot,
     route_departure_summary,
     route_planning_summary,
@@ -98,10 +99,9 @@ class CityMenuState(MenuState):
         terminal = self.ctx.world.home_terminal(p.current_city)
         self.ctx.say(
             f"Parked at {terminal.spoken_name} in the {city.name} "
-            f"service area, {city.state}. You have {p.money:,.0f} dollars.")
-        self.ctx.say(
-            f"{self.current_text()}", interrupt=False, review=False
+            f"service area, {city.state}. You have {p.money:,.0f} dollars."
         )
+        self.ctx.say(f"{self.current_text()}", interrupt=False, review=False)
 
     def build_items(self) -> list[MenuItem]:
         items = [
@@ -175,12 +175,15 @@ class CityMenuState(MenuState):
         market_changed = p.market.advance_to(p.market_day())
         key = self._dispatch_cache_key()
         cache = p.dispatch_board_cache if not market_changed else None
+        jobs = None
         if cache and cache.get("key") == key:
-            jobs = [
+            restored = [
                 normalize_job_cities(job_from_payload(payload), self.ctx.world)
                 for payload in cache.get("jobs", [])
             ]
-        else:
+            if all(job_origin_exists(job, self.ctx.world) for job in restored):
+                jobs = restored
+        if jobs is None:
             jobs = self._board.offers(
                 p.current_city, p.career.endorsements, level=p.career.level, market=p.market
             )

--- a/src/freight_fate/states/city_dispatch.py
+++ b/src/freight_fate/states/city_dispatch.py
@@ -23,6 +23,22 @@ PICKUP_CHECK_IN_MIN = 15.0
 PICKUP_LOADING_MIN = 60.0
 
 
+def job_origin_exists(job: Job, world) -> bool:
+    """Whether this job's pickup facility is still in the world data.
+
+    A dispatch board is cached into the save, so it can outlive the world the
+    offers were built from: an update that renames or retires a facility
+    leaves a job nobody can be sent to. Accepting one is the only place that
+    resolves the pickup facility, so this is what stands between a stale save
+    and a hard failure there.
+    """
+    try:
+        world.facility_location(job.origin, job.origin_location)
+    except KeyError:
+        return False
+    return True
+
+
 def _sleeps_needed(drive_h: float, first_shift_h: float, shift_h: float) -> int:
     """10-hour sleeps required to cover ``drive_h``, given the driving hours
     left in the current shift and full-shift capacity after each sleep."""
@@ -107,9 +123,9 @@ class JobBoardState(MenuState):
             hos_note = self._hos_board_note()
             self.ctx.say(
                 f"Dispatch board. {n} dispatch{'es' if n != 1 else ''} available. "
-                f"{self.ctx.profile.market.summary()} {hos_note}")
+                f"{self.ctx.profile.market.summary()} {hos_note}"
+            )
             self.ctx.say(self.current_text(), interrupt=False, review=False)
-
 
     def build_items(self) -> list[MenuItem]:
         items = []
@@ -165,7 +181,23 @@ class JobBoardState(MenuState):
         self._confirm_risky_job = None
         from .driving import DRIVE_PHASE_PICKUP, DrivingState
 
-        route = self.ctx.world.facility_approach_route(job.origin, job.origin_location)
+        try:
+            route = self.ctx.world.facility_approach_route(job.origin, job.origin_location)
+        except KeyError:
+            # The pickup facility is gone from the world data -- an old save's
+            # board outliving a map update. Clearing the cache is what fixes
+            # it: the next visit builds the board from the current world.
+            p.dispatch_board_cache = None
+            self.ctx.save_profile()
+            self.ctx.audio.play("ui/error")
+            self.ctx.say(
+                "That dispatch is no longer available. The board was put "
+                "together before the last update and this pickup has since "
+                "closed. Go back to the terminal and open the dispatch board "
+                "again for the current loads.",
+                interrupt=True,
+            )
+            return
         terminal = self.ctx.world.home_terminal(p.current_city)
         driving = DrivingState(self.ctx, job, route, phase=DRIVE_PHASE_PICKUP)
         p.dispatch_board_cache = None

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -435,3 +435,53 @@ def test_build_workflow_uses_curated_nightly_decision_and_notes():
     assert "--exclude-stable-notes latest-stable-notes.md" in workflow
     assert "tools/release_notes.py nightly" in workflow
     assert 'git diff --name-only "$LAST_TAG"..HEAD' not in workflow
+
+
+def test_auto_base_follows_the_release_line_the_branch_was_cut_from(tmp_path, monkeypatch):
+    """A hotfix is cut from main and never contains dev.
+
+    Resolving its base to dev counted dev's bullets as already present and
+    rejected the push over a changelog entry that was right there -- which is
+    what the 1.8.6.2 hotfix hit. Ancestry cannot decide it either, since the
+    two lines each carry commits the other does not.
+    """
+    release_notes = load_release_notes_module()
+    repo = make_repo(tmp_path, changelog("- Seed entry."))
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+    seed = git(repo, "rev-parse", "HEAD")  # git init's branch name varies
+    # dev moves ahead of main, as it always is between releases...
+    git(repo, "checkout", "-q", "-b", "dev")
+    for n in range(4):
+        (repo / f"dev{n}.txt").write_text("dev work\n", encoding="utf-8")
+        commit(repo, f"feat: dev only {n}")
+    git(repo, "update-ref", "refs/remotes/origin/dev", "HEAD")
+
+    # ...and main carries release commits of its own that dev never sees, so
+    # neither branch contains the other. That is the shape this has to read.
+    git(repo, "checkout", "-q", "-b", "stable-line", seed)
+    (repo / "release.txt").write_text("1.0\n", encoding="utf-8")
+    commit(repo, "release: 1.0")
+    git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    git(repo, "checkout", "-q", "-b", "hotfix/1.0.1", "refs/remotes/origin/main")
+    (repo / "fix.txt").write_text("hotfix\n", encoding="utf-8")
+    commit(repo, "fix: stable only")
+    assert release_notes.nearest_release_line() == "origin/main"
+    assert release_notes.resolve_base("auto") == "origin/main"
+
+    # An ordinary branch off dev still resolves to dev...
+    git(repo, "checkout", "-q", "-b", "feat/thing", "refs/remotes/origin/dev")
+    (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+    commit(repo, "feat: a feature")
+    assert release_notes.nearest_release_line() == "origin/dev"
+
+    # ...and still does once dev has moved on without it.
+    git(repo, "checkout", "-q", "dev")
+    (repo / "more.txt").write_text("more dev work\n", encoding="utf-8")
+    commit(repo, "feat: more dev")
+    git(repo, "update-ref", "refs/remotes/origin/dev", "HEAD")
+    git(repo, "checkout", "-q", "feat/thing")
+    assert release_notes.nearest_release_line() == "origin/dev"
+
+    # An explicit base is never second-guessed.
+    assert release_notes.resolve_base("origin/main") == "origin/main"

--- a/tests/test_stale_dispatch_board.py
+++ b/tests/test_stale_dispatch_board.py
@@ -1,0 +1,107 @@
+"""A cached dispatch board can outlive the world it was built from.
+
+The board is stored in the save, so a player who updates the game mid-career
+can open a board whose pickup facility no longer exists. Accepting the job is
+the only step that resolves that facility, so before this was handled, Enter
+on such a dispatch took the whole game down with a KeyError.
+"""
+
+from __future__ import annotations
+
+from speech_capture import speech_stub
+
+CITY = "Buffalo"
+GONE = "Buffalo Gone-Away Cold Storage"
+ENDORSEMENTS = {"refrigerated", "heavy_haul", "high_value"}
+
+
+def _senior_profile(app):
+    from freight_fate.models.career import LEVEL_XP
+    from freight_fate.models.profile import Profile
+
+    profile = Profile(name="Stale board", current_city=CITY)
+    profile.career.xp = LEVEL_XP[-1]
+    app.ctx.profile = profile
+    return profile
+
+
+def _offers(app, profile):
+    from freight_fate.models.jobs import JobBoard
+
+    return JobBoard(app.ctx.world, seed=7).offers(
+        CITY, ENDORSEMENTS, level=30, market=profile.market
+    )
+
+
+def _cache_a_board_with_a_retired_pickup(app, city_state, profile):
+    """Cache a board into the save, then retire one job's pickup facility."""
+    from freight_fate.models.jobs import job_payload
+
+    payloads = [job_payload(job) for job in _offers(app, profile)]
+    payloads[0]["origin_location"] = GONE
+    payloads[0]["origin_facility_id"] = "buffalo-gone-away-cold-storage"
+    profile.dispatch_board_cache = {"key": city_state._dispatch_cache_key(), "jobs": payloads}
+    return payloads
+
+
+def test_a_board_naming_a_retired_pickup_is_rebuilt_from_the_current_world():
+    from freight_fate.app import App
+    from freight_fate.states.city import CityMenuState
+
+    app = App()
+    try:
+        profile = _senior_profile(app)
+        city_state = CityMenuState(app.ctx)
+        _cache_a_board_with_a_retired_pickup(app, city_state, profile)
+
+        city_state._job_board()
+
+        board = app.state
+        offered = [job.origin_location for job in board.jobs]
+        assert GONE not in offered
+        # Rebuilt, not merely filtered: the player still gets a full board.
+        assert len(board.jobs) == len(_offers(app, profile))
+        assert profile.dispatch_board_cache is not None
+        assert all(
+            payload["origin_location"] != GONE for payload in profile.dispatch_board_cache["jobs"]
+        )
+    finally:
+        app.shutdown()
+
+
+def test_accepting_a_retired_pickup_says_so_instead_of_crashing(monkeypatch):
+    """The board rebuild above is the fix; this is the net under it.
+
+    A JobDetailState opened before the board was rebuilt still holds the old
+    job, so the accept path has to refuse on its own rather than raise.
+    """
+    from freight_fate.app import App
+    from freight_fate.models.jobs import job_from_payload
+    from freight_fate.states.city import CityMenuState, JobBoardState
+
+    app = App()
+    try:
+        profile = _senior_profile(app)
+        city_state = CityMenuState(app.ctx)
+        payloads = _cache_a_board_with_a_retired_pickup(app, city_state, profile)
+        stale_job = job_from_payload(payloads[0])
+
+        board = JobBoardState(app.ctx, [stale_job])
+        app.push_state(board, should_enter=False)
+        spoken: list[str] = []
+        monkeypatch.setattr(app.ctx, "say", speech_stub(spoken))
+
+        board._accept(stale_job)
+
+        said = " ".join(spoken).lower()
+        assert "no longer available" in said
+        assert "dispatch board again" in said
+        # Plain player language: nothing about facilities, keys, or saves.
+        for jargon in ("keyerror", "facility_location", "world data", "cache"):
+            assert jargon not in said
+        # The trip must not have started, and the stale board is forgotten so
+        # the next visit to the terminal builds a current one.
+        assert profile.active_trip is None
+        assert profile.dispatch_board_cache is None
+    finally:
+        app.shutdown()

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -305,7 +305,33 @@ def current_branch() -> str:
 def resolve_base(base: str) -> str:
     if base != "auto":
         return base
-    return "origin/main" if current_branch() == "main" else "origin/dev"
+    if current_branch() == "main":
+        return "origin/main"
+    return nearest_release_line()
+
+
+def nearest_release_line() -> str:
+    """Which release line the current branch was cut from.
+
+    Feature and fix branches sit on dev, but a hotfix is cut from main and
+    never contains dev -- so comparing it against dev counts dev's bullets as
+    already present and rejects the push over a changelog entry that is right
+    there. This is measured as the nearest branch point rather than plain
+    ancestry, because main is an ancestor of dev as well: ancestry alone would
+    send every dev branch that has fallen behind to main instead.
+    """
+    candidates = []
+    for ref in ("origin/dev", "origin/main"):
+        try:
+            counts = run_git(["rev-list", "--count", "--left-right", f"{ref}...HEAD"])
+        except Exception:
+            continue  # a clone without that remote branch
+        # Both sides of the divergence, not just ours: a hotfix is zero
+        # commits behind main and a long way behind dev, which is the whole
+        # signal. Counting only our own side would call those two the same.
+        candidates.append((sum(int(n) for n in counts.split()), ref))
+    # Ties favour dev, which sorts first and is where ordinary work belongs.
+    return min(candidates)[1] if candidates else "origin/dev"
 
 
 def ref_is_ancestor(ancestor: str, descendant: str) -> bool:

--- a/uv.lock
+++ b/uv.lock
@@ -449,7 +449,7 @@ wheels = [
 
 [[package]]
 name = "freight-fate"
-version = "1.8.6.1"
+version = "1.8.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
Hotfix onto stable. Carries **only** the dispatch-board crash fix (from
[PR #137](https://github.com/Orinks/Freight-Fate/pull/137), already on `dev`).
The keyring and pause-menu work that landed on `dev` today stays there for
1.8.7.

## What was wrong

The dispatch board is cached into the save, so it outlives the world data its
offers were built from. Accepting a job is the only step that resolves the
pickup facility, and that raises `KeyError` for a facility a later update
renamed or retired. Nothing caught it, so Enter on such a dispatch took the
process down.

The board opens and reads out perfectly first -- every line speaks, including
the job that will fail -- so it presents as the accept itself. A player who
updated mid-career hits it on the first board they open.

## What players get

The board is rebuilt from the current world when a restored job names a pickup
that is gone, so the unusable dispatch is never listed and the board is still
full. If a closed pickup is reached another way, the game says so in plain
speech and sends the player back for a fresh board instead of quitting.

## Also in here: the changelog gate

Pushing this branch was refused by the pre-push release-note gate. It resolved
`--base auto` to `origin/dev` for any branch not literally named `main`, so a
hotfix cut from `main` was measured against `dev` -- where this bullet already
was, the fix having landed there first -- and counted as adding nothing. It now
resolves to whichever release line the branch was actually cut from.

Ancestry can't decide that here, because the two lines each carry commits the
other doesn't: release commits live only on `main`. It measures total
divergence from each candidate instead. Covered by a new test that models that
shape, including a `dev` branch that has fallen behind.

This is maintainer tooling, so it carries `[skip changelog]` and is invisible
to players. It rides along because it is release tooling that was blocking a
release.

## Tests

- `uv run pytest` -- 1405 passed on this branch.
- `tests/test_stale_dispatch_board.py` is new and was verified to fail without
  the two source changes.
- A sweep of 855 fresh dispatches across 57 cities accepts cleanly, which
  places this on restored boards specifically rather than on dispatch
  acceptance generally.
- The other candidate path was driven too and is already safe: loading a saved
  career whose in-progress trip names a retired facility.
  `DrivingState.from_snapshot` guards the same call and drops the player at
  the terminal.

## Accessibility impact

One new spoken line, on the refusal path, after the standard `ui/error` sound:
"That dispatch is no longer available. The board was put together before the
last update and this pickup has since closed. Go back to the terminal and open
the dispatch board again for the current loads." A test asserts it carries the
two facts a player needs and contains no maintainer jargon. Nothing else about
menu navigation or the board's spoken content changed.

## Release

Changelog filed under `## 1.8.6.2 - 2026-07-29`; version bumped in
`pyproject.toml` and `uv.lock`. Tag `v1.8.6.2` after merge.
