### PR TITLE
Resolve the changelog gate's base to the branch's own release line

### DIFF
--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -435,3 +435,53 @@ def test_build_workflow_uses_curated_nightly_decision_and_notes():
     assert "--exclude-stable-notes latest-stable-notes.md" in workflow
     assert "tools/release_notes.py nightly" in workflow
     assert 'git diff --name-only "$LAST_TAG"..HEAD' not in workflow
+
+
+def test_auto_base_follows_the_release_line_the_branch_was_cut_from(tmp_path, monkeypatch):
+    """A hotfix is cut from main and never contains dev.
+
+    Resolving its base to dev counted dev's bullets as already present and
+    rejected the push over a changelog entry that was right there -- which is
+    what the 1.8.6.2 hotfix hit. Ancestry cannot decide it either, since the
+    two lines each carry commits the other does not.
+    """
+    release_notes = load_release_notes_module()
+    repo = make_repo(tmp_path, changelog("- Seed entry."))
+    monkeypatch.setattr(release_notes, "ROOT", repo)
+    seed = git(repo, "rev-parse", "HEAD")  # git init's branch name varies
+    # dev moves ahead of main, as it always is between releases...
+    git(repo, "checkout", "-q", "-b", "dev")
+    for n in range(4):
+        (repo / f"dev{n}.txt").write_text("dev work\n", encoding="utf-8")
+        commit(repo, f"feat: dev only {n}")
+    git(repo, "update-ref", "refs/remotes/origin/dev", "HEAD")
+
+    # ...and main carries release commits of its own that dev never sees, so
+    # neither branch contains the other. That is the shape this has to read.
+    git(repo, "checkout", "-q", "-b", "stable-line", seed)
+    (repo / "release.txt").write_text("1.0\n", encoding="utf-8")
+    commit(repo, "release: 1.0")
+    git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    git(repo, "checkout", "-q", "-b", "hotfix/1.0.1", "refs/remotes/origin/main")
+    (repo / "fix.txt").write_text("hotfix\n", encoding="utf-8")
+    commit(repo, "fix: stable only")
+    assert release_notes.nearest_release_line() == "origin/main"
+    assert release_notes.resolve_base("auto") == "origin/main"
+
+    # An ordinary branch off dev still resolves to dev...
+    git(repo, "checkout", "-q", "-b", "feat/thing", "refs/remotes/origin/dev")
+    (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+    commit(repo, "feat: a feature")
+    assert release_notes.nearest_release_line() == "origin/dev"
+
+    # ...and still does once dev has moved on without it.
+    git(repo, "checkout", "-q", "dev")
+    (repo / "more.txt").write_text("more dev work\n", encoding="utf-8")
+    commit(repo, "feat: more dev")
+    git(repo, "update-ref", "refs/remotes/origin/dev", "HEAD")
+    git(repo, "checkout", "-q", "feat/thing")
+    assert release_notes.nearest_release_line() == "origin/dev"
+
+    # An explicit base is never second-guessed.
+    assert release_notes.resolve_base("origin/main") == "origin/main"

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -305,7 +305,33 @@ def current_branch() -> str:
 def resolve_base(base: str) -> str:
     if base != "auto":
         return base
-    return "origin/main" if current_branch() == "main" else "origin/dev"
+    if current_branch() == "main":
+        return "origin/main"
+    return nearest_release_line()
+
+
+def nearest_release_line() -> str:
+    """Which release line the current branch was cut from.
+
+    Feature and fix branches sit on dev, but a hotfix is cut from main and
+    never contains dev -- so comparing it against dev counts dev's bullets as
+    already present and rejects the push over a changelog entry that is right
+    there. This is measured as the nearest branch point rather than plain
+    ancestry, because main is an ancestor of dev as well: ancestry alone would
+    send every dev branch that has fallen behind to main instead.
+    """
+    candidates = []
+    for ref in ("origin/dev", "origin/main"):
+        try:
+            counts = run_git(["rev-list", "--count", "--left-right", f"{ref}...HEAD"])
+        except Exception:
+            continue  # a clone without that remote branch
+        # Both sides of the divergence, not just ours: a hotfix is zero
+        # commits behind main and a long way behind dev, which is the whole
+        # signal. Counting only our own side would call those two the same.
+        candidates.append((sum(int(n) for n in counts.split()), ref))
+    # Ties favour dev, which sorts first and is where ordinary work belongs.
+    return min(candidates)[1] if candidates else "origin/dev"
 
 
 def ref_is_ancestor(ancestor: str, descendant: str) -> bool:


### PR DESCRIPTION
Carries the release-tooling fix from the 1.8.6.2 hotfix ([PR #139](https://github.com/Orinks/Freight-Fate/pull/139)) onto `dev`, so both lines have it.

The pre-push release-note gate resolved `--base auto` to `origin/dev` for every branch not literally named `main`, so a hotfix cut from `main` was measured against `dev`. Its changelog bullet was already there -- the same fix having landed on `dev` first -- so the gate counted it as pre-existing and refused the push over an entry sitting right in the file. That blocked 1.8.6.2 until it was fixed.

Ancestry can't decide which line a branch belongs to here, because the two each carry commits the other doesn't: release commits live only on `main`. It now measures total divergence from each candidate and takes the nearer. A hotfix is zero commits behind `main` and far behind `dev`; a `dev` branch is the other way round, even when it has fallen well behind. Counting only our own side of the divergence makes those two cases identical, which is what a first attempt did and what the new test pins.

Maintainer tooling only -- no player-facing change, so `[skip changelog]`.

Tests: `uv run pytest tests/test_release_notes.py` -- 18 passed, including the new case covering a hotfix branch, a fresh `dev` branch, and a `dev` branch that has fallen behind.