### PR TITLE
Fix quick manual shifts respecting clutch input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Quick manual downshifts now respect the clutch the moment you press it.**
+  The previous clutch over-rev fix corrected the truck simulation, but the
+  live driving controls still had a timing gap: if you pressed Shift and tapped
+  Q or W quickly, the gear-change key could be handled before the next frame
+  refreshed the clutch state. That could still produce a false redline warning
+  or engine damage even though the clutch was physically held down. Manual
+  shift inputs now recognize Shift as clutch-down immediately, so damage only
+  starts if you release the clutch while the selected gear is too low for your
+  road speed. Sorry for missing this player-input path in the first fix.
+
 ## 1.8.8.1 - 2026-08-08
 
 ### Added

--- a/src/freight_fate/states/driving_controls.py
+++ b/src/freight_fate/states/driving_controls.py
@@ -16,6 +16,8 @@ class DrivingControlsMixin:
 
         key = event.key
         tr = self.truck.transmission
+        if not tr.automatic and getattr(event, "mod", 0) & pygame.KMOD_SHIFT:
+            tr.clutch = 1.0
         if key in (pygame.K_LCTRL, pygame.K_RCTRL):
             self.ctx.stop_event_speech()
             self._set_status("Event voice stopped.")

--- a/tests/test_driving_manual_controls.py
+++ b/tests/test_driving_manual_controls.py
@@ -1,0 +1,52 @@
+import pygame
+import pytest
+from driving_feature_helpers import open_limits, quiet_trip, start_drive
+
+
+def test_shift_modified_manual_downshift_uses_clutch_before_next_update(monkeypatch):
+    from freight_fate.app import App
+
+    class Keys:
+        pressed = {pygame.K_LSHIFT}
+
+        def __getitem__(self, key):
+            return key in self.pressed
+
+    monkeypatch.setattr(pygame.key, "get_pressed", lambda: Keys())
+
+    app = App()
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        open_limits(driving)
+        app.ctx.settings.automatic_transmission = False
+        truck = driving.truck
+        truck.start_engine()
+        truck.set_air_ready(parking_brake=False)
+        truck.transmission.automatic = False
+        truck.transmission.gear = 2
+        truck.transmission.clutch = 0.0  # stale until the update loop samples held keys
+        truck.velocity_mps = 60.0 / 2.23694
+        truck.rpm = truck.specs.idle_rpm
+
+        driving.handle_event(
+            pygame.event.Event(
+                pygame.KEYDOWN,
+                key=pygame.K_q,
+                unicode="q",
+                mod=pygame.KMOD_SHIFT,
+            )
+        )
+
+        assert truck.transmission.gear == 1
+        assert truck.transmission.clutch == 1.0
+        assert truck.coupled_rpm() > truck.specs.max_rpm * 1.05
+        assert not truck.over_revving
+
+        for _ in range(5 * 60):
+            driving.update(1 / 60)
+
+        assert truck.rpm < truck.specs.max_rpm * 0.6
+        assert truck.damage_pct == pytest.approx(0.0)
+    finally:
+        app.shutdown()


### PR DESCRIPTION
## Summary
- Fix a live input timing gap where quick Shift+Q/W manual shifts could see stale clutch state.
- Add a driving-controls regression test for downshifting before the next held-key update samples the clutch.
- Document the follow-up fix in the Unreleased changelog, including an apology for the missed input path.

## Details
The earlier clutch over-rev fix corrected the truck simulation, but the driving controls can handle a gear-change key before the next frame copies held Shift into `transmission.clutch`. That meant a fast player input could still request a downshift while the transmission thought the clutch was released.

Manual shift key events now treat the Shift modifier as clutch-down immediately, so the input path matches the simulation guarantee: selecting a lower gear with the clutch held does not warn or damage the engine. Damage still begins if the clutch is released while the selected gear is too low for road speed.

## Tests
- `python -m pytest tests/test_driving_manual_controls.py tests/test_vehicle.py tests/test_driving_cruise_weather.py -k "manual_downshift_with_clutch_in or shift_modified or cruise_does_not_rev_engine_when_clutch_is_depressed" -q`
- `ruff check src/freight_fate/states/driving_controls.py tests/test_driving_manual_controls.py`
- `python -m freight_fate.app --smoke`
