### PR TITLE
fix(input): driving keys read as held under JAWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@
 
 ### Fixed
 
+- **Driving keys now work with JAWS without the pass-through key.** JAWS
+  hands the game each arrow key as an instant tap rather than a held key,
+  so holding Up, Down, Left, or Right to accelerate, brake, or steer did
+  nothing until you pressed JAWS Key and 3 before every key. The game now
+  reads the stream of taps JAWS sends while a key is held as the hold it
+  is, so you drive with the same keys as everyone else, and letting go
+  releases the pedal or the wheel within a fraction of a second. Menus
+  were never affected. One limit remains: JAWS never tells the game how
+  long you held a key, so a single quick tap of a pedal reads as a short
+  press of about half a second.
+
 - **The cloud backup list now tells you how to fix a conflict.** A career
   whose backups stopped because another computer changed the cloud copy now
   says, in the list and inside the career, that opening it lets you choose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@
   so holding Up, Down, Left, or Right to accelerate, brake, or steer did
   nothing until you pressed JAWS Key and 3 before every key. The game now
   reads the stream of taps JAWS sends while a key is held as the hold it
-  is, so you drive with the same keys as everyone else, and letting go
-  releases the pedal or the wheel within a fraction of a second. Menus
-  were never affected. One limit remains: JAWS never tells the game how
-  long you held a key, so a single quick tap of a pedal reads as a short
-  press of about half a second.
+  is, so you drive with the same keys as everyone else. Menus were never
+  affected. Two limits remain, because JAWS only re-sends a held key
+  about four times a second and never says how long you held it: letting
+  go of a pedal or the wheel takes effect about a third of a second
+  later, and a single quick tap of a pedal reads as a short press of
+  about half a second.
 
 - **The cloud backup list now tells you how to fix a conflict.** A career
   whose backups stopped because another computer changed the cloud copy now

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,6 +43,21 @@ milestone below (speeding consequences especially).
 
 From a batch of player reports:
 
+- [x] **Driving keys did nothing under JAWS without JAWS Key+3 -- FIXED
+  2026-08-24 (player report relayed by Norm, 1.8.8).** JAWS binds the
+  arrows to its own scripts in every application, swallows the physical
+  key, and re-sends it as an instant press-and-release pair, once per
+  keyboard auto-repeat; driving polls `pygame.key.get_pressed()` and
+  never saw a hold (menus react to the press event, so they worked).
+  `held_keys.py` turns the pair train back into a hold sized to the
+  Windows repeat delay and rate, OR'd with SDL's own state so the
+  physical-keyboard path is byte-for-byte what it was. `tools/key_probe.py`
+  logs what any screen reader actually delivers.
+- [ ] Under a key-re-sending screen reader a tap cannot be told from a
+  hold until the first auto-repeat, so tap-length gestures (1.9's
+  double-tap-and-hold pedal latch) are invisible through JAWS; a gesture
+  counted in press events would see them. Run the probe on a JAWS
+  machine and tighten the grace constants to the measured pair timing.
 - [x] **Map screen read raw data keys for the route -- FIXED 2026-07-21
   (NVDA player report).** Its first line joined the world's city slugs, so an
   east-coast run opened with "new underscore york underscore n y underscore u

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,15 +49,19 @@ From a batch of player reports:
   key, and re-sends it as an instant press-and-release pair, once per
   keyboard auto-repeat; driving polls `pygame.key.get_pressed()` and
   never saw a hold (menus react to the press event, so they worked).
-  `held_keys.py` turns the pair train back into a hold sized to the
-  Windows repeat delay and rate, OR'd with SDL's own state so the
-  physical-keyboard path is byte-for-byte what it was. `tools/key_probe.py`
-  logs what any screen reader actually delivers.
+  `held_keys.py` turns the pair train back into a hold, OR'd with SDL's
+  own state so the physical-keyboard path is byte-for-byte what it was.
+  Measured with `tools/key_probe.py` on Norm's JAWS machine the same day:
+  first repeat at the Windows delay (512 ms), then pairs every ~250 ms
+  (242-272) -- JAWS's script, not the 33 ms Windows rate -- so the
+  tracker learns the spacing from the pairs themselves and sizes the
+  hold to it; release reads ~370 ms late under JAWS, the price of a
+  four-a-second poll.
 - [ ] Under a key-re-sending screen reader a tap cannot be told from a
   hold until the first auto-repeat, so tap-length gestures (1.9's
   double-tap-and-hold pedal latch) are invisible through JAWS; a gesture
-  counted in press events would see them. Run the probe on a JAWS
-  machine and tighten the grace constants to the measured pair timing.
+  counted in press events would see them. Second JAWS machine's probe
+  log would confirm the ~250 ms spacing is JAWS-typical, not Norm's box.
 - [x] **Map screen read raw data keys for the route -- FIXED 2026-07-21
   (NVDA player report).** Its first line joined the world's city slugs, so an
   east-coast run opened with "new underscore york underscore n y underscore u

--- a/src/freight_fate/app.py
+++ b/src/freight_fate/app.py
@@ -19,6 +19,7 @@ from .cloud_saves import CloudSaves
 from .controller import ControllerManager
 from .data.world import World, get_world
 from .discord_presence import DiscordPresence
+from .held_keys import HeldKeys
 from .message_log import MessageCategory, MessageLog
 from .models.economy import Economy
 from .models.profile import Profile
@@ -84,6 +85,7 @@ class GameContext:
         self.speech: Speech = app.speech
         self.audio: AudioEngine = app.audio
         self.controller: ControllerManager = app.controller
+        self.held_keys: HeldKeys = app.held_keys
         self.settings: Settings = app.settings
         self.world: World = app.world
         self.economy: Economy = app.economy
@@ -395,6 +397,10 @@ class App:
             enabled=self.settings.controller_enabled,
             haptics=self.settings.haptics_enabled,
         )
+        # What the player is holding, as driving polls it. Fed from the
+        # event loop so a screen reader that re-sends keys as instant
+        # press-and-release pairs (JAWS) still reads as a hold.
+        self.held_keys = HeldKeys()
         self.ctx = GameContext(self)
         self.ctx.apply_volumes()
         self.ctx.apply_speech()
@@ -409,6 +415,7 @@ class App:
         return self.states[-1] if self.states else None
 
     def push_state(self, state: State, should_enter: bool = True) -> None:
+        self.held_keys.clear()  # a new screen never inherits held keys
         self.states.append(state)
         if should_enter:
             state.enter()
@@ -421,6 +428,7 @@ class App:
         state, so they use this instead of pop_state.
         """
         if self.states:
+            self.held_keys.clear()
             state = self.states.pop()
             if should_exit:
                 state.exit()
@@ -502,7 +510,9 @@ class App:
                     with contextlib.suppress(Exception):
                         pygame.event.pump()
                     continue
+                self.held_keys.begin_frame(pygame.time.get_ticks())
                 for event in events:
+                    self.held_keys.note(event)
                     if event.type == pygame.WINDOWFOCUSGAINED:
                         # Switching screen readers happens outside the game;
                         # re-check speech the moment the player comes back.

--- a/src/freight_fate/held_keys.py
+++ b/src/freight_fate/held_keys.py
@@ -13,27 +13,33 @@ poll never catches: menus react to the press event and work, driving polls
 and does nothing until the player passes one key through with JAWS Key+3.
 Holding the key does not help by itself, but the keyboard's auto-repeat
 still runs underneath; every repeat goes through the same hook and arrives
-as another press-and-release pair, at the operating system's repeat delay
-and rate.
+as another press-and-release pair. Measured on the owner's JAWS machine
+(2026-08-24): the first repeat lands at the Windows repeat delay (512 ms),
+and the rest at about 250 ms apart -- not the 33 ms Windows rate, because
+JAWS's script takes that long per key and the repeats queue behind it.
 
-This tracker turns that train back into a hold. Every press starts a pulse
-sized to the operating system's repeat timing: long enough to reach the
-first auto-repeat after a fresh press, and just past one repeat interval
-once repeats are arriving. A release that lands in the same frame as its
-press (or the next one) is synthetic -- nobody taps a key inside one frame
--- and leaves the pulse alone; a release any later is the player's finger
-and ends it. The driving loop reads a key as held when SDL says so OR a
-pulse is alive, so the physical-keyboard path is exactly what it always was
-and the re-injected path reads as a hold that lapses about one repeat
-interval after the finger lifts.
+This tracker turns that train back into a hold. Every press starts a pulse:
+a fresh press gets one long enough to reach the first auto-repeat (the
+operating system's delay plus grace); a repeat gets one just past the
+spacing the repeats are actually arriving at, which the tracker learns from
+the pairs themselves (second repeat onward, synthetic pairs only) and keeps
+for the rest of the session. Until it has learned that spacing, repeats get
+the fresh pulse too, so the very first hold never stutters. A release that
+lands in the same frame as its press (or the next one) is synthetic --
+nobody taps a key inside one frame -- and leaves the pulse alone; a release
+any later is the player's finger and ends it. The driving loop reads a key
+as held when SDL says so OR a pulse is alive, so the physical-keyboard path
+is exactly what it always was and the re-injected path reads as a hold
+that lapses one learned spacing plus grace after the last pair.
 
 Two honest limits. A screen reader that re-injects keys never shows the game
 how long a tap lasted, so under JAWS a tap reads as a hold for the repeat
-delay (half a second at the Windows default) and a gesture built on tap
-length cannot be seen. And the game cannot tell whether such a screen
-reader is running, so the pulse logic is always on; on the physical path it
-only ever adds a hold when a whole press-and-release arrives inside one
-short frame, which a finger cannot do.
+delay (half a second at the Windows default), letting go reads about a
+third of a second late, and a gesture built on tap length cannot be seen.
+And the game cannot tell whether such a screen reader is running, so the
+pulse logic is always on; on the physical path it only ever adds a hold
+when a whole press-and-release arrives inside one short frame, which a
+finger cannot do.
 """
 
 from __future__ import annotations
