### PR TITLE
Restart cloud backups when the cloud slot is empty instead of sticking in conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
   disappears.** If your account's cloud storage was reset, or you deleted a
   career's cloud backup from another computer, this computer still remembered
   the old cloud copy and treated the mismatch as a conflict -- and from then
-  on it silently stopped backing that career up. The game now notices there is
-  nothing in the cloud to protect, starts the career's backups over fresh, and
-  your next save is backed up as usual.
+  on it silently stopped backing that career up. That also trapped careers
+  whose conflict was real when it was noticed but whose cloud copy later
+  vanished. The game now checks whether there is anything in the cloud left
+  to protect before staying quiet, starts the career's backups over fresh
+  when there is not, and your next save is backed up as usual. Careers with a
+  genuine conflict -- a newer copy really is in the cloud -- still wait for
+  you to choose a side in the Cloud backup menu.
 
 - **Quick manual downshifts now respect the clutch the moment you press it.**
   The previous clutch over-rev fix corrected the truck simulation, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixed
 
+- **Cloud backup no longer goes quiet after the cloud copy of a career
+  disappears.** If your account's cloud storage was reset, or you deleted a
+  career's cloud backup from another computer, this computer still remembered
+  the old cloud copy and treated the mismatch as a conflict -- and from then
+  on it silently stopped backing that career up. The game now notices there is
+  nothing in the cloud to protect, starts the career's backups over fresh, and
+  your next save is backed up as usual.
+
 - **Quick manual downshifts now respect the clutch the moment you press it.**
   The previous clutch over-rev fix corrected the truck simulation, but the
   live driving controls still had a timing gap: if you pressed Shift and tapped

--- a/src/freight_fate/cloud_saves.py
+++ b/src/freight_fate/cloud_saves.py
@@ -690,7 +690,15 @@ class CloudSaves:
 
     def _upload_slot(self, name: str, snapshot: dict) -> None:
         slot = self.sync_state.slot(name)
-        if "conflict" in slot:
+        conflict = slot.get("conflict")
+        if conflict is not None and conflict.get("latestRevision") is None:
+            # Recorded by an older build against an empty cloud slot (wiped
+            # deployment, or deleted from another machine). No newer save
+            # exists to protect, so start the slot over instead of staying
+            # silent forever.
+            self.sync_state.forget(name)
+            slot = {}
+        elif conflict is not None:
             # Never retry into a known conflict; the player resolves it from
             # the Cloud backup menu. Drop the snapshot -- the local file is
             # still the source of truth for "keep mine".
@@ -716,6 +724,19 @@ class CloudSaves:
             log.info("Cloud backup of %s uploaded as revision %s", name, result["revision"])
             return
         if result.get("reason") == "conflict":
