### PR TITLE
docs(template): tell contributors to target dev, not main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,10 @@
 <!-- Thanks for contributing! See CONTRIBUTING.md for branch targets,
      test commands, and accessibility expectations.
 
+     Target the `dev` branch, not `main`. GitHub defaults new PRs to
+     `main`, but `main` is only for stable release work -- change the
+     base branch to `dev` before opening this PR.
+
      Heads up: the 1.8 line is in maintenance until 1.9 preview snapshots
      begin, so only major and minor bug fixes are being accepted for now.
      Have a feature in mind? Open an issue for it instead and it can be


### PR DESCRIPTION
## What changed and why

Added an explicit line to the PR template's top comment telling contributors to target the `dev` branch. GitHub defaults new PRs to `main`, and the template only pointed at CONTRIBUTING.md for branch targets without saying it outright — a contributor bugfix PR (#144) just landed on `main` and had to be retargeted by hand.

## What players or maintainers will notice

Nothing player-facing. Contributors opening a PR now see the dev-target instruction directly in the template, next to the existing bugfix-only-until-1.9 note.

## Tests and checks run

None needed — comment-only change to the PR template. The changelog gate hook passed at commit time.

## Accessibility impact

None. No gameplay, spoken text, or keyboard flow touched.

## Changelog

- [x] This change is not player-facing, and every commit message in this PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