@@ -52,11 +58,11 @@ log = logging.getLogger(__name__)
 DEFAULT_REPEAT_DELAY_MS = 500
 DEFAULT_REPEAT_INTERVAL_MS = 33
 
-# Grace on top of the operating system's timing. The fresh-press pulse has
-# to outlast the repeat delay plus the screen reader's script latency and a
-# frame of batching; the per-repeat pulse has to outlast one interval plus
-# a frame, and it is how long after the finger lifts the key still reads
-# held, so it stays short.
+# Grace on top of the measured timing. The fresh-press pulse has to outlast
+# the repeat delay plus the screen reader's script latency and a frame of
+# batching; the per-repeat pulse has to outlast one spacing plus jitter
+# (about 30 ms measured) and a frame, and it is how long after the finger
+# lifts the key still reads held, so it stays short.
 FRESH_GRACE_MS = 150
 REPEAT_GRACE_MS = 100
 
@@ -74,6 +80,11 @@ SYNTHETIC_FRAME_MAX_MS = 40
 # system's first auto-repeat (which never fires early), so it is a new tap of
 # the same key and earns a fresh full pulse.
 REPEAT_EARLY_TOLERANCE_MS = 60
+
+# The learned repeat spacing is the largest of this many recent spacings, so
+# one slow script run widens the window at once and a run of quick ones
+# narrows it again only once it has aged out.
+LEARNED_SPACINGS = 8
 
 _SPI_GETKEYBOARDDELAY = 0x0016
 _SPI_GETKEYBOARDSPEED = 0x000A
@@ -139,7 +150,8 @@ class HeldKeys:
     ``begin_frame`` once per frame with the frame's tick time, ``note`` for
     every event, ``snapshot`` whenever a state wants to poll. ``clear``
     forgets the pulses (the app calls it when the state stack changes, so a
-    screen never inherits the last screen's held keys).
+    screen never inherits the last screen's held keys); what the tracker
+    has learned about the repeat spacing survives it.
     """
 
     def __init__(
@@ -157,7 +169,10 @@ class HeldKeys:
         self._frame_span_ms = 0
         self._pulse_until: dict[int, int] = {}
         self._train_start: dict[int, int] = {}
+        self._train_repeats: dict[int, int] = {}
         self._pressed_at: dict[int, int] = {}
+        self._last_pair_synthetic: dict[int, bool] = {}
+        self._spacings: list[int] = []
 
     # -- timing -------------------------------------------------------------------
 
@@ -170,14 +185,26 @@ class HeldKeys:
         return self._interval_ms
 
     @property
+    def learned_spacing_ms(self) -> int | None:
+        """The spacing re-injected repeats are actually arriving at, once seen."""
+        return max(self._spacings) if self._spacings else None
+
+    @property
     def fresh_pulse_ms(self) -> int:
         """How long a lone press reads held: to the first auto-repeat, plus grace."""
         return self._delay_ms + FRESH_GRACE_MS
 
     @property
     def repeat_pulse_ms(self) -> int:
-        """How long each repeat extends the hold: one interval, plus grace."""
-        return self._interval_ms + REPEAT_GRACE_MS
+        """How long each repeat extends the hold: one spacing, plus grace.
+
+        The spacing is the learned one when there is one (never shorter than
+        the operating system's own rate); before anything is learned it is
+        the fresh pulse, so the first hold of a session cannot stutter."""
+        learned = self.learned_spacing_ms
+        if learned is None:
+            return self.fresh_pulse_ms
+        return max(self._interval_ms, learned) + REPEAT_GRACE_MS
 
     def refresh_repeat_timing(self) -> None:
         """Re-read the operating system's repeat timing (on window focus, so a
@@ -205,6 +232,7 @@ class HeldKeys:
     def clear(self) -> None:
         self._pulse_until.clear()
         self._train_start.clear()
+        self._train_repeats.clear()
 
     def _press(self, key: int) -> None:
         now = self._now
@@ -216,12 +244,27 @@ class HeldKeys:
             and now - start >= self._delay_ms - REPEAT_EARLY_TOLERANCE_MS
         )
         if repeating:
+            repeats = self._train_repeats.get(key, 0) + 1
+            self._train_repeats[key] = repeats
+            # The first repeat sits at the delay, not the rate; from the
+            # second on, the gap to the previous pair is the real spacing --
+            # but only synthetic pairs teach it, a finger's rhythm never does.
+            previous = self._pressed_at.get(key)
+            if (
+                repeats >= 2
+                and previous is not None
+                and self._last_pair_synthetic.get(key, False)
+                and now - previous < self._delay_ms - REPEAT_EARLY_TOLERANCE_MS
+            ):
+                self._learn_spacing(now - previous)
             window = self.repeat_pulse_ms
         else:
             window = self.fresh_pulse_ms
             self._train_start[key] = now
+            self._train_repeats[key] = 0
         self._pulse_until[key] = max(until, now + window)
         self._pressed_at[key] = now
+        self._last_pair_synthetic[key] = False
 
     def _release(self, key: int) -> None:
         pressed_at = self._pressed_at.get(key)
@@ -231,9 +274,15 @@ class HeldKeys:
             and self._frame_span_ms <= SYNTHETIC_FRAME_MAX_MS
         )
         if synthetic:
+            self._last_pair_synthetic[key] = True
             return
         self._pulse_until.pop(key, None)
         self._train_start.pop(key, None)
+        self._train_repeats.pop(key, None)
+
+    def _learn_spacing(self, spacing_ms: int) -> None:
+        self._spacings.append(int(spacing_ms))
+        del self._spacings[:-LEARNED_SPACINGS]
 
     # -- reading --------------------------------------------------------------------
 
@@ -244,6 +293,7 @@ class HeldKeys:
         for key in dead:
             self._pulse_until.pop(key, None)
             self._train_start.pop(key, None)
+            self._train_repeats.pop(key, None)
         return frozenset(self._pulse_until)
 
     def snapshot(self, pressed: Mapping[int, bool] | None = None) -> HeldSnapshot:

--- a/src/freight_fate/held_keys.py
+++ b/src/freight_fate/held_keys.py
@@ -1,0 +1,254 @@
+"""Held keys as the driving loop should see them, screen reader or not.
+
+Driving reads the pedals and the wheel by polling: is Up down right now?
+``pygame.key.get_pressed()`` answers from the key events SDL received, and
+with no screen reader, or with NVDA, that is the physical keyboard: a held
+key reads held until the finger lifts.
+
+JAWS is different. It binds the arrow keys to its own scripts in every
+application, so its keyboard hook swallows the physical press, runs the
+script, and re-sends the key to the application as a synthetic
+press-and-release pair. The game sees a tap that lasts zero frames, which a
+poll never catches: menus react to the press event and work, driving polls
+and does nothing until the player passes one key through with JAWS Key+3.
+Holding the key does not help by itself, but the keyboard's auto-repeat
+still runs underneath; every repeat goes through the same hook and arrives
+as another press-and-release pair, at the operating system's repeat delay
+and rate.
+
+This tracker turns that train back into a hold. Every press starts a pulse
+sized to the operating system's repeat timing: long enough to reach the
+first auto-repeat after a fresh press, and just past one repeat interval
+once repeats are arriving. A release that lands in the same frame as its
+press (or the next one) is synthetic -- nobody taps a key inside one frame
+-- and leaves the pulse alone; a release any later is the player's finger
+and ends it. The driving loop reads a key as held when SDL says so OR a
+pulse is alive, so the physical-keyboard path is exactly what it always was
+and the re-injected path reads as a hold that lapses about one repeat
+interval after the finger lifts.
+
+Two honest limits. A screen reader that re-injects keys never shows the game
+how long a tap lasted, so under JAWS a tap reads as a hold for the repeat
+delay (half a second at the Windows default) and a gesture built on tap
+length cannot be seen. And the game cannot tell whether such a screen
+reader is running, so the pulse logic is always on; on the physical path it
+only ever adds a hold when a whole press-and-release arrives inside one
+short frame, which a finger cannot do.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Mapping
+
+import pygame
+
+log = logging.getLogger(__name__)
+
+# Fallbacks when the operating system will not say: the Windows defaults
+# (delay setting 1 of 0..3 is 500 ms; rate setting 31 of 0..31 is about 30
+# repeats per second).
+DEFAULT_REPEAT_DELAY_MS = 500
+DEFAULT_REPEAT_INTERVAL_MS = 33
+
+# Grace on top of the operating system's timing. The fresh-press pulse has
+# to outlast the repeat delay plus the screen reader's script latency and a
+# frame of batching; the per-repeat pulse has to outlast one interval plus
+# a frame, and it is how long after the finger lifts the key still reads
+# held, so it stays short.
+FRESH_GRACE_MS = 150
+REPEAT_GRACE_MS = 100
+
+# A release this soon after its press is synthetic: the same frame, or the
+# next one at 60 frames per second. The fastest finger tap is far longer.
+SYNTHETIC_GAP_MS = 25
+
+# ...but only when the frame was a normal one. After a long hitch a whole
+# real tap can land in one batch, and then the honest answer is "not held",
+# never a half-second hold. A re-injected pair dropped this way costs
+# nothing: the next repeat pair re-establishes the hold a frame later.
+SYNTHETIC_FRAME_MAX_MS = 40
+
+# A press this soon after its pulse train began cannot be the operating
+# system's first auto-repeat (which never fires early), so it is a new tap of
+# the same key and earns a fresh full pulse.
+REPEAT_EARLY_TOLERANCE_MS = 60
+
+_SPI_GETKEYBOARDDELAY = 0x0016
+_SPI_GETKEYBOARDSPEED = 0x000A
+
+
+def repeat_delay_ms(setting: int) -> int:
+    """Windows keyboard delay setting (0..3) to milliseconds before the
+    first auto-repeat: 250 ms per step, so 0 is 250 ms and 3 is a second."""
+    return (max(0, min(3, int(setting))) + 1) * 250
+
+
+def repeat_interval_ms(setting: int) -> int:
+    """Windows keyboard speed setting (0..31) to milliseconds between
+    auto-repeats: 0 is about 2.5 repeats per second, 31 about 30."""
+    rate = 2.5 + 27.5 * max(0, min(31, int(setting))) / 31
+    return round(1000 / rate)
+
+
+def os_repeat_timing() -> tuple[int, int]:
+    """(delay, interval) in ms of the keyboard auto-repeat, from Windows when
+    it answers, else the defaults. Only Windows has JAWS, and only Windows
+    exposes the setting this cheaply, so nothing else is asked."""
+    if sys.platform != "win32":
+        return DEFAULT_REPEAT_DELAY_MS, DEFAULT_REPEAT_INTERVAL_MS
+    try:
+        import ctypes
+
+        user32 = ctypes.windll.user32
+        delay = ctypes.c_uint(0)
+        speed = ctypes.c_uint(0)
+        got_delay = user32.SystemParametersInfoW(_SPI_GETKEYBOARDDELAY, 0, ctypes.byref(delay), 0)
+        got_speed = user32.SystemParametersInfoW(_SPI_GETKEYBOARDSPEED, 0, ctypes.byref(speed), 0)
+    except Exception:
+        log.debug("Keyboard repeat timing unavailable; using defaults", exc_info=True)
+        return DEFAULT_REPEAT_DELAY_MS, DEFAULT_REPEAT_INTERVAL_MS
+    delay_ms = repeat_delay_ms(delay.value) if got_delay else DEFAULT_REPEAT_DELAY_MS
+    interval_ms = repeat_interval_ms(speed.value) if got_speed else DEFAULT_REPEAT_INTERVAL_MS
+    return delay_ms, interval_ms
+
+
+class HeldSnapshot:
+    """One frame's answer to "is this key held?", indexed like
+    ``pygame.key.get_pressed()`` so the driving code reads it unchanged."""
+
+    __slots__ = ("_pressed", "_pulsed")
+
+    def __init__(self, pressed, pulsed: frozenset[int]) -> None:
+        self._pressed = pressed
+        self._pulsed = pulsed
+
+    def __getitem__(self, key: int) -> bool:
+        return bool(self._pressed[key]) or key in self._pulsed
+
+    @property
+    def pulsed(self) -> frozenset[int]:
+        """Keys held only by a re-injected press train (for diagnostics)."""
+        return self._pulsed
+
+
+class HeldKeys:
+    """Track which keys the player is holding, fed by the app's event loop.
+
+    ``begin_frame`` once per frame with the frame's tick time, ``note`` for
+    every event, ``snapshot`` whenever a state wants to poll. ``clear``
+    forgets the pulses (the app calls it when the state stack changes, so a
+    screen never inherits the last screen's held keys).
+    """
+
+    def __init__(
+        self,
+        repeat_delay_ms: int | None = None,
+        repeat_interval_ms: int | None = None,
+    ) -> None:
+        if repeat_delay_ms is None or repeat_interval_ms is None:
+            os_delay, os_interval = os_repeat_timing()
+            repeat_delay_ms = os_delay if repeat_delay_ms is None else repeat_delay_ms
+            repeat_interval_ms = os_interval if repeat_interval_ms is None else repeat_interval_ms
+        self._delay_ms = int(repeat_delay_ms)
+        self._interval_ms = int(repeat_interval_ms)
+        self._now = 0
+        self._frame_span_ms = 0
+        self._pulse_until: dict[int, int] = {}
+        self._train_start: dict[int, int] = {}
+        self._pressed_at: dict[int, int] = {}
+
+    # -- timing -------------------------------------------------------------------
+
+    @property
+    def repeat_delay_ms(self) -> int:
+        return self._delay_ms
+
+    @property
+    def repeat_interval_ms(self) -> int:
+        return self._interval_ms
+
+    @property
+    def fresh_pulse_ms(self) -> int:
+        """How long a lone press reads held: to the first auto-repeat, plus grace."""
+        return self._delay_ms + FRESH_GRACE_MS
+
+    @property
+    def repeat_pulse_ms(self) -> int:
+        """How long each repeat extends the hold: one interval, plus grace."""
+        return self._interval_ms + REPEAT_GRACE_MS
+
+    def refresh_repeat_timing(self) -> None:
+        """Re-read the operating system's repeat timing (on window focus, so a
+        player who changed the keyboard settings gets them without a restart)."""
+        self._delay_ms, self._interval_ms = os_repeat_timing()
+
+    # -- feeding --------------------------------------------------------------------
+
+    def begin_frame(self, now_ms: int) -> None:
+        self._frame_span_ms = now_ms - self._now if self._now else 0
+        self._now = now_ms
+
+    def note(self, event: pygame.event.Event) -> None:
+        if event.type == pygame.KEYDOWN:
+            self._press(event.key)
+        elif event.type == pygame.KEYUP:
+            self._release(event.key)
+        elif event.type == pygame.WINDOWFOCUSLOST:
+            # SDL releases every key when the window loses focus; the pulses
+            # go with them so alt-tabbing away never leaves a pedal down.
+            self.clear()
+        elif event.type == pygame.WINDOWFOCUSGAINED:
+            self.refresh_repeat_timing()
+
+    def clear(self) -> None:
+        self._pulse_until.clear()
+        self._train_start.clear()
+
+    def _press(self, key: int) -> None:
+        now = self._now
+        until = self._pulse_until.get(key, 0)
+        start = self._train_start.get(key)
+        repeating = (
+            until > now
+            and start is not None
+            and now - start >= self._delay_ms - REPEAT_EARLY_TOLERANCE_MS
+        )
+        if repeating:
+            window = self.repeat_pulse_ms
+        else:
+            window = self.fresh_pulse_ms
+            self._train_start[key] = now
+        self._pulse_until[key] = max(until, now + window)
+        self._pressed_at[key] = now
+
+    def _release(self, key: int) -> None:
+        pressed_at = self._pressed_at.get(key)
+        synthetic = (
+            pressed_at is not None
+            and self._now - pressed_at <= SYNTHETIC_GAP_MS
+            and self._frame_span_ms <= SYNTHETIC_FRAME_MAX_MS
+        )
+        if synthetic:
+            return
+        self._pulse_until.pop(key, None)
+        self._train_start.pop(key, None)
+
+    # -- reading --------------------------------------------------------------------
+
+    def pulsed(self) -> frozenset[int]:
+        """Keys a re-injected press train is holding as of this frame."""
+        now = self._now
+        dead = [key for key, until in self._pulse_until.items() if until <= now]
+        for key in dead:
+            self._pulse_until.pop(key, None)
+            self._train_start.pop(key, None)
+        return frozenset(self._pulse_until)
+
+    def snapshot(self, pressed: Mapping[int, bool] | None = None) -> HeldSnapshot:
+        """This frame's held keys: SDL's own state (``pygame.key.get_pressed``
+        unless ``pressed`` is given) plus any live pulse."""
+        if pressed is None:
+            pressed = pygame.key.get_pressed()
+        return HeldSnapshot(pressed, self.pulsed())

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -48,7 +48,11 @@ class DrivingUpdateMixin:
                 # fresh, closer instruction once the normal window reaches them.
                 self._destination_exit_announced_key = ""
         self._sync_weather_source()
-        keys = pygame.key.get_pressed()
+        # Not the raw SDL state: the tracker also holds a key through the
+        # press-and-release pairs a screen reader such as JAWS re-sends in
+        # place of the physical key, so a held arrow drives under JAWS
+        # without the pass-through key (see held_keys.py).
+        keys = self.ctx.held_keys.snapshot()
         ramp = dt * 2.2
         self._brake_lockout_cue_timer = max(0.0, self._brake_lockout_cue_timer - dt)
         self._lane_rumble_timer = max(0.0, self._lane_rumble_timer - dt)

--- a/tests/test_held_keys.py
+++ b/tests/test_held_keys.py
@@ -1,10 +1,12 @@
 """The held-key tracker: driving must read a held arrow under JAWS.
 
 JAWS swallows the physical arrow key and re-sends it to the game as an