+            if result.get("latestRevision") is None:
+                # The cloud slot is empty -- the staging deployment was wiped,
+                # or the slot was deleted from another machine -- so there is
+                # no newer save to protect. Drop the stale revision and let the
+                # retry pass re-create the slot from this machine's save.
+                self.sync_state.forget(name)
+                self._retry_at = self._clock() + self._retry
+                log.info(
+                    "Cloud backup of %s named a revision the cloud no longer "
+                    "has; restarting the slot fresh",
+                    name,
+                )
+                return
             self.sync_state.record_conflict(name, result)
             self._done_with(name, snapshot)
             log.warning(

--- a/src/freight_fate/cloud_saves.py
+++ b/src/freight_fate/cloud_saves.py
@@ -699,11 +699,23 @@ class CloudSaves:
             self.sync_state.forget(name)
             slot = {}
         elif conflict is not None:
-            # Never retry into a known conflict; the player resolves it from
-            # the Cloud backup menu. Drop the snapshot -- the local file is
-            # still the source of truth for "keep mine".
-            self._done_with(name, snapshot)
-            return
+            # A known conflict names a real cloud revision -- but that copy
+            # may have vanished since it was recorded (deployment reset, or
+            # the slot deleted from another machine), and then there is
+            # nothing left to protect. Re-check before staying silent.
+            if self._cloud_slot_exists(name):
+                # Still there: the player resolves it from the Cloud backup
+                # menu. Drop the snapshot -- the local file is still the
+                # source of truth for "keep mine".
+                self._done_with(name, snapshot)
+                return
+            log.info(
+                "Cloud backup of %s was blocked by a conflict whose cloud "
+                "copy no longer exists; restarting the slot fresh",
+                name,
+            )
+            self.sync_state.forget(name)
+            slot = {}
         _, content_hash = cloud_content(snapshot)
         if slot.get("hash") == content_hash:
             self._done_with(name, snapshot)
@@ -778,6 +790,21 @@ class CloudSaves:
             return
         # Transient (network, 5xx): keep the snapshot, back off.
         self._retry_at = self._clock() + self._retry
+
+    def _cloud_slot_exists(self, name: str) -> bool:
+        """Whether the cloud still holds any revision of this slot. Errs on
+        the side of True: an unreachable or refusing server must keep the
+        conflict guard in place."""
+        try:
+            reply = list_saves(self._identity, transport=self._transport)
+        except CloudAuthError:
+            return True
+        if reply is None:
+            return True
+        # The reply grew a wrapper dict when the public-career choice landed;
+        # accept both shapes so this survives either side of that change.
+        entries = reply["saves"] if isinstance(reply, dict) else reply
+        return any(entry.get("saveName") == name for entry in entries)
 
     def resolve_keep_mine(self, name: str, profile_dict: dict) -> bool:
         """Conflict choice: overwrite the cloud with this machine's save.

--- a/tests/test_cloud_saves.py
+++ b/tests/test_cloud_saves.py
@@ -351,6 +351,81 @@ def test_recorded_empty_cloud_conflict_heals_on_the_next_backup():
     assert service.sync_state.slot("Road Star")["revision"] == 1
 
 
+class RoutedTransport:
+    """Serves the slot-list GET and the upload POST from one fake."""
+
+    def __init__(self, *, list_reply, upload_reply=None, list_error=None) -> None:
+        self.list_reply = list_reply
+        self.list_error = list_error
+        self.upload_reply = upload_reply or {"ok": True, "revision": 1}
+        self.requests: list[tuple[str, dict | None, dict[str, str]]] = []
+
+    def __call__(self, url: str, payload: dict | None, headers: dict[str, str]) -> dict:
+        self.requests.append((url, payload, headers))
+        if payload is None:  # the list fetch
+            if self.list_error is not None:
+                raise self.list_error
+            return self.list_reply
+        return self.upload_reply
+
+    @property
+    def posts(self) -> list[dict]:
+        return [p for _, p, _ in self.requests if p is not None]
+
+
+def test_stale_recorded_conflict_heals_when_the_cloud_slot_is_gone():
+    """A conflict recorded against a cloud copy that has since vanished
+    (deployment reset, slot deleted from another machine) must not block
+    backups forever: the guard re-checks the cloud and starts over."""
+    transport = RoutedTransport(list_reply={"ok": True, "saves": []})
+    clock = Clock()
+    service = make_service(transport, clock)
+    service.sync_state.record_synced("Road Star", 7, "stale-hash")
+    service.sync_state.record_conflict(
+        "Road Star",
+        {"latestRevision": 40, "latestCreatedAt": 1_700_000_000_000, "latestSummary": "level 18"},
+    )
+    profile = Profile(name="Road Star")
+
+    service.queue_backup(profile)
+    drain(service, clock)
+    assert len(transport.posts) == 1
+    assert transport.posts[0]["parentRevision"] is None
+    assert service.conflicts() == {}
+    assert service.sync_state.slot("Road Star")["revision"] == 1
+
+
+def test_recorded_conflict_with_a_live_cloud_copy_still_blocks():
+    transport = RoutedTransport(
+        list_reply={"ok": True, "saves": [{"saveName": "Road Star", "revision": 40}]}
+    )
+    clock = Clock()
+    service = make_service(transport, clock)
+    service.sync_state.record_synced("Road Star", 7, "stale-hash")
+    service.sync_state.record_conflict("Road Star", {"latestRevision": 40})
+    profile = Profile(name="Road Star")
+
+    service.queue_backup(profile)
+    drain(service, clock)
+    # The other machine's newer save is still at stake: nothing uploads and
+    # the conflict stays for the player to resolve.
+    assert transport.posts == []
+    assert "Road Star" in service.conflicts()
+
+
+def test_conflict_recheck_that_cannot_reach_the_cloud_keeps_the_guard():
+    transport = RoutedTransport(list_reply={}, list_error=OSError("no route"))
+    clock = Clock()
+    service = make_service(transport, clock)
+    service.sync_state.record_conflict("Road Star", {"latestRevision": 40})
+    profile = Profile(name="Road Star")
+
+    service.queue_backup(profile)
+    drain(service, clock)
+    assert transport.posts == []
+    assert "Road Star" in service.conflicts()
+
+
 def test_keep_mine_overwrites_the_cloud_and_clears_the_conflict():
     transport = FakeTransport(error=conflict_error(latest_revision=5))
     clock = Clock()

--- a/tests/test_cloud_saves.py
+++ b/tests/test_cloud_saves.py
@@ -304,6 +304,53 @@ def test_conflict_marks_the_slot_and_stops_backups():
     assert len(transport.posts) == 1
 
 
+def test_empty_cloud_conflict_restarts_the_slot_instead_of_sticking():
+    """A conflict whose latest revision is null means the cloud slot is empty
+    (the deployment was wiped, or the slot was deleted from another machine).
+    There is no newer save at stake, so the guard must not stick: the slot
+    starts over as a fresh upload instead of silently never backing up again.
+    """
+    transport = FakeTransport(error=conflict_error(latest_revision=None))
+    clock = Clock()
+    service = make_service(transport, clock)
+    # This machine remembers a revision the server no longer has.
+    service.sync_state.record_synced("Road Star", 7, "stale-hash")
+    profile = Profile(name="Road Star")
+
+    service.queue_backup(profile)
+    drain(service, clock)
+    assert len(transport.posts) == 1
+    assert transport.posts[0]["parentRevision"] == 7
+    # Not a real conflict: nothing is recorded for the player to resolve.
+    assert service.conflicts() == {}
+
+    # The stale revision is gone, and the retry goes out as a fresh slot.
+    transport.error = None
+    clock.advance(RETRY_INTERVAL_S + 0.1)
+    service.pump()
+    assert len(transport.posts) == 2
+    assert transport.posts[1]["parentRevision"] is None
+    assert service.sync_state.slot("Road Star")["revision"] == 1
+
+
+def test_recorded_empty_cloud_conflict_heals_on_the_next_backup():
+    """Older builds recorded the empty-cloud conflict as sticky. A save made
+    under this build must clear that mark and back up fresh."""
+    transport = FakeTransport()
+    clock = Clock()
+    service = make_service(transport, clock)
+    service.sync_state.record_synced("Road Star", 7, "stale-hash")
+    service.sync_state.record_conflict("Road Star", {"latestRevision": None})
+    profile = Profile(name="Road Star")
+
+    service.queue_backup(profile)
+    drain(service, clock)
+    assert len(transport.posts) == 1
+    assert transport.posts[0]["parentRevision"] is None
+    assert service.conflicts() == {}
+    assert service.sync_state.slot("Road Star")["revision"] == 1
+
+
 def test_keep_mine_overwrites_the_cloud_and_clears_the_conflict():
     transport = FakeTransport(error=conflict_error(latest_revision=5))
     clock = Clock()


### PR DESCRIPTION
## What changed and why

Two ways a career's cloud backups could silently stop forever, both seen in
tester sync states after the 2026-08-11 staging data wipe:

1. **Empty-cloud conflict.** A conflict reply with a null `latestRevision`
   means the cloud slot is empty — the deployment's data was reset, or the
   slot was deleted from another computer. The guard treated it like a real
   conflict: recorded sticky, never retried (`Cloud backup of TigerDaddy
   skipped: the cloud copy is newer (revision None)` in jerry's log). An
   empty slot has no newer save to protect, so the client now drops the
   stale sync state and re-uploads fresh on the next retry pass; conflict
   marks recorded by older builds heal the same way on the next save.

2. **Stale recorded conflict.** Shane's `cloud_saves.json` showed a conflict
   recorded pre-wipe against a real revision (`latestRevision: 40`) whose
   cloud copy no longer exists. The guard skipped the upload before ever
   asking the server, so the stall outlived case 1's fix. A recorded
   conflict now re-checks whether the slot still exists in the cloud before
   blocking a backup; if the slot is gone, the conflict is stale and the
   slot restarts fresh.

Real conflicts — the cloud copy still exists — keep the exact same sticky
behavior and spoken resolution flow, and the re-check errs on the side of
keeping the guard when the server is unreachable or refuses credentials.

## What players or maintainers will notice

Careers that quietly stopped backing up after a cloud reset or remote delete
resume backing up on their next save, with no action needed. Nothing changes
for genuine two-machine conflicts.

## Tests and checks run

- `uv run pytest tests/test_cloud_saves.py -n 0` — 41 tests, all pass. Five
  new: empty-cloud conflict restarts the slot; a previously recorded sticky
  empty-cloud conflict heals on the next backup; a stale recorded conflict
  heals when the cloud slot is gone; a recorded conflict with a live cloud
  copy still blocks; a re-check that cannot reach the cloud keeps the guard.
- `uv run ruff check` and byte-compile on the touched files.

## Accessibility impact

No spoken text or keyboard flow changes. The healed paths remove a silent
failure state that previously contradicted the spoken "Cloud backup is
ready" status.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
