### PR TITLE
fix(weather): accept hourly NWS station reports as live conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
 
 ### Fixed
 
+- **Live weather no longer gives up on a healthy weather service.** Weather
+  stations file their reports once an hour, but the game treated any report
+  more than thirty minutes old as a failure -- so for most of every hour it
+  quietly switched to simulated fallback weather even when the service was
+  fine. A report now stays current until it is well past the hourly cycle,
+  so live weather stays live, and the weather app still tells you exactly
+  how old the reading is.
+
 - **Real-world weather now follows the truck instead of the next city.** Live
   National Weather Service conditions update as you move along a route, and
   weather reports say when conditions are live, still loading, last known, or

--- a/src/freight_fate/sim/real_weather.py
+++ b/src/freight_fate/sim/real_weather.py
@@ -42,6 +42,14 @@ FETCH_TIMEOUT_S = 8.0
 # turns over, and quick enough to catch off-schedule SPECI observations.
 CACHE_TTL_S = 5 * 60.0
 STALE_AFTER_S = 30 * 60.0  # keep serving cached data this long if refreshes fail
+# NWS stations file routine METAR observations once an hour (off-schedule
+# SPECIs are the exception), and dissemination adds minutes on top, so the
+# newest observation a healthy station offers is 30-60 minutes old for most
+# of every hour. That is what "current conditions" means; rejecting it as
+# stale pushed players onto simulated fallback weather for no reason. Only
+# an observation well past the hourly cycle -- a dead or parked station --
+# is unusable.
+OBSERVATION_MAX_AGE_S = 2 * 60 * 60.0
 RETRY_AFTER_S = 60.0  # wait before retrying a failed city
 STRONG_WIND_KMH = 38.0
 # The game's fog is a sub-half-mile, 40-mph event with fog horns, but NWS
@@ -288,7 +296,7 @@ class RealWeatherProvider:
     def _usable(self, entry: _CachedObservation) -> bool:
         return (
             self._clock() - entry.fetched_at <= STALE_AFTER_S
-            and self._wall_clock() - entry.observed_at <= STALE_AFTER_S
+            and self._wall_clock() - entry.observed_at <= OBSERVATION_MAX_AGE_S
         )
 
     def unavailable(self, city: str) -> bool:
@@ -331,7 +339,7 @@ class RealWeatherProvider:
             observed_at = fetched[4] if len(fetched) > 4 else None
             if observed_at is None:
                 observed_at = self._wall_clock()
-            if self._wall_clock() - float(observed_at) > STALE_AFTER_S:
+            if self._wall_clock() - float(observed_at) > OBSERVATION_MAX_AGE_S:
                 raise ValueError("NWS observation is too old to use")
             kind = map_condition(text, wind, visibility_mi)
             with self._lock:

--- a/tests/test_real_weather.py
+++ b/tests/test_real_weather.py
@@ -5,6 +5,7 @@ import threading
 
 from freight_fate.sim.real_weather import (
     CACHE_TTL_S,
+    OBSERVATION_MAX_AGE_S,
     RETRY_AFTER_S,
     STALE_AFTER_S,
     RealWeatherProvider,
@@ -233,9 +234,25 @@ def test_failed_refresh_expires_last_known_observation_instead_of_loading_foreve
     assert p.unavailable("route-cell")
 
 
+def test_hourly_metar_cadence_is_still_live():
+    """NWS stations file routine observations once an hour, so the newest
+    available observation is 30-60 minutes old for most of every hour. That is
+    what "current conditions" means; it must never read as an NWS failure and
+    push the player onto simulated fallback weather."""
+    now = [2_000_000.0]
+    p = SyncProvider(
+        fetch=lambda lat, lon: ("Heavy Rain", 5.0, 12.0, 1.0, now[0] - 45 * 60.0),
+        clock=lambda: 0.0,
+        wall_clock=lambda: now[0],
+    )
+    p.request("route-cell", 40.0, -80.0)
+    assert p.get("route-cell") is WeatherKind.HEAVY_RAIN
+    assert not p.unavailable("route-cell")
+
+
 def test_old_nws_observation_timestamp_is_never_treated_as_live():
     now = [2_000_000.0]
-    old = now[0] - STALE_AFTER_S - 1
+    old = now[0] - OBSERVATION_MAX_AGE_S - 1
     p = SyncProvider(
         fetch=lambda lat, lon: ("Heavy Rain", 5.0, 12.0, 1.0, old),
         clock=lambda: 0.0,
@@ -254,7 +271,7 @@ def test_expired_observation_retries_then_recovers_to_live_weather():
         calls[0] += 1
         observed_at = wall[0]
         if calls[0] == 1:
-            observed_at -= STALE_AFTER_S + 1
+            observed_at -= OBSERVATION_MAX_AGE_S + 1
         return "Clear", 0.0, 10.0, 10.0, observed_at
 
     provider = SyncProvider(


### PR DESCRIPTION
## What changed and why

Players report the game saying "Simulated fallback weather" far more often than NWS is actually down. Root cause: the live-weather freshness gate treats any observation more than 30 minutes old as a failed fetch. NWS stations file routine METAR observations once an hour, so for most of every hour the newest observation a perfectly healthy station offers is 30-60 minutes old — the provider rejected it, marked the city failed, and the game fell back to simulated weather while the service was fine.

Observation age now has its own two-hour ceiling (`OBSERVATION_MAX_AGE_S`), matched to the hourly reporting cycle plus dissemination slack; a genuinely dead or parked station still falls back. The 30-minute `STALE_AFTER_S` window keeps its original job — how long cached data survives failed refreshes. The weather app still announces the reading's true age, so nothing gets quietly presented as fresher than it is.

## What players or maintainers will notice

With real weather on, players stay on live conditions through the normal hourly station cycle instead of hearing "Simulated fallback weather" flip in and out. The weather app's "Observation age" line keeps telling the truth about how old the reading is.

## Tests and checks run

- `uv run pytest tests/test_real_weather.py tests/test_weather_trip.py tests/test_season.py` — 122 passed; the new `test_hourly_metar_cadence_is_still_live` fails on the old code and passes on the new (verified both ways)
- `uv run ruff check src tests`

## Accessibility impact

Spoken text is unchanged; the fix only changes when the existing live/fallback wording applies. Players hear the accurate source label more often.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