-instant press-and-release pair, once per keyboard auto-repeat. A poll of
-``pygame.key.get_pressed()`` never sees it held. The tracker turns the
-train of pairs back into one hold, without changing what the physical
-keyboard path (no screen reader, NVDA) reads.
+instant press-and-release pair: one at the press, one at the Windows repeat
+delay, then one per repeat at whatever spacing its script manages (about
+250 ms on the owner's machine, measured 2026-08-24, not the 33 ms Windows
+rate). A poll of ``pygame.key.get_pressed()`` never sees it held. The
+tracker turns the train of pairs back into one hold, without changing what
+the physical keyboard path (no screen reader, NVDA) reads.
 """
 
 import pygame
@@ -22,6 +24,9 @@ from freight_fate.held_keys import (
 FRAME_MS = 16  # 60 frames per second, as the game runs
 DELAY_MS = 500  # the Windows default auto-repeat delay
 INTERVAL_MS = 33  # ...and rate (about 30 per second)
+# The owner's JAWS log, 2026-08-24: first repeat at 512 ms, then these.
+JAWS_FIRST_REPEAT_MS = 512
+JAWS_SPACINGS_MS = [263, 245, 269, 271, 242, 251, 270, 250, 244, 271, 249, 242, 254, 250]
 
 
 class NoKeys:
@@ -64,21 +69,38 @@ class Sim:
     def held(self, key, pressed=None):
         return self.tracker.snapshot(pressed if pressed is not None else NoKeys())[key]
 
-    def jaws_hold(self, key, seconds):
-        """What JAWS delivers for a key held ``seconds``: a pair now, then a
-        pair per auto-repeat after the delay. Returns the frames it read held."""
-        start = self.now
-        end = start + int(seconds * 1000)
-        next_pair = start
-        held_frames = []
+    def pair_times(self, start, seconds, first_repeat=DELAY_MS, spacings=(INTERVAL_MS,)):
+        """When a screen reader re-sends pairs for a key held ``seconds``."""
+        times = [start, start + first_repeat]
+        i = 0
+        while times[-1] < start + int(seconds * 1000):
+            times.append(times[-1] + spacings[i % len(spacings)])
+            i += 1
+        return [t for t in times if t < start + int(seconds * 1000)]
+
+    def screen_reader_hold(self, key, seconds, first_repeat=DELAY_MS, spacings=(INTERVAL_MS,)):
+        """Deliver the pairs for a hold, frame by frame; return each frame's
+        held reading from the first pair on."""
+        pairs = self.pair_times(self.now, seconds, first_repeat, spacings)
+        end = self.now + int(seconds * 1000)
+        readings = []
         while self.now < end:
             events = ()
-            if self.now >= next_pair:
+            if pairs and self.now >= pairs[0]:
                 events = (down(key), up(key))
-                next_pair = (start + DELAY_MS) if next_pair == start else next_pair + INTERVAL_MS
+                pairs.pop(0)
             self.frame(*events)
-            held_frames.append(self.held(key))
-        return held_frames
+            readings.append(self.held(key))
+        return readings
+
+    def frames_until_released(self, key, limit_ms=2000):
+        start = self.now
+        while self.held(key):
+            self.frame()
+            assert self.now - start <= limit_ms, (
+                f"still held {self.now - start} ms after the pairs stopped"
+            )
+        return self.now - start
 
 
 def test_physical_hold_still_reads_straight_from_sdl():
@@ -101,20 +123,55 @@ def test_a_re_injected_pair_reads_held_until_the_first_repeat_would_come():
     assert not sim.held(pygame.K_UP)
 
 
-def test_a_repeat_train_is_one_continuous_hold_that_lapses_quickly():
+def test_the_owners_jaws_train_is_one_continuous_hold_from_the_first_pair():
+    """Replays the measured log: no learned spacing yet, 250 ms repeats."""
     sim = Sim()
-    frames = sim.jaws_hold(pygame.K_UP, 2.0)
-    assert all(frames), f"the hold broke at frame {frames.index(False)} of {len(frames)}"
-    released_at = sim.now
-    while sim.held(pygame.K_UP):
-        sim.frame()
-        assert sim.now - released_at <= INTERVAL_MS + REPEAT_GRACE_MS + 2 * FRAME_MS
+    readings = sim.screen_reader_hold(pygame.K_UP, 4.0, JAWS_FIRST_REPEAT_MS, JAWS_SPACINGS_MS)
+    assert all(readings), f"the hold broke at frame {readings.index(False)} of {len(readings)}"
+    # Letting go reads late by one spacing plus grace: the price of a
+    # screen reader that only re-sends the key four times a second.
+    lag = sim.frames_until_released(pygame.K_UP)
+    assert lag <= max(JAWS_SPACINGS_MS) + REPEAT_GRACE_MS + 2 * FRAME_MS
+    # The fake clock delivers pairs on frame boundaries, so the learned
+    # spacing can sit one frame off the nominal value.
+    assert abs(sim.tracker.learned_spacing_ms - max(JAWS_SPACINGS_MS)) <= FRAME_MS
+    # The next hold, on another key, starts with the spacing already known.
+    readings = sim.screen_reader_hold(pygame.K_DOWN, 3.0, JAWS_FIRST_REPEAT_MS, JAWS_SPACINGS_MS)
+    assert all(readings)
+    assert (
+        sim.frames_until_released(pygame.K_DOWN)
+        <= max(JAWS_SPACINGS_MS) + REPEAT_GRACE_MS + 2 * FRAME_MS
+    )
+
+
+def test_a_fast_repeat_train_lapses_quickly_once_its_spacing_is_learned():
+    sim = Sim()
+    readings = sim.screen_reader_hold(pygame.K_UP, 2.0)
+    assert all(readings), f"the hold broke at frame {readings.index(False)} of {len(readings)}"
+    assert abs(sim.tracker.learned_spacing_ms - INTERVAL_MS) <= FRAME_MS
+    assert sim.frames_until_released(pygame.K_UP) <= INTERVAL_MS + REPEAT_GRACE_MS + 3 * FRAME_MS
     # Once a hold has lapsed, a fresh press earns the full fresh pulse again.
     sim.frame(down(pygame.K_UP), up(pygame.K_UP))
     pressed_at = sim.now
     while sim.now < pressed_at + DELAY_MS:
         sim.frame()
         assert sim.held(pygame.K_UP)
+
+
+def test_a_fingers_rhythm_never_teaches_the_repeat_spacing():
+    # Real taps (release in a later frame) at a steady 200 ms: physical
+    # keyboards never produce repeat pairs, so nothing is learned from them.
+    sim = Sim()
+    for _ in range(6):
+        sim.frame(down(pygame.K_DOWN))
+        for _ in range(3):
+            sim.frame()
+        sim.frame(up(pygame.K_DOWN))
+        assert not sim.held(pygame.K_DOWN)
+        for _ in range(8):
+            sim.frame()
+    assert sim.tracker.learned_spacing_ms is None
+    assert sim.tracker.repeat_pulse_ms == sim.tracker.fresh_pulse_ms
 
 
 def test_the_finger_lifting_ends_the_hold_at_once():
@@ -158,14 +215,16 @@ def test_each_key_keeps_its_own_hold():
     assert sim.held(pygame.K_LEFT)
 
 
-def test_clear_and_focus_loss_drop_every_pulse():
+def test_clear_and_focus_loss_drop_every_pulse_but_keep_the_learning():
     sim = Sim()
-    sim.frame(down(pygame.K_UP), up(pygame.K_UP))
+    sim.screen_reader_hold(pygame.K_UP, 1.5, JAWS_FIRST_REPEAT_MS, JAWS_SPACINGS_MS)
+    assert sim.tracker.learned_spacing_ms is not None
     sim.tracker.clear()
     assert not sim.held(pygame.K_UP)
     sim.frame(down(pygame.K_UP), up(pygame.K_UP))
     sim.frame(pygame.event.Event(pygame.WINDOWFOCUSLOST))
     assert not sim.held(pygame.K_UP)
+    assert sim.tracker.learned_spacing_ms is not None
 
 
 def test_windows_repeat_settings_decode_to_the_documented_timing():
@@ -178,7 +237,7 @@ def test_windows_repeat_settings_decode_to_the_documented_timing():
     assert repeat_interval_ms(-5) == 400
     tracker = HeldKeys(repeat_delay_ms=1000, repeat_interval_ms=400)
     assert tracker.fresh_pulse_ms == 1000 + FRESH_GRACE_MS
-    assert tracker.repeat_pulse_ms == 400 + REPEAT_GRACE_MS
+    assert tracker.repeat_pulse_ms == tracker.fresh_pulse_ms  # nothing learned yet
 
 
 def test_a_new_screen_never_inherits_the_last_screens_hold():
@@ -201,8 +260,10 @@ def test_a_new_screen_never_inherits_the_last_screens_hold():
         app.shutdown()
 
 
-def test_driving_reads_a_jaws_held_accelerator_as_throttle(monkeypatch):
-    """End to end: the pairs JAWS delivers for a held Up arrow drive the truck."""
+def test_driving_reads_a_jaws_held_accelerator_as_steady_throttle(monkeypatch):
+    """End to end, at the measured JAWS cadence: the pairs for a held Up
+    arrow drive the truck, the throttle never stutters, and it comes off
+    within a second of the pairs stopping."""
     from freight_fate.app import App
 
     monkeypatch.setattr(pygame.key, "get_pressed", lambda: NoKeys())
@@ -215,19 +276,24 @@ def test_driving_reads_a_jaws_held_accelerator_as_throttle(monkeypatch):
         truck = driving.truck
         assert truck.throttle == 0.0
         sim = Sim(app.held_keys)
-        # A hold of two seconds, frame by frame through the real update.
-        start = sim.now
-        next_pair = start
-        while sim.now < start + 2000:
+        pairs = sim.pair_times(sim.now, 4.0, JAWS_FIRST_REPEAT_MS, JAWS_SPACINGS_MS)
+        end = sim.now + 4000
+        lowest_after_full = 1.0
+        reached_full = False
+        while sim.now < end:
             events = ()
-            if sim.now >= next_pair:
+            if pairs and sim.now >= pairs[0]:
                 events = (down(pygame.K_UP), up(pygame.K_UP))
-                next_pair = (start + DELAY_MS) if next_pair == start else next_pair + INTERVAL_MS
+                pairs.pop(0)
             sim.frame(*events)
             driving.update(FRAME_MS / 1000)
-        assert truck.throttle > 0.9
-        # The finger lifts: the pairs stop, and the throttle comes off within
-        # a few frames instead of lingering.
+            if truck.throttle > 0.95:
+                reached_full = True
+            elif reached_full:
+                lowest_after_full = min(lowest_after_full, truck.throttle)
+        assert reached_full
+        assert lowest_after_full >= 0.9, f"throttle stuttered down to {lowest_after_full:.2f}"
+        # The finger lifts: the pairs stop, and the throttle comes off.
         for _ in range(60):
             sim.frame()
             driving.update(FRAME_MS / 1000)

--- a/tests/test_held_keys.py
+++ b/tests/test_held_keys.py
@@ -1,0 +1,236 @@
+"""The held-key tracker: driving must read a held arrow under JAWS.
+
+JAWS swallows the physical arrow key and re-sends it to the game as an
+instant press-and-release pair, once per keyboard auto-repeat. A poll of
+``pygame.key.get_pressed()`` never sees it held. The tracker turns the
+train of pairs back into one hold, without changing what the physical
+keyboard path (no screen reader, NVDA) reads.
+"""
+
+import pygame
+from driving_feature_helpers import key_event, quiet_trip, release_air_brakes, start_drive
+
+from freight_fate.held_keys import (
+    FRESH_GRACE_MS,
+    REPEAT_GRACE_MS,
+    SYNTHETIC_FRAME_MAX_MS,
+    HeldKeys,
+    repeat_delay_ms,
+    repeat_interval_ms,
+)
+
+FRAME_MS = 16  # 60 frames per second, as the game runs
+DELAY_MS = 500  # the Windows default auto-repeat delay
+INTERVAL_MS = 33  # ...and rate (about 30 per second)
+
+
+class NoKeys:
+    """SDL's view after a re-injected pair: nothing is down."""
+
+    def __getitem__(self, key):
+        return False
+
+
+class Keys:
+    def __init__(self, held=()):
+        self.held = set(held)
+
+    def __getitem__(self, key):
+        return key in self.held
+
+
+def down(key):
+    return pygame.event.Event(pygame.KEYDOWN, key=key, unicode="", mod=0)
+
+
+def up(key):
+    return pygame.event.Event(pygame.KEYUP, key=key, mod=0)
+
+
+class Sim:
+    """Advance the tracker frame by frame with a fake clock."""
+
+    def __init__(self, tracker=None):
+        self.tracker = tracker or HeldKeys(repeat_delay_ms=DELAY_MS, repeat_interval_ms=INTERVAL_MS)
+        self.now = 1000
+        self.tracker.begin_frame(self.now)
+
+    def frame(self, *events, span=FRAME_MS):
+        self.now += span
+        self.tracker.begin_frame(self.now)
+        for event in events:
+            self.tracker.note(event)
+
+    def held(self, key, pressed=None):
+        return self.tracker.snapshot(pressed if pressed is not None else NoKeys())[key]
+
+    def jaws_hold(self, key, seconds):
+        """What JAWS delivers for a key held ``seconds``: a pair now, then a
+        pair per auto-repeat after the delay. Returns the frames it read held."""
+        start = self.now
+        end = start + int(seconds * 1000)
+        next_pair = start
+        held_frames = []
+        while self.now < end:
+            events = ()
+            if self.now >= next_pair:
+                events = (down(key), up(key))
+                next_pair = (start + DELAY_MS) if next_pair == start else next_pair + INTERVAL_MS
+            self.frame(*events)
+            held_frames.append(self.held(key))
+        return held_frames
+
+
+def test_physical_hold_still_reads_straight_from_sdl():
+    sim = Sim()
+    assert sim.held(pygame.K_UP, Keys({pygame.K_UP}))
+    assert not sim.held(pygame.K_UP, Keys())
+    assert not sim.held(pygame.K_DOWN, Keys({pygame.K_UP}))
+
+
+def test_a_re_injected_pair_reads_held_until_the_first_repeat_would_come():
+    sim = Sim()
+    sim.frame(down(pygame.K_UP), up(pygame.K_UP))
+    assert sim.held(pygame.K_UP)
+    pressed_at = sim.now
+    while sim.now < pressed_at + DELAY_MS:
+        sim.frame()
+        assert sim.held(pygame.K_UP), f"lapsed {sim.now - pressed_at} ms after the press"
+    while sim.now < pressed_at + DELAY_MS + FRESH_GRACE_MS + FRAME_MS:
+        sim.frame()
+    assert not sim.held(pygame.K_UP)
+
+
+def test_a_repeat_train_is_one_continuous_hold_that_lapses_quickly():
+    sim = Sim()
+    frames = sim.jaws_hold(pygame.K_UP, 2.0)
+    assert all(frames), f"the hold broke at frame {frames.index(False)} of {len(frames)}"
+    released_at = sim.now
+    while sim.held(pygame.K_UP):
+        sim.frame()
+        assert sim.now - released_at <= INTERVAL_MS + REPEAT_GRACE_MS + 2 * FRAME_MS
+    # Once a hold has lapsed, a fresh press earns the full fresh pulse again.
+    sim.frame(down(pygame.K_UP), up(pygame.K_UP))
+    pressed_at = sim.now
+    while sim.now < pressed_at + DELAY_MS:
+        sim.frame()
+        assert sim.held(pygame.K_UP)
+
+
+def test_the_finger_lifting_ends_the_hold_at_once():
+    sim = Sim()
+    sim.frame(down(pygame.K_DOWN))
+    for _ in range(5):
+        sim.frame()
+        assert sim.held(pygame.K_DOWN, Keys({pygame.K_DOWN}))
+    sim.frame(up(pygame.K_DOWN))
+    assert not sim.held(pygame.K_DOWN)
+
+
+def test_a_pair_that_lands_after_a_hitch_is_not_a_hold():
+    # A whole real tap can arrive in one batch after a long frame; the honest
+    # answer is "not held", not a half-second of brake.
+    sim = Sim()
+    sim.frame(down(pygame.K_DOWN), up(pygame.K_DOWN), span=SYNTHETIC_FRAME_MAX_MS + 100)
+    assert not sim.held(pygame.K_DOWN)
+
+
+def test_a_second_tap_before_the_delay_is_a_fresh_press_not_a_repeat():
+    sim = Sim()
+    sim.frame(down(pygame.K_DOWN), up(pygame.K_DOWN))
+    for _ in range(9):  # about 150 ms later: a double tap
+        sim.frame()
+    sim.frame(down(pygame.K_DOWN), up(pygame.K_DOWN))
+    second_at = sim.now
+    while sim.now < second_at + DELAY_MS:
+        sim.frame()
+        assert sim.held(pygame.K_DOWN)
+
+
+def test_each_key_keeps_its_own_hold():
+    sim = Sim()
+    sim.frame(down(pygame.K_UP), up(pygame.K_UP))
+    sim.frame(down(pygame.K_LEFT), up(pygame.K_LEFT))
+    assert sim.held(pygame.K_UP) and sim.held(pygame.K_LEFT)
+    assert not sim.held(pygame.K_RIGHT)
+    sim.frame(up(pygame.K_UP))  # a later release: the finger, not the pair
+    assert not sim.held(pygame.K_UP)
+    assert sim.held(pygame.K_LEFT)
+
+
+def test_clear_and_focus_loss_drop_every_pulse():
+    sim = Sim()
+    sim.frame(down(pygame.K_UP), up(pygame.K_UP))
+    sim.tracker.clear()
+    assert not sim.held(pygame.K_UP)
+    sim.frame(down(pygame.K_UP), up(pygame.K_UP))
+    sim.frame(pygame.event.Event(pygame.WINDOWFOCUSLOST))
+    assert not sim.held(pygame.K_UP)
+
+
+def test_windows_repeat_settings_decode_to_the_documented_timing():
+    assert repeat_delay_ms(0) == 250
+    assert repeat_delay_ms(1) == 500
+    assert repeat_delay_ms(3) == 1000
+    assert repeat_delay_ms(99) == 1000  # clamped, never a runaway pulse
+    assert repeat_interval_ms(31) == 33
+    assert repeat_interval_ms(0) == 400
+    assert repeat_interval_ms(-5) == 400
+    tracker = HeldKeys(repeat_delay_ms=1000, repeat_interval_ms=400)
+    assert tracker.fresh_pulse_ms == 1000 + FRESH_GRACE_MS
+    assert tracker.repeat_pulse_ms == 400 + REPEAT_GRACE_MS
+
+
+def test_a_new_screen_never_inherits_the_last_screens_hold():
+    from freight_fate.app import App
+    from freight_fate.states.base import State
+
+    app = App()
+    try:
+        app.held_keys.begin_frame(1000)
+        app.held_keys.note(down(pygame.K_UP))
+        app.held_keys.note(up(pygame.K_UP))
+        assert app.ctx.held_keys.snapshot(NoKeys())[pygame.K_UP]
+        app.push_state(State(app.ctx))
+        assert not app.ctx.held_keys.snapshot(NoKeys())[pygame.K_UP]
+        app.held_keys.note(down(pygame.K_UP))
+        app.held_keys.note(up(pygame.K_UP))
+        app.pop_state()
+        assert not app.ctx.held_keys.snapshot(NoKeys())[pygame.K_UP]
+    finally:
+        app.shutdown()
+
+
+def test_driving_reads_a_jaws_held_accelerator_as_throttle(monkeypatch):
+    """End to end: the pairs JAWS delivers for a held Up arrow drive the truck."""
+    from freight_fate.app import App
+
+    monkeypatch.setattr(pygame.key, "get_pressed", lambda: NoKeys())
+    app = App()
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        release_air_brakes(driving)
+        driving.handle_event(key_event(pygame.K_e))  # engine on
+        truck = driving.truck
+        assert truck.throttle == 0.0
+        sim = Sim(app.held_keys)
+        # A hold of two seconds, frame by frame through the real update.
+        start = sim.now
+        next_pair = start
+        while sim.now < start + 2000:
+            events = ()
+            if sim.now >= next_pair:
+                events = (down(pygame.K_UP), up(pygame.K_UP))
+                next_pair = (start + DELAY_MS) if next_pair == start else next_pair + INTERVAL_MS
+            sim.frame(*events)
+            driving.update(FRAME_MS / 1000)
+        assert truck.throttle > 0.9
+        # The finger lifts: the pairs stop, and the throttle comes off within
+        # a few frames instead of lingering.
+        for _ in range(60):
+            sim.frame()
+            driving.update(FRAME_MS / 1000)
+        assert truck.throttle == 0.0
+    finally:
+        app.shutdown()

