### PR TITLE
fix(build): cap MinGW compile jobs by RAM so no-MSVC Windows builds stop dying midway

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ check, and archives it as `dist/FreightFate-<version>-windows-portable.zip`
 - `--tag <label>` — override the version label in the archive name, as the
   nightly workflow does.
 
+On Windows the build compiles with Visual Studio's C++ toolchain when
+one is installed. Without it, Nuitka downloads a MinGW64 GCC toolchain
+on first build, and the script caps compile parallelism to one job per
+2 GB of RAM — the parallel compilers otherwise exhaust memory midway
+through and the build dies with a GCC error. No build step needs
+administrator rights, so if a build fails, re-run it in a normal
+prompt and report the first error line rather than retrying elevated.
+
 If the build succeeds but the archive seems to vanish on Windows, check
 your antivirus: freshly built unsigned executables are sometimes
 quarantined on sight. Add an exclusion for the `dist/` folder or restore

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -230,6 +230,39 @@ def test_release_docs_are_staged_with_build_payload(tmp_path, monkeypatch):
     )
 
 
+def test_mingw_job_cap_gives_each_compiler_two_gigabytes():
+    build_release = load_build_release_module()
+    gib = 1024**3
+
+    assert build_release.mingw_safe_job_count(16, 8 * gib) == 4
+    assert build_release.mingw_safe_job_count(4, 32 * gib) == 4  # never above CPU count
+    assert build_release.mingw_safe_job_count(8, 2 * gib) == 1
+    assert build_release.mingw_safe_job_count(8, 1 * gib) == 1  # always at least one job
+    assert build_release.mingw_safe_job_count(8, None) == 8  # unknown RAM: Nuitka default
+
+
+def test_windows_build_without_msvc_caps_nuitka_compile_jobs(monkeypatch):
+    build_release = load_build_release_module()
+    monkeypatch.setattr(build_release.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(build_release, "windows_msvc_available", lambda: False)
+    monkeypatch.setattr(build_release, "windows_total_memory_bytes", lambda: 8 * 1024**3)
+    monkeypatch.setattr(build_release.os, "cpu_count", lambda: 16)
+
+    cmd = build_release.build_nuitka_command(build_release.ROOT / "tools" / "_entry.py")
+
+    assert "--jobs=4" in cmd
+
+
+def test_windows_build_with_msvc_keeps_nuitka_default_jobs(monkeypatch):
+    build_release = load_build_release_module()
+    monkeypatch.setattr(build_release.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(build_release, "windows_msvc_available", lambda: True)
+
+    cmd = build_release.build_nuitka_command(build_release.ROOT / "tools" / "_entry.py")
+
+    assert not any(arg.startswith("--jobs=") for arg in cmd)
+
+
 def test_strip_user_data_removes_saves_and_logs(tmp_path):
     build_release = load_build_release_module()
     build_dir = tmp_path / "FreightFate"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -8,6 +8,11 @@ import threading
 from pathlib import Path
 from types import SimpleNamespace
 
+# The POSIX-payload tests fake sys.platform as "linux" and then load modules
+# that import numpy lazily; numpy's own import probes sys.platform and calls
+# os.uname() on "linux", which does not exist on Windows. Importing it here,
+# under the real platform, keeps the fake from ever reaching that probe.
+import numpy  # noqa: F401
 import pytest
 
 from freight_fate import updater

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -325,6 +325,75 @@ KEYRING_NUITKA_ARGS = [
 ]
 
 
+# Nuitka compiles one C file per CPU core in parallel. On a Windows machine
+# without Visual Studio's C++ toolchain it silently falls back to a downloaded
+# MinGW64 GCC whose processes each peak at over half a gigabyte, so one per
+# core exhausts memory midway through the ~360-module compile on typical
+# 8-16 GB machines -- the failure surfaces as GCC dying partway, and elevation
+# does not help. One job per this many bytes keeps the compile inside physical
+# memory; MSVC machines (CI, dev boxes) keep Nuitka's default.
+MINGW_JOB_MEMORY_BYTES = 2 * 1024**3
+
+
+def mingw_safe_job_count(cpu_count: int, memory_bytes: int | None) -> int:
+    """Parallel compile jobs the MinGW64 fallback can afford on this machine."""
+    if not memory_bytes:
+        return cpu_count
+    return max(1, min(cpu_count, memory_bytes // MINGW_JOB_MEMORY_BYTES))
+
+
+def windows_total_memory_bytes() -> int | None:
+    """Total physical RAM on Windows, or None when the query fails."""
+    import ctypes
+
+    class MemoryStatusEx(ctypes.Structure):
+        _fields_ = [
+            ("dwLength", ctypes.c_uint32),
+            ("dwMemoryLoad", ctypes.c_uint32),
+            ("ullTotalPhys", ctypes.c_uint64),
+            ("ullAvailPhys", ctypes.c_uint64),
+            ("ullTotalPageFile", ctypes.c_uint64),
+            ("ullAvailPageFile", ctypes.c_uint64),
+            ("ullTotalVirtual", ctypes.c_uint64),
+            ("ullAvailVirtual", ctypes.c_uint64),
+            ("ullAvailExtendedVirtual", ctypes.c_uint64),
+        ]
+
+    status = MemoryStatusEx()
+    status.dwLength = ctypes.sizeof(MemoryStatusEx)
+    if not ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+        return None
+    return int(status.ullTotalPhys)
+
+
+def windows_msvc_available() -> bool:
+    """Whether Nuitka will find Visual Studio's C++ toolchain."""
+    vswhere = (
+        Path(os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)"))
+        / "Microsoft Visual Studio"
+        / "Installer"
+        / "vswhere.exe"
+    )
+    if not vswhere.exists():
+        return False
+    result = subprocess.run(
+        [
+            str(vswhere),
+            "-products",
+            "*",
+            "-latest",
+            "-requires",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "-property",
+            "installationPath",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
 def build_nuitka_command(entry: Path) -> list[str]:
     """Build the Nuitka command for the current platform."""
     system = platform.system()
@@ -356,6 +425,14 @@ def build_nuitka_command(entry: Path) -> list[str]:
 
     if system == "Windows":
         cmd.append("--windows-console-mode=disable")
+        if not windows_msvc_available():
+            jobs = mingw_safe_job_count(os.cpu_count() or 1, windows_total_memory_bytes())
+            cmd.append(f"--jobs={jobs}")
+            print(
+                "No Visual Studio C++ toolchain found; Nuitka will compile with its "
+                f"downloaded MinGW64 GCC, capped at {jobs} parallel job(s) to fit "
+                "this machine's memory."
+            )
     elif system == "Darwin":
         cmd.append(f"--macos-app-name={APP_NAME}")
 


### PR DESCRIPTION
## What changed and why

A tester without Visual Studio reported `tools/build_release.py` failing midway with a GCC error, and again (as a mid-build crash) when retried from an elevated prompt. Root cause: on a Windows machine without the Visual Studio C++ toolchain, Nuitka silently falls back to a downloaded winlibs MinGW64 GCC and compiles with one job per CPU core and no memory awareness. This project compiles ~360 C modules, and the parallel GCC processes each peak at over half a gigabyte (measured ~6.8 GB aggregate during a forced `--mingw64` build), which exhausts memory partway through on typical 8-16 GB machines. Elevation never mattered. CI and dev machines never hit it because both have MSVC installed.

`build_release.py` now detects the missing MSVC toolchain via `vswhere` and passes Nuitka `--jobs` capped at one job per 2 GB of RAM, printing a line that says which compiler path is in use and why the cap applies. Machines with MSVC (including CI) keep Nuitka's defaults, so existing builds are unchanged. README's build section documents the fallback and that no build step needs administrator rights.

## What players or maintainers will notice

Players: nothing; release archives are unchanged. Maintainers and testers building standalone copies on Windows without Visual Studio get a slower but reliable compile instead of a mid-build GCC failure, plus a printed explanation of the compiler fallback.

## Tests and checks run

- `uv run pytest tests/test_updater.py` (three new tests for the job cap and the MSVC/no-MSVC command lines; the one pre-existing failure on Windows checkouts, `test_linux_packaged_payload_requires_prism_dependency_bundle`, is unrelated and unchanged)
- `uv run ruff check src tests tools`
- Full forced-MinGW reproduction build (`--mingw64`) on Windows completed and produced a working `FreightFate.exe`, confirming the fallback toolchain itself is sound

## Accessibility impact

None; build tooling and contributor docs only. No spoken text or gameplay path changes.

## Changelog

- [ ] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [x] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
