### PR TITLE
fix(units): apply the metric setting to every distance and speed readout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@
   closed pickup anyway, the game says so and sends you back for a fresh board
   instead of quitting.
 
+- **Kilometers are now used everywhere, not just out on the road.** With units
+  set to metric, the driving cues spoke kilometers but several other screens
+  still read miles, so the same trip was measured two different ways depending
+  on where you asked. The dispatch board's job details, the distance and rate
+  it quotes, the summary you hear when you take a load or deadhead to a
+  pickup, the exit and hazard callouts, your remaining distance to a pickup,
+  the delivery summary's credited distance, your lifetime distance in career
+  stats, and the on-screen speed and trip readouts now all use the unit you
+  chose. Career stats also says "Lifetime kilometers" instead of labelling
+  kilometers as miles, and the pay rate reads as dollars per kilometer with
+  the figure recalculated to match. Nothing changes if you play in miles.
+
 ## 1.8.6.1 - 2026-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@
   chose. Career stats also says "Lifetime kilometers" instead of labelling
   kilometers as miles, and the pay rate reads as dollars per kilometer with
   the figure recalculated to match. Nothing changes if you play in miles.
+  Contributed by otaviols ([@otaviols](https://github.com/otaviols)) in
+  [PR #142](https://github.com/Orinks/Freight-Fate/pull/142).
 
 ## 1.8.6.1 - 2026-07-28
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,7 +141,8 @@ From a batch of player reports:
   summary, career stats, or the on-screen HUD, so a metric player heard
   kilometers on the road and miles everywhere else. All of those now go through
   the shared `units` helpers, and `sim.trip` delegates to them too rather than
-  keeping its own copy of the conversion (one of which used a rounded factor).
+  keeping its own copy of the conversion (one of which used a rounded factor)
+  (PR #142).
 - [ ] **Remaining imperial-only readouts.** Fuel is always gallons and a price
   per gallon, air pressure is always psi, and `weather.describe` omits the
   "Fahrenheit" that `season.py` says, so its temperature reads bare "degrees".

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,6 +135,18 @@ From a batch of player reports:
   item now sits in the pause menu (between Settings and Abandon job), so a
   player can see who is hauling mid-drive without quitting to the main menu.
   Viewing shares nothing about the paused driver.
+- [x] **Metric units applied consistently.** The units setting converted the
+  driving cues but not the dispatch board, job details, pay rate, departure and
+  deadhead summaries, exit and hazard callouts, pickup distance, delivery
+  summary, career stats, or the on-screen HUD, so a metric player heard
+  kilometers on the road and miles everywhere else. All of those now go through
+  the shared `units` helpers, and `sim.trip` delegates to them too rather than
+  keeping its own copy of the conversion (one of which used a rounded factor).
+- [ ] **Remaining imperial-only readouts.** Fuel is always gallons and a price
+  per gallon, air pressure is always psi, and `weather.describe` omits the
+  "Fahrenheit" that `season.py` says, so its temperature reads bare "degrees".
+  Adding litres, bar/kPa, and a consistent temperature phrase is a feature
+  rather than a units-setting bug, so it wants its own pass on the 1.9 line.
 - [ ] **Ambient-cue spacing (anti-stacking).** Priority handling fixes the
   critical case; still worth spacing or coalescing simultaneous low-priority
   cues so a burst of chatter does not pile up. Lower priority than the above.

--- a/src/freight_fate/settings.py
+++ b/src/freight_fate/settings.py
@@ -7,7 +7,14 @@ import logging
 from dataclasses import asdict, dataclass
 
 from .models.profile import data_dir
-from .units import spoken_distance
+from .units import (
+    MILES_TO_KM,
+    distance_unit,
+    hud_speed,
+    spoken_distance,
+    spoken_gap,
+    to_distance,
+)
 
 log = logging.getLogger(__name__)
 
@@ -164,9 +171,31 @@ class Settings:
     def speed_text(self, mph: float) -> str:
         if self.imperial_units:
             return f"{spoken_distance(mph, 'mile')} per hour"
-        return f"{spoken_distance(mph * 1.609344, 'kilometer')} per hour"
+        return f"{spoken_distance(mph * MILES_TO_KM, 'kilometer')} per hour"
 
     def distance_text(self, miles: float) -> str:
         if self.imperial_units:
             return spoken_distance(miles, "mile")
-        return spoken_distance(miles * 1.609344, "kilometer")
+        return spoken_distance(miles * MILES_TO_KM, "kilometer")
+
+    def gap_text(self, miles: float) -> str:
+        """A spoken distance kept to one decimal, for close-range cues."""
+        return spoken_gap(miles, self.imperial_units)
+
+    def hud_speed_text(self, mph: float) -> str:
+        """Speed for the visual HUD, in the short written form."""
+        return hud_speed(mph, self.imperial_units)
+
+    def distance_value(self, miles: float, decimals: int = 0, *, grouped: bool = False) -> str:
+        """A bare converted distance, for readouts that name the unit once
+        after two numbers ("12 of 400 miles")."""
+        group = "," if grouped else ""
+        return f"{to_distance(miles, self.imperial_units):{group}.{decimals}f}"
+
+    def distance_unit_text(self, *, plural: bool = True) -> str:
+        """The player's distance unit, to pair with ``distance_value``."""
+        return distance_unit(self.imperial_units, plural=plural)
+
+    def per_distance(self, per_mile: float) -> float:
+        """A per-mile rate as a rate in the player's own distance unit."""
+        return per_mile if self.imperial_units else per_mile / MILES_TO_KM

--- a/src/freight_fate/sim/trip.py
+++ b/src/freight_fate/sim/trip.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import random
 
 from ..data.world import Leg, Route, get_world
-from ..units import spoken_distance
+from ..units import distance_unit, spoken_distance, spoken_gap, to_distance
 from .hos import clock_text, is_night
 from .timezones import appointment_text, city_zone, zone_for
 from .trip_models import *
@@ -123,19 +123,16 @@ class Trip:
         self.navigation_cues = self._build_navigation_cues()
 
     def _distance_text(self, miles: float) -> str:
-        if self.imperial:
-            return _spoken_distance(miles, "mile")
-        return _spoken_distance(miles * 1.609344, "kilometer")
+        return _spoken_distance(
+            to_distance(miles, self.imperial),
+            distance_unit(self.imperial, plural=False),
+        )
 
     def _gap_text(self, miles: float) -> str:
-        if self.imperial:
-            return f"{miles:.1f} miles"
-        return f"{miles * 1.609344:.1f} kilometers"
+        return spoken_gap(miles, self.imperial)
 
     def _speed_value(self, mph: float) -> str:
-        if self.imperial:
-            return f"{mph:.0f}"
-        return f"{mph * 1.609344:.0f}"
+        return f"{to_distance(mph, self.imperial):.0f}"
 
     def _compute_leg_starts(self) -> list[float]:
         starts, acc = [], 0.0
@@ -757,16 +754,11 @@ class Trip:
         return max(0, min(100, round(100.0 * self.position_mi / total)))
 
     def progress_summary(self, imperial: bool = True) -> str:
-        if imperial:
-            dist = (
-                f"{_spoken_distance(self.remaining_miles, 'mile')} "
-                f"remaining of {self.total_miles:.0f}"
-            )
-        else:
-            dist = (
-                f"{_spoken_distance(self.remaining_miles * 1.609, 'kilometer')} "
-                f"remaining of {self.total_miles * 1.609:.0f}"
-            )
+        remaining = _spoken_distance(
+            to_distance(self.remaining_miles, imperial),
+            distance_unit(imperial, plural=False),
+        )
+        dist = f"{remaining} remaining of {to_distance(self.total_miles, imperial):.0f}"
         leg = self.route.legs[self.current_leg_index]
         toward = self.route.cities[self.current_leg_index + 1]
         world = get_world()
@@ -793,10 +785,8 @@ class Trip:
         if cue is None:
             return f"Destination {get_world().spoken_city(self.route.cities[-1])} ahead."
         ahead = max(0.0, cue.at_mi - self.position_mi)
-        ahead_text = (
-            _spoken_distance(ahead, "mile")
-            if imperial
-            else _spoken_distance(ahead * 1.609344, "kilometer")
+        ahead_text = _spoken_distance(
+            to_distance(ahead, imperial), distance_unit(imperial, plural=False)
         )
         if cue.kind == "rest_stop":
             return f"Next stop in {ahead_text}: {cue.text}."

--- a/src/freight_fate/states/career_stats.py
+++ b/src/freight_fate/states/career_stats.py
@@ -37,6 +37,7 @@ class CareerStatsState(MenuState):
 
     def _lines(self) -> list[str]:
         p = self.ctx.profile
+        s = self.ctx.settings
         career = p.career
         pct = (100 * career.on_time_deliveries / career.deliveries) if career.deliveries else 100
         rest = "fully rested" if fully_rested(p) else f"fatigue {p.fatigue:.0f} percent"
@@ -44,7 +45,8 @@ class CareerStatsState(MenuState):
             f"Level {career.level} driver, {career.xp:.0f} experience",
             f"Reputation: {career.reputation:.0f} out of 100",
             f"Deliveries: {career.deliveries}, {pct:.0f} percent on time",
-            f"Lifetime miles: {career.total_miles:,.0f}",
+            f"Lifetime {s.distance_unit_text()}: "
+            f"{s.distance_value(career.total_miles, grouped=True)}",
             f"Lifetime earnings: {career.total_earnings:,.0f} dollars",
             f"Rest: {rest}",
             f"Hours: {p.hos.summary(self.ctx.settings.hos_mode).rstrip('.')}",

--- a/src/freight_fate/states/city.py
+++ b/src/freight_fate/states/city.py
@@ -464,7 +464,8 @@ class BobtailDestState(MenuState):
         self.ctx.save_profile()
         spoken_dest = job.spoken_destination
         self.ctx.say(
-            f"Bobtailing empty to {spoken_dest}, {route.miles:.0f} miles on "
+            f"Bobtailing empty to {spoken_dest}, "
+            f"{self.ctx.settings.distance_text(route.miles)} on "
             f"{route.highways[0]}. No load and no pay -- you will see the "
             f"{spoken_dest} dispatch board on arrival. Check in at the city "
             "terminal when you get there.",

--- a/src/freight_fate/states/city_dispatch.py
+++ b/src/freight_fate/states/city_dispatch.py
@@ -14,6 +14,7 @@ from ..models.jobs import (
     route_drive_hours,
 )
 from ..music import select_menu_music_sequence
+from ..settings import Settings
 from ..sim.hos import LIMITS
 from ..sim.timezones import appointment_text, city_zone
 from ..sim.vehicle import TruckState
@@ -88,14 +89,15 @@ def route_planning_summary(route: Route) -> str:
     )
 
 
-def route_departure_summary(route: Route) -> str:
+def route_departure_summary(route: Route, settings: Settings) -> str:
     toll_text = (
         f" Carrier toll estimate {route.estimated_tolls:,.0f} dollars."
         if route.estimated_tolls > 0
         else ""
     )
     return (
-        f"Loaded trip is {route.miles:.0f} miles via {', then '.join(route.highways)}.{toll_text}"
+        f"Loaded trip is {settings.distance_text(route.miles)} "
+        f"via {', then '.join(route.highways)}.{toll_text}"
     )
 
 
@@ -205,7 +207,8 @@ class JobBoardState(MenuState):
         self.ctx.save_profile()
         self.ctx.say(
             f"Dispatch accepted from {terminal.name}. Deadhead "
-            f"{route.miles:.1f} miles on {route.highways[0]} to pickup at "
+            f"{self.ctx.settings.gap_text(route.miles)} on "
+            f"{route.highways[0]} to pickup at "
             f"{job.origin_facility_text()}. "
             "Check in with the shipper when you arrive.",
             interrupt=True,
@@ -338,6 +341,7 @@ class JobDetailState(MenuState):
         job = self.job
         p = self.ctx.profile
         world = self.ctx.world
+        s = self.ctx.settings
         dollars_per_mile = job.pay / max(job.distance_mi, 1.0)
         # The detail view is the "tell me more" surface, so it always names the
         # state -- board offers stay short, but a player who does not know
@@ -358,9 +362,10 @@ class JobDetailState(MenuState):
             f"Cargo: {job.cargo.label}.",
             f"Origin: {origin_text}.",
             f"Destination: {destination_text}.",
-            f"Distance: {job.distance_mi:.0f} miles.",
+            f"Distance: {s.distance_text(job.distance_mi)}.",
             f"Pay: {job.pay:,.0f} dollars.",
-            f"Dollars per mile: {dollars_per_mile:.2f}.",
+            f"Dollars per {s.distance_unit_text(plural=False)}: "
+            f"{s.per_distance(dollars_per_mile):.2f}.",
             # The appointment reads in the receiver's local time, the way real
             # dispatch quotes it. "About" because the clock starts at pickup
             # departure, after check-in and loading.
@@ -669,7 +674,7 @@ class PickupFacilityState(MenuState):
             f"Cargo: {self.job.weight_tons:.0f} tons of {self.job.cargo.label}",
             f"Destination: {self.job.spoken_destination}",
             f"Status: {state}",
-            f"Speed: {self.truck.speed_mph:.0f} mph",
+            f"Speed: {self.ctx.settings.hud_speed_text(self.truck.speed_mph)}",
             f"Air: {self.truck.air_pressure_psi:.0f} psi   "
             f"{'parking set' if self.truck.parking_brake else 'parking released'}",
         ]
@@ -847,7 +852,8 @@ class RouteSelectState(MenuState):
         next_context = driving.trip.next_navigation_context()
         self.ctx.say(
             f"Navigation set for {self.job.destination_facility_text()}. "
-            f"{route_departure_summary(route)} {next_context} Departing now.",
+            f"{route_departure_summary(route, self.ctx.settings)} "
+            f"{next_context} Departing now.",
             interrupt=True,
         )
         self.ctx.push_state(driving)

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -289,7 +289,7 @@ class DrivingEventMixin:
         else:
             head = f"Signaling for the {stop.spoken_name} exit,"
         message = (
-            f"{head} {ahead:.1f} miles ahead. Slow to "
+            f"{head} {self.ctx.settings.gap_text(ahead)} ahead. Slow to "
             f"{self.ctx.settings.speed_text(RAMP_MAX_MPH)} or less for the ramp."
             + self._cap_cruise_for_ramp()
         )
@@ -407,7 +407,7 @@ class DrivingEventMixin:
 
     def _destination_exit_announcement(self, stop, ahead: float) -> str:
         labeled = getattr(stop, "exit_phrase", "") or stop.exit_label
-        distance = f"{ahead:.0f} miles" if round(ahead) != 1 else "1 mile"
+        distance = self.ctx.settings.distance_text(ahead)
         core = (
             f"In {distance}, {labeled}, destination exit."
             if labeled
@@ -1342,15 +1342,17 @@ class DrivingEventMixin:
             if self.phase == DRIVE_PHASE_PICKUP
             else f"Driving loaded to {self.job.spoken_destination}"
         )
+        s = self.ctx.settings
+        decimals = 1 if self.phase == DRIVE_PHASE_PICKUP else 0
         remaining = (
-            f"{self.trip.remaining_miles:.1f} of {self.trip.total_miles:.1f} miles"
-            if self.phase == DRIVE_PHASE_PICKUP
-            else f"{self.trip.remaining_miles:.0f} of {self.trip.total_miles:.0f} miles"
+            f"{s.distance_value(self.trip.remaining_miles, decimals)} of "
+            f"{s.distance_value(self.trip.total_miles, decimals)} {s.distance_unit_text()}"
         )
         return [
             title,
             "",
-            f"Speed: {t.speed_mph:.0f} mph (limit {limit:.0f}{', ' + reason if reason else ''})",
+            f"Speed: {s.hud_speed_text(t.speed_mph)} "
+            f"(limit {s.distance_value(limit)}{', ' + reason if reason else ''})",
             f"Gear: {gear}   RPM: {t.rpm:.0f}   {'ENGINE ON' if t.engine_on else 'engine off'}"
             + (f"   CRUISE {self._cruise_mph:.0f}" if self._cruise_mph is not None else ""),
             f"Air: {t.air_pressure_psi:.0f} psi   "

--- a/src/freight_fate/states/driving_menu_states.py
+++ b/src/freight_fate/states/driving_menu_states.py
@@ -626,7 +626,7 @@ class FacilityArrivalState(MenuState):
             self.title,
             "",
             f"Facility: {self.facility}",
-            f"Speed: {self.driving.truck.speed_mph:.0f} mph",
+            f"Speed: {self.ctx.settings.hud_speed_text(self.driving.truck.speed_mph)}",
             "Docking required before delivery settlement.",
             "",
         ] + [("> " if i == self.index else "  ") + item.text for i, item in enumerate(self.items)]
@@ -857,7 +857,7 @@ class ArrivalState(MenuState):
             f"Money after settlement: {p.money:,.0f} dollars.",
             bonus_text + ".",
             f"Route: {' to '.join(self.ctx.world.spoken_city(c) for c in d.route.cities)}.",
-            f"Distance credited: {job.distance_mi:.0f} miles.",
+            f"Distance credited: {self.ctx.settings.distance_text(job.distance_mi)}.",
             cargo_condition + ".",
             f"Fuel remaining: {d.truck.fuel_fraction * 100:.0f} percent.",
             f"Truck damage now: {d.truck.damage_pct:.0f} percent.",

--- a/src/freight_fate/states/driving_pickup.py
+++ b/src/freight_fate/states/driving_pickup.py
@@ -89,7 +89,7 @@ class DrivingPickupMixin:
 
     def _pickup_progress_summary(self) -> str:
         return (
-            f"{self.trip.remaining_miles:.1f} miles remaining of "
-            f"{self.trip.total_miles:.1f} to pickup at "
+            f"{self.ctx.settings.gap_text(self.trip.remaining_miles)} remaining of "
+            f"{self.ctx.settings.distance_value(self.trip.total_miles, 1)} to pickup at "
             f"{self._pickup_facility_text()}."
         )

--- a/src/freight_fate/units.py
+++ b/src/freight_fate/units.py
@@ -8,9 +8,38 @@ reach it.
 
 from __future__ import annotations
 
+MILES_TO_KM = 1.609344
+
 
 def spoken_distance(value: float, unit: str) -> str:
     """A whole-number distance with the unit pluralized for speech, so a
     screen reader never hears "in 1 miles"."""
     rounded = round(value)
     return f"{rounded:.0f} {unit if rounded == 1 else unit + 's'}"
+
+
+def to_distance(miles: float, imperial: bool) -> float:
+    """An internal mileage as the number the player's unit setting asks for.
+
+    The sim measures everything in miles; this is the single conversion the
+    readouts go through, so a metric player never hears one screen's
+    kilometers next to another screen's raw miles.
+    """
+    return miles if imperial else miles * MILES_TO_KM
+
+
+def distance_unit(imperial: bool, *, plural: bool = True) -> str:
+    """The spoken name of the player's distance unit."""
+    unit = "mile" if imperial else "kilometer"
+    return unit + "s" if plural else unit
+
+
+def spoken_gap(miles: float, imperial: bool) -> str:
+    """A one-decimal distance, for cues close enough that rounding to whole
+    units would hide the gap being announced."""
+    return f"{to_distance(miles, imperial):.1f} {distance_unit(imperial)}"
+
+
+def hud_speed(mph: float, imperial: bool) -> str:
+    """Speed for the visual HUD, in the short written form."""
+    return f"{mph:.0f} mph" if imperial else f"{to_distance(mph, imperial):.0f} km/h"

--- a/tests/test_metric_readouts.py
+++ b/tests/test_metric_readouts.py
@@ -1,0 +1,159 @@
+"""Readouts that used to speak miles no matter what the units setting said.
+
+The units setting always converted the driving cues, so a metric player heard
+kilometers out on the road and then raw miles the moment they opened dispatch,
+career stats, or the delivery summary. These lock each of those surfaces to the
+player's own unit.
+"""
+
+from freight_fate.settings import Settings
+from freight_fate.units import (
+    MILES_TO_KM,
+    distance_unit,
+    hud_speed,
+    spoken_gap,
+    to_distance,
+)
+
+
+def _metric() -> Settings:
+    s = Settings()
+    s.imperial_units = False
+    return s
+
+
+def _imperial() -> Settings:
+    s = Settings()
+    s.imperial_units = True
+    return s
+
+
+def test_to_distance_leaves_imperial_alone_and_converts_metric():
+    assert to_distance(100.0, True) == 100.0
+    assert to_distance(100.0, False) == 100.0 * MILES_TO_KM
+
+
+def test_distance_unit_names_both_settings_singular_and_plural():
+    assert distance_unit(True) == "miles"
+    assert distance_unit(True, plural=False) == "mile"
+    assert distance_unit(False) == "kilometers"
+    assert distance_unit(False, plural=False) == "kilometer"
+
+
+def test_spoken_gap_keeps_one_decimal_in_both_units():
+    assert spoken_gap(2.0, True) == "2.0 miles"
+    assert spoken_gap(2.0, False) == "3.2 kilometers"
+
+
+def test_hud_speed_uses_the_short_written_form():
+    assert hud_speed(55.0, True) == "55 mph"
+    assert hud_speed(55.0, False) == "89 km/h"
+
+
+def test_distance_value_and_unit_pair_up_for_two_number_readouts():
+    s = _metric()
+    assert s.distance_value(100.0) == "161"
+    assert s.distance_value(100.0, 1) == "160.9"
+    assert s.distance_value(1000.0, grouped=True) == "1,609"
+    assert s.distance_unit_text() == "kilometers"
+
+
+def test_per_distance_rescales_a_per_mile_rate():
+    # $3.22 a mile is $2.00 a kilometer -- the rate falls, it does not rise.
+    assert _imperial().per_distance(3.218688) == 3.218688
+    assert round(_metric().per_distance(3.218688), 2) == 2.0
+
+
+def test_route_departure_summary_speaks_the_players_unit():
+    from freight_fate.states.city_dispatch import route_departure_summary
+
+    class _Route:
+        miles = 100.0
+        highways = ["I-90"]
+        estimated_tolls = 0.0
+
+    assert "161 kilometers" in route_departure_summary(_Route(), _metric())
+    assert "100 miles" in route_departure_summary(_Route(), _imperial())
+
+
+def test_job_detail_reads_distance_and_rate_in_metric():
+    from freight_fate.app import App
+    from freight_fate.models.jobs import CARGO_CATALOG, Job
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.city_dispatch import JobDetailState
+
+    app = App()
+    try:
+        app.ctx.settings.imperial_units = False
+        app.ctx.profile = Profile(name="Metric", current_city="Buffalo")
+        route = app.ctx.world.supported_route("Buffalo", "Rochester")
+        job = Job(
+            CARGO_CATALOG["general"],
+            12.0,
+            "Buffalo",
+            "company yard",
+            "Rochester",
+            route.miles,
+            1000.0,
+            12.0,
+            destination_location="Rochester freight market",
+        )
+        lines = JobDetailState(app.ctx, None, job)._detail_lines()
+        joined = " ".join(lines)
+        assert "kilometers" in joined
+        assert "Dollars per kilometer" in joined
+        assert "mile" not in joined
+    finally:
+        app.shutdown()
+
+
+def test_career_stats_label_follows_the_units_setting():
+    from freight_fate.app import App
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.career_stats import CareerStatsState
+
+    app = App()
+    try:
+        app.ctx.profile = Profile(name="Metric", current_city="Buffalo")
+        app.ctx.profile.career.total_miles = 1000.0
+        app.ctx.settings.imperial_units = False
+        lines = CareerStatsState(app.ctx)._lines()
+        assert "Lifetime kilometers: 1,609" in " ".join(lines)
+
+        app.ctx.settings.imperial_units = True
+        lines = CareerStatsState(app.ctx)._lines()
+        assert "Lifetime miles: 1,000" in " ".join(lines)
+    finally:
+        app.shutdown()
+
+
+def test_driving_hud_shows_metric_speed_and_remaining_distance():
+    from freight_fate.app import App
+    from freight_fate.models.jobs import CARGO_CATALOG, Job
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.driving import DrivingState
+
+    app = App()
+    try:
+        app.ctx.settings.imperial_units = False
+        app.ctx.profile = Profile(name="Metric", current_city="Buffalo")
+        route = app.ctx.world.supported_route("Buffalo", "Rochester")
+        job = Job(
+            CARGO_CATALOG["general"],
+            12.0,
+            "Buffalo",
+            "company yard",
+            "Rochester",
+            route.miles,
+            1000.0,
+            12.0,
+            destination_location="Rochester freight market",
+        )
+        d = DrivingState(app.ctx, job, route, phase="delivery")
+        d.truck.velocity_mps = 55.0 / 2.23694  # 55 mph
+        joined = " ".join(d.lines())
+        assert "Speed: 89 km/h" in joined
+        assert "kilometers" in joined
+        assert "mph" not in joined
+    finally:
+        app.shutdown()


### PR DESCRIPTION
## What changed and why

With units set to metric, the driving cues spoke kilometers but a lot of other
readouts wrote `miles` and `mph` straight into their f-strings, so the same
trip was measured two different ways depending on which screen you asked. The
affected surfaces were the dispatch board's job details, the distance and pay
rate it quotes, the summary spoken when you take a load or deadhead to a
pickup, the exit and hazard callouts, the remaining distance to a pickup, the
delivery summary's credited distance, lifetime distance in career stats, and
the on-screen speed and trip readouts.

The root cause was duplication rather than any single missed call site: the
conversion lived in `settings` **and** again in `sim.trip`, so each new readout
could reintroduce the bug. The shared rule now lives in the `units` leaf module
(`to_distance`, `distance_unit`, `spoken_gap`, `hud_speed`, plus a `MILES_TO_KM`
constant replacing the inline factors), `Settings` grows the readout helpers the
call sites actually needed (`gap_text`, `hud_speed_text`, `distance_value`,
`distance_unit_text`, `per_distance`), and `sim.trip` delegates to the shared
helpers instead of keeping its own copy.

Two things turned up while fixing this and are included:

- `Trip.progress_summary` multiplied by a rounded `1.609` on the metric path,
  so it quietly disagreed with every other conversion in the game.
- Career stats read "Lifetime miles" while showing a kilometer figure, i.e. it
  labelled kilometers as miles.

Imperial output is byte-identical on purpose -- only the metric path changes.
That is why the existing suite needed no edits.

One signature change to flag for review: `route_departure_summary(route)` is now
`route_departure_summary(route, settings)`, since it has to consult the setting.
It is re-exported from `states/city.py`'s `__all__`; the only caller in the repo
is updated.

## What players or maintainers will notice

Players who play in kilometers now hear and see kilometers everywhere instead
of kilometers on the road and miles in every menu. Career stats says "Lifetime
kilometers" rather than labelling kilometers as miles, and the pay rate reads
as dollars per kilometer with the figure recalculated to match (a $3.22/mile
load reads as $2.00/kilometer). Players who play in miles notice nothing at
all -- that output is unchanged down to the byte.

Maintainers get one place to change distance and speed wording. A new readout
that goes through `Settings` cannot ship half-converted the way these did.

## Tests and checks run

- `uv run pytest` -- 1442 passed (1432 existing, unchanged, plus 10 new).
- `uv run ruff check src tests tools` -- clean.
- `uv run python -m compileall src tests tools` -- clean.

New `tests/test_metric_readouts.py` covers the `units` helpers and the
`Settings` methods directly, then locks the four surfaces that regressed:
`route_departure_summary`, the job detail lines, the career-stats label, and the
driving HUD. The integration cases assert `"mile" not in ...` and
`"mph" not in ...` on the composed output, so a future readout that hardcodes
imperial fails the suite instead of shipping.

## Accessibility impact

This is a spoken-text change, so accessibility is the point of it rather than a
side effect. Every fixed string is player-facing speech or a HUD line, and the
wording was checked in both unit settings.

Pluralization was the specific hazard and it is handled by the existing
`spoken_distance` helper, so a screen reader gets "1 mile" / "1 kilometer" and
never "1 miles". The destination-exit callout previously carried its own
hand-rolled singular special case (`"1 mile" if round(ahead) == 1`); it now uses
the shared helper and keeps the same spoken result. Singular versus plural units
in career stats and the pay rate go through `distance_unit_text(plural=False)`
so "Dollars per kilometer" does not read as "per kilometers".

No visual-only cues were added, no keyboard flow changed, and no spoken
information was removed or replaced by anything on screen.

## Changelog

CI requires a `CHANGELOG.md` entry when user-facing paths (such as `src/`
or `docs/`) change. Check one:

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

`ROADMAP.md` is updated in the same change per `AGENTS.md`: this fix is checked
off in the player-feedback round, and the readouts the units setting still does
not reach are recorded there as an unchecked follow-up rather than left in a
commit message -- fuel is always gallons and a price per gallon, air pressure is
always psi, and `weather.describe` omits the "Fahrenheit" that `season.py` says,
so its temperature reads as a bare "degrees". Those need litres, bar/kPa, and a
consistent temperature phrase, which is a feature rather than a units-setting
bug, so it wants its own pass on the 1.9 line rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