--- a/tools/key_probe.py
+++ b/tools/key_probe.py
@@ -1,0 +1,205 @@
+"""Show what the keyboard looks like to the game, screen reader and all.
+
+Freight Fate polls its driving keys, and a screen reader that re-sends keys
+as instant press-and-release pairs (JAWS does) makes a held arrow invisible
+to a poll. This opens a bare window, logs every key event with its timing
+and what SDL's own key state said at that moment, and reports what the
+held-key tracker (``freight_fate.held_keys``) made of it -- so a player can
+show exactly what their screen reader delivers, and we can size the fix to
+it instead of guessing.
+
+Usage::
+
+    uv run python tools/key_probe.py           # log to the console and key_probe.log
+    uv run python tools/key_probe.py --speak   # also speak a long line per arrow press
+
+Click or tab into the window, then press and hold the arrow keys for a few
+seconds each; Escape quits and prints a summary in plain words. With
+``--speak``, every arrow press speaks a long sentence with interrupt on, so
+the ear can tell whether the screen reader cuts the previous one off.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+
+import pygame  # noqa: E402
+
+from freight_fate.held_keys import HeldKeys  # noqa: E402
+
+ARROWS = {
+    pygame.K_UP: "Up",
+    pygame.K_DOWN: "Down",
+    pygame.K_LEFT: "Left",
+    pygame.K_RIGHT: "Right",
+}
+LONG_LINE = (
+    "This is a long sentence spoken with interrupt on, so that the next arrow "
+    "press should cut it off before it reaches the very end of the line."
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--speak", action="store_true", help="speak a long line on each arrow press"
+    )
+    parser.add_argument("--log", default="key_probe.log", help="log file (default: key_probe.log)")
+    args = parser.parse_args()
+
+    speech = None
+    if args.speak:
+        from freight_fate.speech import Speech
+
+        speech = Speech()
+
+    pygame.init()
+    pygame.display.set_caption("Freight Fate key probe")
+    screen = pygame.display.set_mode((720, 300))
+    font = pygame.font.SysFont("Segoe UI, DejaVu Sans, Arial", 22)
+    clock = pygame.time.Clock()
+    tracker = HeldKeys()
+    log_file = open(args.log, "w", encoding="utf-8")  # noqa: SIM115 -- closed below
+
+    def emit(line: str) -> None:
+        print(line, flush=True)
+        log_file.write(line + "\n")
+
+    emit(
+        f"key probe: repeat delay {tracker.repeat_delay_ms} ms, repeat interval "
+        f"{tracker.repeat_interval_ms} ms (from the operating system)"
+    )
+    emit("hold the arrow keys for a few seconds each; Escape to finish")
+
+    last_down: dict[int, int] = {}
+    gaps_down_up: dict[int, list[int]] = {}
+    spacing_downs: dict[int, list[int]] = {}
+    counts: dict[int, list[int]] = {}
+    longest_sdl_hold: dict[int, int] = {}
+    longest_tracker_hold: dict[int, int] = {}
+    sdl_hold_since: dict[int, int] = {}
+    tracker_hold_since: dict[int, int] = {}
+    status = "waiting for keys"
+    running = True
+    while running:
+        clock.tick(60)
+        now = pygame.time.get_ticks()
+        tracker.begin_frame(now)
+        for event in pygame.event.get():
+            tracker.note(event)
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type in (pygame.KEYDOWN, pygame.KEYUP):
+                key = event.key
+                if event.type == pygame.KEYDOWN and key == pygame.K_ESCAPE:
+                    running = False
+                    continue
+                name = ARROWS.get(key) or pygame.key.name(key)
+                sdl_now = bool(pygame.key.get_pressed()[key])
+                if event.type == pygame.KEYDOWN:
+                    counts.setdefault(key, [0, 0])[0] += 1
+                    previous = last_down.get(key)
+                    spacing = f", {now - previous} ms since the last press" if previous else ""
+                    if previous:
+                        spacing_downs.setdefault(key, []).append(now - previous)
+                    last_down[key] = now
+                    emit(
+                        f"{now:>8} DOWN {name}{spacing}; SDL now says {'down' if sdl_now else 'up'}"
+                    )
+                    if speech is not None and key in ARROWS:
+                        speech.say(f"{name}. {LONG_LINE}", interrupt=True)
+                else:
+                    counts.setdefault(key, [0, 0])[1] += 1
+                    pressed = last_down.get(key)
+                    gap = f" {now - pressed} ms after its press" if pressed is not None else ""
+                    if pressed is not None:
+                        gaps_down_up.setdefault(key, []).append(now - pressed)
+                    emit(f"{now:>8} UP   {name}{gap}; SDL now says {'down' if sdl_now else 'up'}")
+        snapshot = tracker.snapshot()
+        pressed_now = pygame.key.get_pressed()
+        for key in ARROWS:
+            for held, since, longest in (
+                (bool(pressed_now[key]), sdl_hold_since, longest_sdl_hold),
+                (bool(snapshot[key]), tracker_hold_since, longest_tracker_hold),
+            ):
+                if held and key not in since:
+                    since[key] = now
+                elif not held and key in since:
+                    longest[key] = max(longest.get(key, 0), now - since.pop(key))
+        held_names = [name for key, name in ARROWS.items() if snapshot[key]]
+        sdl_names = [name for key, name in ARROWS.items() if pressed_now[key]]
+        status = (
+            f"game reads held: {', '.join(held_names) or 'nothing'}   "
+            f"SDL reads held: {', '.join(sdl_names) or 'nothing'}"
+        )
+        screen.fill((16, 16, 24))
+        for i, line in enumerate(
+            (
+                "Freight Fate key probe -- hold the arrows, Escape to finish",
+                status,
+                f"log: {args.log}",
+            )
+        ):
+            screen.blit(font.render(line, True, (230, 230, 230)), (20, 30 + i * 36))
+        pygame.display.flip()
+
+    for key in ARROWS:
+        for since, longest in (
+            (sdl_hold_since, longest_sdl_hold),
+            (tracker_hold_since, longest_tracker_hold),
+        ):
+            if key in since:
+                longest[key] = max(longest.get(key, 0), pygame.time.get_ticks() - since.pop(key))
+
+    emit("")
+    emit("summary")
+    if not counts:
+        emit("no key events arrived. Was the probe window focused?")
+    for key, (downs, ups) in counts.items():
+        name = ARROWS.get(key) or pygame.key.name(key)
+        gaps = gaps_down_up.get(key, [])
+        spacing = spacing_downs.get(key, [])
+        parts = [f"{name}: {downs} presses, {ups} releases"]
+        if gaps:
+            parts.append(f"release came a median {statistics.median(gaps):.0f} ms after its press")
+        if spacing:
+            parts.append(f"presses a median {statistics.median(spacing):.0f} ms apart")
+        parts.append(f"longest hold SDL saw {longest_sdl_hold.get(key, 0)} ms")
+        parts.append(f"longest hold the game read {longest_tracker_hold.get(key, 0)} ms")
+        emit("; ".join(parts) + ".")
+    verdict = None
+    if any(gaps for gaps in gaps_down_up.values()):
+        every_gap = [g for gaps in gaps_down_up.values() for g in gaps]
+        if statistics.median(every_gap) <= 25:
+            verdict = (
+                "Your screen reader re-sends each key as an instant press and release: "
+                "the game never sees the key held by itself, and the tracker is what "
+                "makes holding work."
+            )
+        else:
+            verdict = (
+                "Your keys reach the game as real holds: the release comes when your "
+                "finger lifts, and the tracker changes nothing."
+            )
+        emit(verdict)
+    log_file.close()
+    if speech is not None:
+        if verdict:
+            speech.say(verdict, interrupt=True)
+        pygame.time.wait(6000)  # let the verdict finish before speech shuts down
+        speech.shutdown()
+    pygame.quit()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/key_probe.py
+++ b/tools/key_probe.py
@@ -10,21 +10,29 @@ it instead of guessing.
 
 Usage::
 
-    uv run python tools/key_probe.py           # log to the console and key_probe.log
-    uv run python tools/key_probe.py --speak   # also speak a long line per arrow press
+    uv run python tools/key_probe.py             # 25 seconds, then it reports
+    uv run python tools/key_probe.py --seconds 40
+    uv run python tools/key_probe.py --speak     # also a long line per arrow press
 
-Click or tab into the window, then press and hold the arrow keys for a few
-seconds each; Escape quits and prints a summary in plain words. With
-``--speak``, every arrow press speaks a long sentence with interrupt on, so
-the ear can tell whether the screen reader cuts the previous one off.
+Tab into the window when it opens, then press and hold each arrow key for a
+few seconds. The probe finishes by itself after ``--seconds`` (Escape ends
+it early), closes its window, and speaks its findings through the screen
+reader as well as printing them. Every run writes its own timestamped log
+in the current folder, flushed line by line, so nothing is lost if the
+console is closed afterwards. With ``--speak``, every arrow press speaks a
+long sentence with interrupt on, so the ear can tell whether the screen
+reader cuts the previous one off.
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import statistics
 import sys
+import time
+import traceback
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -46,90 +54,158 @@ LONG_LINE = (
     "This is a long sentence spoken with interrupt on, so that the next arrow "
     "press should cut it off before it reaches the very end of the line."
 )
+SYNTHETIC_GAP_MS = 25  # the tracker's own threshold, mirrored for the verdict
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    parser.add_argument(
-        "--speak", action="store_true", help="speak a long line on each arrow press"
-    )
-    parser.add_argument("--log", default="key_probe.log", help="log file (default: key_probe.log)")
-    args = parser.parse_args()
+class Report:
+    """Console plus a per-run log file, flushed on every line."""
 
-    speech = None
-    if args.speak:
-        from freight_fate.speech import Speech
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._file = open(path, "w", encoding="utf-8")  # noqa: SIM115 -- closed in close()
 
-        speech = Speech()
+    def line(self, text: str) -> None:
+        print(text, flush=True)
+        self._file.write(text + "\n")
+        self._file.flush()
 
+    def close(self) -> None:
+        self._file.close()
+
+
+class Voice:
+    """The game's own speech, or silence if it cannot start."""
+
+    def __init__(self, enabled: bool) -> None:
+        self._speech = None
+        if not enabled:
+            return
+        try:
+            from freight_fate.speech import Speech
+
+            self._speech = Speech()
+        except Exception:
+            self._speech = None
+
+    @property
+    def name(self) -> str:
+        return self._speech.backend_name if self._speech is not None else "none"
+
+    def say(self, text: str, interrupt: bool = True) -> None:
+        if self._speech is None:
+            return
+        with contextlib.suppress(Exception):
+            self._speech.say(text, interrupt=interrupt)
+
+    def say_and_wait(self, text: str) -> None:
+        """Speak, then give the screen reader time to finish before we exit."""
+        self.say(text, interrupt=True)
+        if self._speech is not None:
+            time.sleep(min(20.0, 1.0 + len(text.split()) / 2.5))
+
+    def shutdown(self) -> None:
+        if self._speech is not None:
+            with contextlib.suppress(Exception):
+                self._speech.shutdown()
+
+
+def name_of(key: int) -> str:
+    return ARROWS.get(key) or pygame.key.name(key)
+
+
+def run_window(args, report: Report, voice: Voice) -> dict:
+    """Open the window, collect events until the deadline or Escape, and
+    return the raw measurements. The window is closed before returning so
+    the console (and the screen reader) get focus back for the summary."""
     pygame.init()
     pygame.display.set_caption("Freight Fate key probe")
     screen = pygame.display.set_mode((720, 300))
     font = pygame.font.SysFont("Segoe UI, DejaVu Sans, Arial", 22)
     clock = pygame.time.Clock()
     tracker = HeldKeys()
-    log_file = open(args.log, "w", encoding="utf-8")  # noqa: SIM115 -- closed below
-
-    def emit(line: str) -> None:
-        print(line, flush=True)
-        log_file.write(line + "\n")
-
-    emit(
-        f"key probe: repeat delay {tracker.repeat_delay_ms} ms, repeat interval "
-        f"{tracker.repeat_interval_ms} ms (from the operating system)"
+    report.line(
+        f"repeat delay {tracker.repeat_delay_ms} ms, repeat interval "
+        f"{tracker.repeat_interval_ms} ms (from the operating system); "
+        f"speech through {voice.name}"
     )
-    emit("hold the arrow keys for a few seconds each; Escape to finish")
+    report.line(f"collecting for {args.seconds} seconds; Escape ends early")
+    voice.say(
+        "Key probe ready. Tab into the probe window, then hold each arrow key for a few "
+        f"seconds. It finishes by itself in {args.seconds} seconds.",
+        interrupt=True,
+    )
 
-    last_down: dict[int, int] = {}
-    gaps_down_up: dict[int, list[int]] = {}
-    spacing_downs: dict[int, list[int]] = {}
-    counts: dict[int, list[int]] = {}
-    longest_sdl_hold: dict[int, int] = {}
-    longest_tracker_hold: dict[int, int] = {}
+    data = {
+        "last_down": {},
+        "gaps_down_up": {},
+        "spacing_downs": {},
+        "counts": {},
+        "longest_sdl_hold": {},
+        "longest_tracker_hold": {},
+        "events": 0,
+        "focused": False,
+    }
     sdl_hold_since: dict[int, int] = {}
     tracker_hold_since: dict[int, int] = {}
+    last_event_at = None
+    deadline = pygame.time.get_ticks() + args.seconds * 1000
+    warned_ten = False
     status = "waiting for keys"
     running = True
     while running:
         clock.tick(60)
         now = pygame.time.get_ticks()
         tracker.begin_frame(now)
+        if now >= deadline:
+            running = False
+        elif not warned_ten and deadline - now <= 10_000:
+            warned_ten = True
+            voice.say("Ten seconds left.", interrupt=False)
         for event in pygame.event.get():
             tracker.note(event)
             if event.type == pygame.QUIT:
                 running = False
+            elif event.type == pygame.WINDOWFOCUSGAINED:
+                data["focused"] = True
             elif event.type in (pygame.KEYDOWN, pygame.KEYUP):
                 key = event.key
                 if event.type == pygame.KEYDOWN and key == pygame.K_ESCAPE:
                     running = False
                     continue
-                name = ARROWS.get(key) or pygame.key.name(key)
+                data["events"] += 1
+                name = name_of(key)
                 sdl_now = bool(pygame.key.get_pressed()[key])
+                same_frame = " (same frame as the previous event)" if last_event_at == now else ""
+                last_event_at = now
                 if event.type == pygame.KEYDOWN:
-                    counts.setdefault(key, [0, 0])[0] += 1
-                    previous = last_down.get(key)
+                    data["counts"].setdefault(key, [0, 0])[0] += 1
+                    previous = data["last_down"].get(key)
                     spacing = f", {now - previous} ms since the last press" if previous else ""
                     if previous:
-                        spacing_downs.setdefault(key, []).append(now - previous)
-                    last_down[key] = now
-                    emit(
-                        f"{now:>8} DOWN {name}{spacing}; SDL now says {'down' if sdl_now else 'up'}"
+                        data["spacing_downs"].setdefault(key, []).append(now - previous)
+                    data["last_down"][key] = now
+                    report.line(
+                        f"{now:>8} DOWN {name}{spacing}; SDL now says "
+                        f"{'down' if sdl_now else 'up'}{same_frame}"
                     )
-                    if speech is not None and key in ARROWS:
-                        speech.say(f"{name}. {LONG_LINE}", interrupt=True)
+                    if args.speak and key in ARROWS:
+                        voice.say(f"{name}. {LONG_LINE}", interrupt=True)
                 else:
-                    counts.setdefault(key, [0, 0])[1] += 1
-                    pressed = last_down.get(key)
+                    data["counts"].setdefault(key, [0, 0])[1] += 1
+                    pressed = data["last_down"].get(key)
                     gap = f" {now - pressed} ms after its press" if pressed is not None else ""
                     if pressed is not None:
-                        gaps_down_up.setdefault(key, []).append(now - pressed)
-                    emit(f"{now:>8} UP   {name}{gap}; SDL now says {'down' if sdl_now else 'up'}")
+                        data["gaps_down_up"].setdefault(key, []).append(now - pressed)
+                    report.line(
+                        f"{now:>8} UP   {name}{gap}; SDL now says "
+                        f"{'down' if sdl_now else 'up'}{same_frame}"
+                    )
         snapshot = tracker.snapshot()
         pressed_now = pygame.key.get_pressed()
         for key in ARROWS:
             for held, since, longest in (
-                (bool(pressed_now[key]), sdl_hold_since, longest_sdl_hold),
-                (bool(snapshot[key]), tracker_hold_since, longest_tracker_hold),
+                (bool(pressed_now[key]), sdl_hold_since, data["longest_sdl_hold"]),
+                (bool(snapshot[key]), tracker_hold_since, data["longest_tracker_hold"]),
             ):
                 if held and key not in since:
                     since[key] = now
@@ -142,63 +218,107 @@ def main() -> int:
             f"SDL reads held: {', '.join(sdl_names) or 'nothing'}"
         )
         screen.fill((16, 16, 24))
-        for i, line in enumerate(
-            (
-                "Freight Fate key probe -- hold the arrows, Escape to finish",
-                status,
-                f"log: {args.log}",
-            )
-        ):
+        lines = (
+            "Freight Fate key probe -- hold the arrows; it finishes by itself",
+            status,
+            f"{max(0, (deadline - now) // 1000)} s left -- log: {report.path.name}",
+        )
+        for i, line in enumerate(lines):
             screen.blit(font.render(line, True, (230, 230, 230)), (20, 30 + i * 36))
         pygame.display.flip()
 
+    end = pygame.time.get_ticks()
     for key in ARROWS:
         for since, longest in (
-            (sdl_hold_since, longest_sdl_hold),
-            (tracker_hold_since, longest_tracker_hold),
+            (sdl_hold_since, data["longest_sdl_hold"]),
+            (tracker_hold_since, data["longest_tracker_hold"]),
         ):
             if key in since:
-                longest[key] = max(longest.get(key, 0), pygame.time.get_ticks() - since.pop(key))
+                longest[key] = max(longest.get(key, 0), end - since.pop(key))
+    pygame.quit()  # close the window first: focus goes back to the console
+    return data
 
-    emit("")
-    emit("summary")
-    if not counts:
-        emit("no key events arrived. Was the probe window focused?")
-    for key, (downs, ups) in counts.items():
-        name = ARROWS.get(key) or pygame.key.name(key)
-        gaps = gaps_down_up.get(key, [])
-        spacing = spacing_downs.get(key, [])
+
+def summarize(data: dict, report: Report) -> list[str]:
+    """Print the findings; return the spoken version (plain sentences)."""
+    spoken: list[str] = []
+    report.line("")
+    report.line("summary")
+    if not data["counts"]:
+        text = (
+            "No key events arrived. The probe window probably never had focus: "
+            "tab or click into it next time."
+            if not data["focused"]
+            else "The window had focus but no key events arrived."
+        )
+        report.line(text)
+        return [text]
+    for key, (downs, ups) in data["counts"].items():
+        name = name_of(key)
+        gaps = data["gaps_down_up"].get(key, [])
+        spacing = data["spacing_downs"].get(key, [])
         parts = [f"{name}: {downs} presses, {ups} releases"]
         if gaps:
             parts.append(f"release came a median {statistics.median(gaps):.0f} ms after its press")
         if spacing:
             parts.append(f"presses a median {statistics.median(spacing):.0f} ms apart")
-        parts.append(f"longest hold SDL saw {longest_sdl_hold.get(key, 0)} ms")
-        parts.append(f"longest hold the game read {longest_tracker_hold.get(key, 0)} ms")
-        emit("; ".join(parts) + ".")
-    verdict = None
-    if any(gaps for gaps in gaps_down_up.values()):
-        every_gap = [g for gaps in gaps_down_up.values() for g in gaps]
-        if statistics.median(every_gap) <= 25:
+        parts.append(f"longest hold SDL saw {data['longest_sdl_hold'].get(key, 0)} ms")
+        parts.append(f"longest hold the game read {data['longest_tracker_hold'].get(key, 0)} ms")
+        line = "; ".join(parts) + "."
+        report.line(line)
+        spoken.append(line.replace(" ms", " milliseconds").replace("SDL", "the keyboard layer"))
+    every_gap = [g for gaps in data["gaps_down_up"].values() for g in gaps]
+    if every_gap:
+        if statistics.median(every_gap) <= SYNTHETIC_GAP_MS:
             verdict = (
-                "Your screen reader re-sends each key as an instant press and release: "
-                "the game never sees the key held by itself, and the tracker is what "
-                "makes holding work."
+                "Verdict: your screen reader re-sends each key as an instant press and "
+                "release. The game never sees the key held by itself, and the tracker is "
+                "what makes holding work."
             )
         else:
             verdict = (
-                "Your keys reach the game as real holds: the release comes when your "
-                "finger lifts, and the tracker changes nothing."
+                "Verdict: your keys reach the game as real holds. The release comes when "
+                "your finger lifts, and the tracker changes nothing."
             )
-        emit(verdict)
-    log_file.close()
-    if speech is not None:
-        if verdict:
-            speech.say(verdict, interrupt=True)
-        pygame.time.wait(6000)  # let the verdict finish before speech shuts down
-        speech.shutdown()
-    pygame.quit()
-    return 0
+        report.line(verdict)
+        spoken.append(verdict)
+    return spoken
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--seconds", type=int, default=25, help="how long to collect (default 25)")
+    parser.add_argument(
+        "--speak", action="store_true", help="speak a long line on each arrow press"
+    )
+    parser.add_argument("--no-speech", action="store_true", help="print only; never speak")
+    parser.add_argument("--log", help="log file (default: key_probe-<timestamp>.log here)")
+    args = parser.parse_args()
+
+    log_path = (
+        Path(args.log) if args.log else Path(f"key_probe-{time.strftime('%Y%m%d-%H%M%S')}.log")
+    )
+    report = Report(log_path)
+    report.line(f"key probe log: {log_path.resolve()}")
+    voice = Voice(enabled=not args.no_speech)
+    status = 0
+    try:
+        data = run_window(args, report, voice)
+        spoken = summarize(data, report)
+        report.line(f"log saved: {log_path.resolve()}")
+        voice.say_and_wait(" ".join(spoken) + " The log is saved in the game folder.")
+    except Exception:
+        status = 1
+        report.line("the probe hit an error:")
+        for line in traceback.format_exc().rstrip().splitlines():
+            report.line("  " + line)
+        voice.say_and_wait("The key probe hit an error. The log has the details.")
+    finally:
+        report.close()
+        voice.shutdown()
+        with contextlib.suppress(Exception):
+            pygame.quit()
+    return status
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed and why

A JAWS player on 1.8.8 reported that the driving keys only work if they press JAWS Key+3 before each key. Norm reproduced it: menus fine, driving dead.

**Cause.** JAWS binds the arrows to its own scripts in every application. Its keyboard hook swallows the physical press and re-sends the key to the game as a synthetic press-and-release pair. Menus react to the `KEYDOWN` event, so they work. Driving polls `pygame.key.get_pressed()` every frame (`driving_updates.py`), and under JAWS the key is never down at poll time. NVDA passes the physical key through untouched, which is why nobody saw it before.

**Measured** on Norm's JAWS machine with the new `tools/key_probe.py` (log in the PR discussion if wanted): every arrow arrives as DOWN then UP 0 ms later in the same frame, SDL never reports it down; the first repeat pair lands at the Windows repeat delay (512 ms); the rest come every ~250 ms (242–272) — JAWS's script latency, not the 33 ms Windows repeat rate.

**Fix.** A small held-key tracker (`src/freight_fate/held_keys.py`) fed from the app's event loop. Every press starts a "pulse": a fresh press gets the OS repeat delay plus grace (read from Windows via `SystemParametersInfo`; defaults elsewhere); a repeat gets the spacing the repeats are *actually* arriving at, which the tracker learns from the synthetic pairs themselves (second repeat on, largest of the last eight) — until it has learned one, repeats get the fresh pulse too, so the first hold of a session cannot stutter. A release in the same short frame as its press is synthetic and leaves the pulse alone; a release any later is the player's finger and ends it. Driving now reads `ctx.held_keys.snapshot()` = SDL's own `get_pressed()` OR'd with live pulses, so the physical-keyboard path is unchanged. Pulses clear on any state-stack change and on focus loss.

`tools/key_probe.py` opens a bare window, logs every key event with timing and SDL's view to a per-run flushed log, finishes by itself, and speaks its findings through the screen reader.

The touched lines are identical on `main` (1.8.8.1) and `dev`, so this cherry-picks cleanly; `hotfix/jaws-held-keys-1.8` (off `main`) is pushed on the fork if a 1.8.8.x hotfix is wanted for the reporter's line. The Rust 1.9 has the same shape of bug (`Input::is_pressed` polled by the driving frame) and needs a port of this tracker inside `Input`; that is a separate PR.

## What players or maintainers will notice

JAWS players drive with the arrows like everyone else — no pass-through key. Nothing changes for NVDA, SAPI, or no-screen-reader players. Two honest limits, stated in the changelog: JAWS only re-sends a held key about four times a second and never says how long it was held, so letting go takes effect about a third of a second late, and a quick tap of a pedal reads as a short press of about half a second.

## Tests and checks run

- `uv run pytest` — 1563 passed, 3 skipped on this branch; full suites also green on the `main` hotfix branch (1551).
- `uv run ruff check src tests tools` clean; `ruff format` on the new files.
- New `tests/test_held_keys.py` (13 tests): physical path unchanged; a lone pair holds until the first repeat would come; the measured JAWS train (replayed from the log) is one continuous hold from the first pair with no learned spacing, and lapses within a spacing plus grace; a fast train lapses quickly once learned; a finger's rhythm never teaches the spacing; the finger lifting ends the hold at once; a pair after a frame hitch is not a hold; a double tap gets a fresh pulse; per-key isolation; clear on stack change and focus loss keeps the learning; Windows setting decode; and end to end, JAWS-cadence Up pairs through the real driving update take the throttle to full with no dip below 0.9 and drop it to 0 within a second of the pairs stopping.
- Manual: Norm ran the probe under JAWS; the verdict line and timings above come from that run.

## Accessibility impact

An accessibility fix: restores keyboard driving for JAWS users. No spoken text changed in the game; the probe's speech is a dev tool.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`, written in plain player language and matching the style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4QKamivXQeSqULeVbueHv
