### PR TITLE
fix(input): driving keys read as held under JAWS (Rust)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -945,6 +945,19 @@
 
 ### Fixed
 
+- **Driving keys now work with JAWS without the pass-through key.** JAWS
+  hands the game each arrow key as an instant tap rather than a held key,
+  so holding Up, Down, Left, or Right to accelerate, brake, or steer did
+  nothing until you pressed JAWS Key and 3 before every key. The game now
+  reads the stream of taps JAWS sends while a key is held as the hold it
+  is, so you drive with the same keys as everyone else. Menus were never
+  affected. Two limits remain, because JAWS only re-sends a held key
+  about four times a second and never says how long you held it: letting
+  go of a pedal or the wheel takes effect about a third of a second
+  later, a single quick tap of a pedal reads as a short press of about
+  half a second, and the double-tap-and-hold pedal latch cannot be caught
+  through JAWS.
+
 - **The game stops doing pointless work sixty times a second while you drive.**
   Every moment at the wheel, it was rebuilding the entire list of radio
   stations from scratch just to work out which station to name on the drivers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ sdl2 = "0.38"
 url = "2"
 form_urlencoded = "1"
 webbrowser = "1"
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_UI_WindowsAndMessaging"] }
 proptest = "1"
 memmap2 = "0.9"
 # 2.x, not 3: the 3.0.0 release on crates.io ships with no features at all

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7104,6 +7104,24 @@ milestone below (speeding consequences especially).
 
 From a batch of player reports:
 
+- [x] **Driving keys did nothing under JAWS without JAWS Key+3 -- FIXED
+  2026-08-24 (player report relayed by Norm, 1.8.8).** JAWS binds the
+  arrows to its own scripts in every application, swallows the physical
+  key, and re-sends it as an instant press-and-release pair; the driving
+  frame polls `ctx.input.is_pressed` and never saw a hold (menus react to
+  the press event, so they worked). Measured with `tools/key_probe.py` on
+  Norm's JAWS machine: first repeat at the Windows delay (512 ms), then
+  pairs every ~250 ms (242-272), JAWS's script latency rather than the
+  33 ms Windows rate. `app::held_keys` turns the pair train back into a
+  hold, learning the spacing from the pairs and reading SDL's own key state
+  OR'd with it, so the physical-keyboard path is unchanged and the harness
+  (which feeds keys without a frame clock) keeps plain semantics. Same fix
+  in Python on `dev` (PR #167) and the `main` hotfix branch.
+- [ ] Under a key-re-sending screen reader a tap cannot be told from a
+  hold until the first auto-repeat, so the double-tap-and-hold pedal latch
+  is invisible through JAWS; a gesture counted in press events would see
+  it. A second JAWS machine's probe log would confirm the ~250 ms spacing
+  is JAWS-typical rather than one box.
 - [x] **Map screen read raw data keys for the route -- FIXED 2026-07-21
   (NVDA player report).** Its first line joined the world's city slugs, so an
   east-coast run opened with "new underscore york underscore n y underscore u

--- a/crates/freight-fate/src/app.rs
+++ b/crates/freight-fate/src/app.rs
@@ -33,14 +33,16 @@ use crate::states::main_menu::ConfirmQuitState;
 
 pub mod boot_timing;
 pub mod context;
+pub mod held_keys;
 pub mod logging;
 pub mod sdl_shell;
 pub mod speech_delivery;
 pub mod testing;
 
 pub use context::{
-    share, Clipboard, ContextParts, GameContext, HeldKeys, MemoryClipboard, Services, SharedState,
+    share, Clipboard, ContextParts, GameContext, MemoryClipboard, Services, SharedState,
 };
+pub use held_keys::HeldKeys;
 pub use logging::{active_log_path, configure_logging};
 pub use speech_delivery::{IntoSpoken, Say, SayEvent, Spoken, TRANSCRIPT_TARGET};
 
@@ -429,6 +431,10 @@ impl App {
                 // Switching screen readers happens outside the game;
                 // re-check speech the moment the player comes back.
                 self.ctx.speech.request_refresh();
+                // So do keyboard settings; and nothing held before the
+                // player left is held now.
+                self.ctx.input.refresh_repeat_timing();
+                self.ctx.input.clear_pulses();
             }
             InputEvent::Quit => self.handle_close_request(),
             InputEvent::KeyDown { key, mods, .. } => {
@@ -546,6 +552,10 @@ impl App {
             },
             None => Vec::new(),
         };
+        // Clock the held-key tracker before this frame's events: a screen
+        // reader's re-injected press-and-release pairs are told apart from a
+        // finger by which frame they land in (see `app::held_keys`).
+        self.ctx.input.begin_frame(dt);
         for event in &events {
             self.handle_event(event);
         }

--- a/crates/freight-fate/src/app/context.rs
+++ b/crates/freight-fate/src/app/context.rs
@@ -25,6 +25,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use super::held_keys::HeldKeys;
+
 use ff_core::achievements::{award, AchievementAward};
 use ff_core::data::world::World;
 use ff_core::message_log::{MessageCategory, MessageLog};
@@ -47,7 +49,7 @@ use crate::net::UreqTransport;
 use crate::online_journal::{queue_achievement, JournalOutbox};
 use crate::online_presence::{OnlineIdentity, OnlinePresence};
 use crate::speech::{apply_speech_settings, SpeechSink};
-use crate::states::base::{Key, Mods, State};
+use crate::states::base::State;
 
 use super::Say;
 
@@ -81,39 +83,6 @@ impl Clipboard for MemoryClipboard {
     fn set_text(&mut self, text: &str) -> bool {
         self.text = Some(text.to_string());
         true
-    }
-}
-
-/// `pygame.key.get_pressed()` / `get_mods()`: the keys currently held, as
-/// the app tracks them from the key events it dispatched.
-#[derive(Debug, Default)]
-pub struct HeldKeys {
-    held: HashSet<Key>,
-    mods: Mods,
-}
-
-impl HeldKeys {
-    pub fn is_pressed(&self, key: Key) -> bool {
-        self.held.contains(&key)
-    }
-
-    pub fn mods(&self) -> Mods {
-        self.mods
-    }
-
-    pub fn press(&mut self, key: Key, mods: Mods) {
-        self.held.insert(key);
-        self.mods = mods;
-    }
-
-    pub fn release(&mut self, key: Key, mods: Mods) {
-        self.held.remove(&key);
-        self.mods = mods;
-    }
-
-    pub fn clear(&mut self) {
-        self.held.clear();
-        self.mods = Mods::NONE;
     }
 }
 
@@ -428,6 +397,7 @@ impl GameContext {
     }
 
     pub fn push_shared_with(&mut self, shared: SharedState, should_enter: bool) {
+        self.input.clear_pulses(); // a new screen never inherits held keys
         let paces_main_speech = shared
             .try_borrow()
             .map(|s| s.paces_main_speech())
@@ -447,6 +417,7 @@ impl GameContext {
     /// the last state; the rebuilding methods below empty it on their way to
     /// a new state, so they use this instead of `pop_state`.
     fn take_top(&mut self, should_exit: bool) {
+        self.input.clear_pulses();
         if let Some(entry) = self.stack.pop() {
             if should_exit {
                 self.exit_now_or_later(&entry.state);

--- a/crates/freight-fate/src/app/held_keys.rs
+++ b/crates/freight-fate/src/app/held_keys.rs
@@ -1,0 +1,656 @@
+//! Held keys as the driving loop should see them, screen reader or not.
+//!
+//! Driving reads the pedals and the wheel by polling: is Up down right now?
+//! [`HeldKeys::is_pressed`] answers from the key events the app dispatched
+//! (`pygame.key.get_pressed()`), and with no screen reader, or with NVDA,
+//! that is the physical keyboard: a held key reads held until the finger
+//! lifts.
+//!
+//! JAWS is different. It binds the arrow keys to its own scripts in every
+//! application, so its keyboard hook swallows the physical press, runs the
+//! script, and re-sends the key to the application as a synthetic
+//! press-and-release pair. The game sees a tap that lasts zero frames, which
+//! a poll never catches: menus react to the press event and work, driving
+//! polls and does nothing until the player passes one key through with JAWS
+//! Key+3. Holding the key does not help by itself, but the keyboard's
+//! auto-repeat still runs underneath; every repeat goes through the same
+//! hook and arrives as another pair. Measured on the owner's JAWS machine
+//! (2026-08-24, `tools/key_probe.py`): the first repeat lands at the Windows
+//! repeat delay (512 ms), the rest about 250 ms apart -- not the 33 ms
+//! Windows rate, because JAWS's script takes that long per key and the
+//! repeats queue behind it.
+//!
+//! The pulse layer here turns that train back into a hold. Every press
+//! starts a pulse: a fresh press gets one long enough to reach the first
+//! auto-repeat (the operating system's delay plus grace); a repeat gets one
+//! just past the spacing the repeats are actually arriving at, which the
+//! tracker learns from the pairs themselves (second repeat onward, synthetic
+//! pairs only) and keeps for the rest of the session. Until it has learned
+//! that spacing, repeats get the fresh pulse too, so the very first hold
+//! never stutters. A release in the same frame as the press that began the
+//! pair is synthetic -- nobody taps a key inside one frame -- and leaves the
+//! pulse alone; a release in a later frame is the player's finger and ends
+//! it. A key reads pressed when it is physically down OR a pulse is alive,
+//! so the physical path is exactly what it always was and the re-injected
+//! path reads as a hold that lapses one learned spacing plus grace after the
+//! last pair.
+//!
+//! Two guards keep the physical path honest. SDL delivers the keyboard's own
+//! auto-repeat as more `KeyDown`s of a key that is already down, so only a
+//! press from the released state can begin a synthetic pair: a finger
+//! lifting in the same frame as one of those repeats is a real release. And
+//! the layer is inert until [`HeldKeys::begin_frame`] has clocked a frame --
+//! the playtest harness and the tests feed keys straight in without a frame
+//! loop, and they keep today's plain semantics.
+//!
+//! Two honest limits. A screen reader that re-injects keys never shows the
+//! game how long a tap lasted, so under JAWS a tap reads as a hold for the
+//! repeat delay (half a second at the Windows default), letting go reads
+//! about a third of a second late, and a gesture built on tap length (the
+//! pedal latch) cannot be seen. And the game cannot tell whether such a
+//! screen reader is running, so the pulse logic is always on; on the
+//! physical path it only ever adds a hold when a whole press-and-release
+//! arrives inside one short frame, which a finger cannot do.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::states::base::{Key, Mods};
+
+/// Fallbacks when the operating system will not say: the Windows defaults
+/// (delay setting 1 of 0..3 is 500 ms; rate setting 31 of 0..31 is about 30
+/// repeats per second).
+pub const DEFAULT_REPEAT_DELAY_MS: u64 = 500;
+pub const DEFAULT_REPEAT_INTERVAL_MS: u64 = 33;
+
+/// Grace on top of the measured timing. The fresh-press pulse has to outlast
+/// the repeat delay plus the screen reader's script latency and a frame of
+/// batching; the per-repeat pulse has to outlast one spacing plus jitter
+/// (about 30 ms measured) and a frame, and it is how long after the finger
+/// lifts the key still reads held, so it stays short.
+pub const FRESH_GRACE_MS: u64 = 150;
+pub const REPEAT_GRACE_MS: u64 = 100;
+
+/// A press and release in one frame is synthetic only when the frame was a
+/// normal one. After a long hitch a whole real tap can land in one batch,
+/// and then the honest answer is "not held", never a half-second hold. A
+/// re-injected pair dropped this way costs nothing: the next repeat pair
+/// re-establishes the hold a frame later.
+pub const SYNTHETIC_FRAME_MAX_MS: u64 = 40;
+
+/// A press this soon after its pulse train began cannot be the operating
+/// system's first auto-repeat (which never fires early), so it is a new tap
+/// of the same key and earns a fresh full pulse.
+pub const REPEAT_EARLY_TOLERANCE_MS: u64 = 60;
+
+/// The learned repeat spacing is the largest of this many recent spacings,
+/// so one slow script run widens the window at once and a run of quick ones
+/// narrows it again only once it has aged out.
+pub const LEARNED_SPACINGS: usize = 8;
+
+/// Windows keyboard delay setting (0..3) to milliseconds before the first
+/// auto-repeat: 250 ms per step, so 0 is 250 ms and 3 is a second.
+pub fn repeat_delay_ms(setting: u32) -> u64 {
+    (u64::from(setting.min(3)) + 1) * 250
+}
+
+/// Windows keyboard speed setting (0..31) to milliseconds between
+/// auto-repeats: 0 is about 2.5 repeats per second, 31 about 30.
+pub fn repeat_interval_ms(setting: u32) -> u64 {
+    let rate = 2.5 + 27.5 * f64::from(setting.min(31)) / 31.0;
+    (1000.0 / rate).round() as u64
+}
+
+/// `(delay, interval)` in ms of the keyboard auto-repeat, from Windows when
+/// it answers, else the defaults. Only Windows has JAWS, and only Windows
+/// exposes the setting this cheaply, so nothing else is asked.
+#[cfg(windows)]
+pub fn os_repeat_timing() -> (u64, u64) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        SystemParametersInfoW, SPI_GETKEYBOARDDELAY, SPI_GETKEYBOARDSPEED,
+    };
+    let mut delay: u32 = 0;
+    let mut speed: u32 = 0;
+    // SAFETY: each call writes exactly one u32 into the local it is handed
+    // and touches nothing else; the locals outlive the calls.
+    let got_delay = unsafe {
+        SystemParametersInfoW(SPI_GETKEYBOARDDELAY, 0, (&mut delay as *mut u32).cast(), 0)
+    } != 0;
+    let got_speed = unsafe {
+        SystemParametersInfoW(SPI_GETKEYBOARDSPEED, 0, (&mut speed as *mut u32).cast(), 0)
+    } != 0;
+    (
+        if got_delay {
+            repeat_delay_ms(delay)
+        } else {
+            DEFAULT_REPEAT_DELAY_MS
+        },
+        if got_speed {
+            repeat_interval_ms(speed)
+        } else {
+            DEFAULT_REPEAT_INTERVAL_MS
+        },
+    )
+}
+
+#[cfg(not(windows))]
+pub fn os_repeat_timing() -> (u64, u64) {
+    (DEFAULT_REPEAT_DELAY_MS, DEFAULT_REPEAT_INTERVAL_MS)
+}
+
+/// `pygame.key.get_pressed()` / `get_mods()`: the keys currently held, as
+/// the app tracks them from the key events it dispatched, plus the pulse
+/// layer that reads a screen reader's re-injected press-and-release train as
+/// the hold it stands for (see the module docs).
+#[derive(Debug)]
+pub struct HeldKeys {
+    held: HashSet<Key>,
+    mods: Mods,
+    delay_ms: u64,
+    interval_ms: u64,
+    /// Frames the app has clocked. Zero means no frame loop is running, and
+    /// then the pulse layer stays out of the way entirely.
+    frame: u64,
+    now_ms: u64,
+    frame_span_ms: u64,
+    pulse_until: HashMap<Key, u64>,
+    train_start: HashMap<Key, u64>,
+    train_repeats: HashMap<Key, u32>,
+    pressed_at: HashMap<Key, u64>,
+    /// The frame of the last press that came from the released state: the
+    /// only kind of press a synthetic pair can begin with.
+    pair_frame: HashMap<Key, u64>,
+    last_pair_synthetic: HashSet<Key>,
+    spacings: Vec<u64>,
+}
+
+impl Default for HeldKeys {
+    fn default() -> Self {
+        let (delay, interval) = os_repeat_timing();
+        Self::with_timing(delay, interval)
+    }
+}
+
+impl HeldKeys {
+    /// A tracker with a known repeat delay and interval (tests; the default
+    /// asks the operating system).
+    pub fn with_timing(repeat_delay_ms: u64, repeat_interval_ms: u64) -> Self {
+        Self {
+            held: HashSet::new(),
+            mods: Mods::NONE,
+            delay_ms: repeat_delay_ms,
+            interval_ms: repeat_interval_ms,
+            frame: 0,
+            now_ms: 0,
+            frame_span_ms: 0,
+            pulse_until: HashMap::new(),
+            train_start: HashMap::new(),
+            train_repeats: HashMap::new(),
+            pressed_at: HashMap::new(),
+            pair_frame: HashMap::new(),
+            last_pair_synthetic: HashSet::new(),
+            spacings: Vec::new(),
+        }
+    }
+
+    // -- reading ------------------------------------------------------------------
+
+    /// Physically down, or held by a live pulse from a re-injected train.
+    pub fn is_pressed(&self, key: Key) -> bool {
+        self.held.contains(&key) || self.pulsed(key)
+    }
+
+    /// Held only by a pulse, not by SDL's own key state.
+    pub fn pulsed(&self, key: Key) -> bool {
+        self.pulse_until
+            .get(&key)
+            .is_some_and(|&until| until > self.now_ms)
+    }
+
+    pub fn mods(&self) -> Mods {
+        self.mods
+    }
+
+    // -- timing -------------------------------------------------------------------
+
+    pub fn repeat_delay_ms(&self) -> u64 {
+        self.delay_ms
+    }
+
+    pub fn repeat_interval_ms(&self) -> u64 {
+        self.interval_ms
+    }
+
+    /// The spacing re-injected repeats are actually arriving at, once seen.
+    pub fn learned_spacing_ms(&self) -> Option<u64> {
+        self.spacings.iter().copied().max()
+    }
+
+    /// How long a lone press reads held: to the first auto-repeat, plus grace.
+    pub fn fresh_pulse_ms(&self) -> u64 {
+        self.delay_ms + FRESH_GRACE_MS
+    }
+
+    /// How long each repeat extends the hold: one spacing, plus grace.
+    ///
+    /// The spacing is the learned one when there is one (never shorter than
+    /// the operating system's own rate); before anything is learned it is
+    /// the fresh pulse, so the first hold of a session cannot stutter.
+    pub fn repeat_pulse_ms(&self) -> u64 {
+        match self.learned_spacing_ms() {
+            Some(learned) => learned.max(self.interval_ms) + REPEAT_GRACE_MS,
+            None => self.fresh_pulse_ms(),
+        }
+    }
+
+    /// Re-read the operating system's repeat timing (on window focus, so a
+    /// player who changed the keyboard settings gets them without a restart).
+    pub fn refresh_repeat_timing(&mut self) {
+        let (delay, interval) = os_repeat_timing();
+        self.delay_ms = delay;
+        self.interval_ms = interval;
+    }
+
+    // -- feeding ------------------------------------------------------------------
+
+    /// Once per frame from the app's loop, before that frame's events, with
+    /// the frame's real duration. This is the clock the pulses run on; until
+    /// it has ticked, presses and releases keep their plain meaning.
+    pub fn begin_frame(&mut self, dt_seconds: f64) {
+        let span = (dt_seconds.max(0.0) * 1000.0).round() as u64;
+        self.frame += 1;
+        self.frame_span_ms = span;
+        self.now_ms += span;
+    }
+
+    pub fn press(&mut self, key: Key, mods: Mods) {
+        let was_held = !self.held.insert(key);
+        self.mods = mods;
+        if self.frame > 0 {
+            self.pulse_press(key, was_held);
+        }
+    }
+
+    pub fn release(&mut self, key: Key, mods: Mods) {
+        self.held.remove(&key);
+        self.mods = mods;
+        if self.frame > 0 {
+            self.pulse_release(key);
+        }
+    }
+
+    /// Forget everything held, physical and pulsed.
+    pub fn clear(&mut self) {
+        self.held.clear();
+        self.mods = Mods::NONE;
+        self.clear_pulses();
+    }
+
+    /// Forget the pulses only (the app calls this when the state stack
+    /// changes, so a screen never inherits the last screen's held keys); what
+    /// the tracker has learned about the repeat spacing survives.
+    pub fn clear_pulses(&mut self) {
+        self.pulse_until.clear();
+        self.train_start.clear();
+        self.train_repeats.clear();
+    }
+
+    fn pulse_press(&mut self, key: Key, was_held: bool) {
+        let now = self.now_ms;
+        let until = self.pulse_until.get(&key).copied().unwrap_or(0);
+        let repeat_after = self.delay_ms.saturating_sub(REPEAT_EARLY_TOLERANCE_MS);
+        let repeating = until > now
+            && self
+                .train_start
+                .get(&key)
+                .is_some_and(|&start| now.saturating_sub(start) >= repeat_after);
+        let window = if repeating {
+            let repeats = self.train_repeats.entry(key).or_insert(0);
+            *repeats += 1;
+            let repeats = *repeats;
+            // The first repeat sits at the delay, not the rate; from the
+            // second on, the gap to the previous pair is the real spacing --
+            // but only synthetic pairs teach it, a finger's rhythm never does.
+            let previous = self.pressed_at.get(&key).copied();
+            if repeats >= 2 && self.last_pair_synthetic.contains(&key) {
+                if let Some(previous) = previous {
+                    let spacing = now.saturating_sub(previous);
+                    if spacing < repeat_after {
+                        self.learn_spacing(spacing);
+                    }
+                }
+            }
+            self.repeat_pulse_ms()
+        } else {
+            self.train_start.insert(key, now);
+            self.train_repeats.insert(key, 0);
+            self.fresh_pulse_ms()
+        };
+        self.pulse_until.insert(key, until.max(now + window));
+        self.pressed_at.insert(key, now);
+        self.last_pair_synthetic.remove(&key);
+        // Only a press from the released state can begin a synthetic pair:
+        // SDL's own auto-repeat arrives as more presses of a key that is
+        // already down, and a finger lifting in the same frame as one of
+        // those is a real release.
+        if was_held {
+            self.pair_frame.remove(&key);
+        } else {
+            self.pair_frame.insert(key, self.frame);
+        }
+    }
+
+    fn pulse_release(&mut self, key: Key) {
+        let synthetic = self.pair_frame.get(&key) == Some(&self.frame)
+            && self.frame_span_ms <= SYNTHETIC_FRAME_MAX_MS;
+        if synthetic {
+            self.last_pair_synthetic.insert(key);
+            return;
+        }
+        self.pulse_until.remove(&key);
+        self.train_start.remove(&key);
+        self.train_repeats.remove(&key);
+    }
+
+    fn learn_spacing(&mut self, spacing_ms: u64) {
+        self.spacings.push(spacing_ms);
+        if self.spacings.len() > LEARNED_SPACINGS {
+            let excess = self.spacings.len() - LEARNED_SPACINGS;
+            self.spacings.drain(..excess);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DT: f64 = 1.0 / 60.0;
+    const FRAME_MS: u64 = 17; // what a 60 fps frame rounds to
+    const DELAY_MS: u64 = 500;
+    const INTERVAL_MS: u64 = 33;
+    /// The owner's JAWS log, 2026-08-24: first repeat at 512 ms, then these.
+    const JAWS_FIRST_REPEAT_MS: u64 = 512;
+    const JAWS_SPACINGS_MS: [u64; 14] = [
+        263, 245, 269, 271, 242, 251, 270, 250, 244, 271, 249, 242, 254, 250,
+    ];
+
+    /// Advance the tracker frame by frame with a fake clock.
+    struct Sim {
+        keys: HeldKeys,
+        now_ms: u64,
+    }
+
+    impl Sim {
+        fn new() -> Self {
+            let mut keys = HeldKeys::with_timing(DELAY_MS, INTERVAL_MS);
+            keys.begin_frame(DT);
+            Self { keys, now_ms: 0 }
+        }
+
+        fn frame(&mut self) {
+            self.frame_of(DT);
+        }
+
+        fn frame_of(&mut self, dt: f64) {
+            self.keys.begin_frame(dt);
+            self.now_ms += (dt * 1000.0).round() as u64;
+        }
+
+        fn pair(&mut self, key: Key) {
+            self.keys.press(key, Mods::NONE);
+            self.keys.release(key, Mods::NONE);
+        }
+
+        /// When a screen reader re-sends pairs for a key held `seconds`.
+        fn pair_times(&self, seconds: f64, first_repeat: u64, spacings: &[u64]) -> Vec<u64> {
+            let start = self.now_ms;
+            let end = start + (seconds * 1000.0) as u64;
+            let mut times = vec![start, start + first_repeat];
+            let mut i = 0;
+            while *times.last().unwrap() < end {
+                times.push(times.last().unwrap() + spacings[i % spacings.len()]);
+                i += 1;
+            }
+            times.retain(|&t| t < end);
+            times
+        }
+
+        /// Deliver the pairs for a hold, frame by frame; return each frame's
+        /// reading from the first pair on.
+        fn screen_reader_hold(
+            &mut self,
+            key: Key,
+            seconds: f64,
+            first_repeat: u64,
+            spacings: &[u64],
+        ) -> Vec<bool> {
+            let mut pairs = self.pair_times(seconds, first_repeat, spacings);
+            let end = self.now_ms + (seconds * 1000.0) as u64;
+            let mut readings = Vec::new();
+            while self.now_ms < end {
+                self.frame();
+                if pairs.first().is_some_and(|&t| self.now_ms >= t) {
+                    pairs.remove(0);
+                    self.pair(key);
+                }
+                readings.push(self.keys.is_pressed(key));
+            }
+            readings
+        }
+
+        fn ms_until_released(&mut self, key: Key) -> u64 {
+            let start = self.now_ms;
+            while self.keys.is_pressed(key) {
+                self.frame();
+                assert!(
+                    self.now_ms - start <= 2000,
+                    "still held {} ms after the pairs stopped",
+                    self.now_ms - start
+                );
+            }
+            self.now_ms - start
+        }
+    }
+
+    fn first_gap(readings: &[bool]) -> Option<usize> {
+        readings.iter().position(|&held| !held)
+    }
+
+    #[test]
+    fn physical_hold_still_reads_straight_from_the_key_state() {
+        let mut sim = Sim::new();
+        sim.keys.press(Key::Up, Mods::NONE);
+        assert!(sim.keys.is_pressed(Key::Up));
+        assert!(!sim.keys.is_pressed(Key::Down));
+        for _ in 0..5 {
+            sim.frame();
+            assert!(sim.keys.is_pressed(Key::Up));
+        }
+        sim.keys.release(Key::Up, Mods::NONE);
+        assert!(!sim.keys.is_pressed(Key::Up));
+    }
+
+    #[test]
+    fn without_a_frame_clock_the_pulse_layer_is_inert() {
+        // The harness and the tests feed keys straight in; a tap through
+        // press and release must keep meaning exactly that.
+        let mut keys = HeldKeys::with_timing(DELAY_MS, INTERVAL_MS);
+        keys.press(Key::Up, Mods::NONE);
+        assert!(keys.is_pressed(Key::Up));
+        keys.release(Key::Up, Mods::NONE);
+        assert!(!keys.is_pressed(Key::Up));
+        assert!(!keys.pulsed(Key::Up));
+    }
+
+    #[test]
+    fn a_re_injected_pair_reads_held_until_the_first_repeat_would_come() {
+        let mut sim = Sim::new();
+        sim.pair(Key::Up);
+        assert!(sim.keys.is_pressed(Key::Up));
+        assert!(sim.keys.pulsed(Key::Up));
+        let pressed_at = sim.now_ms;
+        while sim.now_ms < pressed_at + DELAY_MS {
+            sim.frame();
+            assert!(
+                sim.keys.is_pressed(Key::Up),
+                "lapsed {} ms after the press",
+                sim.now_ms - pressed_at
+            );
+        }
+        while sim.now_ms < pressed_at + DELAY_MS + FRESH_GRACE_MS + FRAME_MS {
+            sim.frame();
+        }
+        assert!(!sim.keys.is_pressed(Key::Up));
+    }
+
+    #[test]
+    fn the_owners_jaws_train_is_one_continuous_hold_from_the_first_pair() {
+        let mut sim = Sim::new();
+        let readings =
+            sim.screen_reader_hold(Key::Up, 4.0, JAWS_FIRST_REPEAT_MS, &JAWS_SPACINGS_MS);
+        assert_eq!(first_gap(&readings), None, "the hold broke");
+        // Letting go reads late by one spacing plus grace: the price of a
+        // screen reader that only re-sends the key four times a second.
+        let max_spacing = *JAWS_SPACINGS_MS.iter().max().unwrap();
+        let lag = sim.ms_until_released(Key::Up);
+        assert!(lag <= max_spacing + REPEAT_GRACE_MS + 2 * FRAME_MS, "{lag}");
+        // The fake clock lands pairs on frame boundaries, so the learned
+        // spacing can sit one frame off the nominal value.
+        let learned = sim.keys.learned_spacing_ms().expect("learned");
+        assert!(learned.abs_diff(max_spacing) <= FRAME_MS, "{learned}");
+        // The next hold, on another key, starts with the spacing known.
+        let readings =
+            sim.screen_reader_hold(Key::Down, 3.0, JAWS_FIRST_REPEAT_MS, &JAWS_SPACINGS_MS);
+        assert_eq!(first_gap(&readings), None);
+        let lag = sim.ms_until_released(Key::Down);
+        assert!(lag <= max_spacing + REPEAT_GRACE_MS + 2 * FRAME_MS, "{lag}");
+    }
+
+    #[test]
+    fn a_fast_repeat_train_lapses_quickly_once_its_spacing_is_learned() {
+        let mut sim = Sim::new();
+        let readings = sim.screen_reader_hold(Key::Up, 2.0, DELAY_MS, &[INTERVAL_MS]);
+        assert_eq!(first_gap(&readings), None);
+        let learned = sim.keys.learned_spacing_ms().expect("learned");
+        assert!(learned.abs_diff(INTERVAL_MS) <= FRAME_MS, "{learned}");
+        let lag = sim.ms_until_released(Key::Up);
+        assert!(lag <= INTERVAL_MS + REPEAT_GRACE_MS + 3 * FRAME_MS, "{lag}");
+        // Once a hold has lapsed, a fresh press earns the full fresh pulse.
+        sim.pair(Key::Up);
+        let pressed_at = sim.now_ms;
+        while sim.now_ms < pressed_at + DELAY_MS {
+            sim.frame();
+            assert!(sim.keys.is_pressed(Key::Up));
+        }
+    }
+
+    #[test]
+    fn a_fingers_rhythm_never_teaches_the_repeat_spacing() {
+        // Real taps, released a few frames later, at a steady 200 ms.
+        let mut sim = Sim::new();
+        for _ in 0..6 {
+            sim.keys.press(Key::Down, Mods::NONE);
+            for _ in 0..3 {
+                sim.frame();
+            }
+            sim.keys.release(Key::Down, Mods::NONE);
+            assert!(!sim.keys.is_pressed(Key::Down));
+            for _ in 0..8 {
+                sim.frame();
+            }
+        }
+        assert_eq!(sim.keys.learned_spacing_ms(), None);
+        assert_eq!(sim.keys.repeat_pulse_ms(), sim.keys.fresh_pulse_ms());
+    }
+
+    #[test]
+    fn sdl_auto_repeat_of_a_held_key_never_makes_a_pair() {
+        // The keyboard's own repeat arrives as more presses of a key that is
+        // already down; the finger lifting in the same frame as one of those
+        // is a real release, not a screen reader's pair.
+        let mut sim = Sim::new();
+        sim.keys.press(Key::Up, Mods::NONE);
+        for _ in 0..40 {
+            sim.frame();
+            sim.keys.press(Key::Up, Mods::NONE); // SDL repeat, every frame
+            assert!(sim.keys.is_pressed(Key::Up));
+        }
+        sim.frame();
+        sim.keys.press(Key::Up, Mods::NONE); // one more repeat...
+        sim.keys.release(Key::Up, Mods::NONE); // ...and the finger lifts
+        assert!(!sim.keys.is_pressed(Key::Up));
+        for _ in 0..3 {
+            sim.frame();
+            assert!(!sim.keys.is_pressed(Key::Up));
+        }
+        assert_eq!(sim.keys.learned_spacing_ms(), None);
+    }
+
+    #[test]
+    fn a_pair_that_lands_after_a_hitch_is_not_a_hold() {
+        // A whole real tap can arrive in one batch after a long frame; the
+        // honest answer is "not held", not a half-second of brake.
+        let mut sim = Sim::new();
+        sim.frame_of((SYNTHETIC_FRAME_MAX_MS + 100) as f64 / 1000.0);
+        sim.pair(Key::Down);
+        assert!(!sim.keys.is_pressed(Key::Down));
+    }
+
+    #[test]
+    fn a_second_tap_before_the_delay_is_a_fresh_press_not_a_repeat() {
+        let mut sim = Sim::new();
+        sim.pair(Key::Down);
+        for _ in 0..9 {
+            sim.frame(); // about 150 ms later: a double tap
+        }
+        sim.pair(Key::Down);
+        let second_at = sim.now_ms;
+        while sim.now_ms < second_at + DELAY_MS {
+            sim.frame();
+            assert!(sim.keys.is_pressed(Key::Down));
+        }
+    }
+
+    #[test]
+    fn each_key_keeps_its_own_hold() {
+        let mut sim = Sim::new();
+        sim.pair(Key::Up);
+        sim.frame();
+        sim.pair(Key::Left);
+        assert!(sim.keys.is_pressed(Key::Up) && sim.keys.is_pressed(Key::Left));
+        assert!(!sim.keys.is_pressed(Key::Right));
+        sim.frame();
+        sim.keys.release(Key::Up, Mods::NONE); // a later release: the finger
+        assert!(!sim.keys.is_pressed(Key::Up));
+        assert!(sim.keys.is_pressed(Key::Left));
+    }
+
+    #[test]
+    fn clearing_the_pulses_keeps_the_learning_and_clear_drops_it_all() {
+        let mut sim = Sim::new();
+        sim.screen_reader_hold(Key::Up, 1.5, JAWS_FIRST_REPEAT_MS, &JAWS_SPACINGS_MS);
+        assert!(sim.keys.learned_spacing_ms().is_some());
+        sim.keys.clear_pulses();
+        assert!(!sim.keys.is_pressed(Key::Up));
+        assert!(sim.keys.learned_spacing_ms().is_some());
+        sim.pair(Key::Up);
+        sim.keys.press(Key::B, Mods::NONE);
+        sim.keys.clear();
+        assert!(!sim.keys.is_pressed(Key::Up));
+        assert!(!sim.keys.is_pressed(Key::B));
+        assert_eq!(sim.keys.mods(), Mods::NONE);
+    }
+
+    #[test]
+    fn windows_repeat_settings_decode_to_the_documented_timing() {
+        assert_eq!(repeat_delay_ms(0), 250);
+        assert_eq!(repeat_delay_ms(1), 500);
+        assert_eq!(repeat_delay_ms(3), 1000);
+        assert_eq!(repeat_delay_ms(99), 1000); // clamped, never a runaway pulse
+        assert_eq!(repeat_interval_ms(31), 33);
+        assert_eq!(repeat_interval_ms(0), 400);
+        let keys = HeldKeys::with_timing(1000, 400);
+        assert_eq!(keys.fresh_pulse_ms(), 1000 + FRESH_GRACE_MS);
+        assert_eq!(keys.repeat_pulse_ms(), keys.fresh_pulse_ms()); // nothing learned yet
+    }
+}

--- a/crates/freight-fate/tests/it/app_held_keys.rs
+++ b/crates/freight-fate/tests/it/app_held_keys.rs
@@ -1,0 +1,123 @@
+//! A screen reader's press-and-release train through the real driving frame
+//! (`test_driving_reads_a_jaws_held_accelerator_as_steady_throttle` in
+//! `tests/test_held_keys.py`): the pairs JAWS delivers for a held Up arrow,
+//! at the cadence measured on the owner's machine, drive the truck, the
+//! throttle never stutters, and it comes off within a second of the pairs
+//! stopping. The unit tests beside `app::held_keys` cover the tracker
+//! itself; this is the wiring, clocked the way `App::frame` clocks it.
+
+use ff_core::data::world::get_world;
+use ff_core::models::jobs::{Job, CARGO_CATALOG};
+use ff_core::models::profile::Profile;
+use ff_core::sim::weather::WeatherKind;
+use freight_fate::app::testing::TestApp;
+use freight_fate::states::base::{Key, Mods};
+use freight_fate::states::driving::DrivingState;
+use freight_fate::states::driving_core::DRIVE_PHASE_DELIVERY;
+
+const DT: f64 = 1.0 / 60.0;
+const FRAME_MS: u64 = 17; // what `begin_frame(DT)` rounds a frame to
+/// The owner's JAWS log, 2026-08-24: first repeat at 512 ms, then these.
+const JAWS_FIRST_REPEAT_MS: u64 = 512;
+const JAWS_SPACINGS_MS: [u64; 14] = [
+    263, 245, 269, 271, 242, 251, 270, 250, 244, 271, 249, 242, 254, 250,
+];
+
+/// `states_driving_controls::a_drive`: a delivery drive on a real short
+/// corridor, built straight rather than driven up to, on an empty road
+/// under a clear sky so nothing but the pedal moves the truck.
+fn a_drive(app: &mut TestApp) -> DrivingState {
+    let (origin, destination) = ("Buffalo", "Rochester");
+    let world = get_world();
+    app.ctx.profile = Some(Profile::named_in("Held Keys", origin));
+    let route = world
+        .supported_route(origin, destination, None)
+        .expect("the world routes")
+        .expect("the corridor is supported");
+    let mut job = Job::new(
+        &CARGO_CATALOG["general"],
+        12.0,
+        origin,
+        "company yard",
+        destination,
+        route.miles(),
+        1000.0,
+        12.0,
+    );
+    job.destination_location = format!("{destination} freight market");
+    let mut drive = DrivingState::new(&mut app.ctx, job, route, None, DRIVE_PHASE_DELIVERY, None);
+    drive.trip.set_npc_vehicles(Vec::new());
+    drive.trip.weather.current = WeatherKind::Clear;
+    drive.trip.truck.set_air_ready(false);
+    drive.trip.truck.engine_on = true;
+    drive.trip.position_mi = drive.trip.total_miles() / 2.0;
+    drive
+}
+
+/// When JAWS re-sends the pairs for a key held `seconds`, in ms from now.
+fn jaws_pair_times(seconds: f64) -> Vec<u64> {
+    let end = (seconds * 1000.0) as u64;
+    let mut times = vec![0, JAWS_FIRST_REPEAT_MS];
+    let mut i = 0;
+    while *times.last().unwrap() < end {
+        times.push(times.last().unwrap() + JAWS_SPACINGS_MS[i % JAWS_SPACINGS_MS.len()]);
+        i += 1;
+    }
+    times.retain(|&t| t < end);
+    times
+}
+
+#[test]
+fn test_driving_reads_a_jaws_held_accelerator_as_steady_throttle() {
+    let mut app = TestApp::new();
+    let clock = app.fake_pacer_clock();
+    let mut d = a_drive(&mut app);
+    assert_eq!(d.trip.truck.throttle, 0.0);
+
+    let mut pairs = jaws_pair_times(4.0);
+    let mut now_ms = 0u64;
+    let mut reached_full = false;
+    let mut lowest_after_full = 1.0f64;
+    while now_ms < 4000 {
+        // Exactly what `App::frame` does: clock the frame, then its events.
+        app.ctx.input.begin_frame(DT);
+        now_ms += FRAME_MS;
+        if pairs.first().is_some_and(|&t| now_ms >= t) {
+            pairs.remove(0);
+            app.ctx.input.press(Key::Up, Mods::NONE);
+            app.ctx.input.release(Key::Up, Mods::NONE);
+        }
+        d.update_frame(&mut app.ctx, DT);
+        clock.advance(DT);
+        let throttle = d.trip.truck.throttle;
+        if throttle > 0.95 {
+            reached_full = true;
+        } else if reached_full {
+            lowest_after_full = lowest_after_full.min(throttle);
+        }
+    }
+    assert!(reached_full, "the pairs never took the throttle to full");
+    assert!(
+        lowest_after_full >= 0.9,
+        "throttle stuttered down to {lowest_after_full:.2}"
+    );
+
+    // The finger lifts: the pairs stop, and the throttle comes off.
+    for _ in 0..60 {
+        app.ctx.input.begin_frame(DT);
+        d.update_frame(&mut app.ctx, DT);
+        clock.advance(DT);
+    }
+    assert_eq!(d.trip.truck.throttle, 0.0);
+}
+
+#[test]
+fn test_a_tap_fed_straight_in_keeps_its_plain_meaning() {
+    // The harness and the other tests press and release without a frame
+    // clock; that must still read as a tap, never as a half-second hold.
+    let mut app = TestApp::new();
+    app.ctx.input.press(Key::Down, Mods::NONE);
+    assert!(app.ctx.input.is_pressed(Key::Down));
+    app.ctx.input.release(Key::Down, Mods::NONE);
+    assert!(!app.ctx.input.is_pressed(Key::Down));
+}

--- a/crates/freight-fate/tests/it/main.rs
+++ b/crates/freight-fate/tests/it/main.rs
@@ -19,6 +19,7 @@ mod app_controller;
 mod app_controls_reference;
 mod app_driving_speech_ladder;
 mod app_event_speech_pacer;
+mod app_held_keys;
 mod app_info_keys;
 mod app_main_channel_pacing;
 mod app_message_review;


### PR DESCRIPTION
## What changed and why

The Rust port of the JAWS driving-keys fix that is #167 on `dev` (Python). Same player report, same cause, same measured data; this is the same tracker inside the Rust `Input`.

**Cause.** JAWS binds the arrows to its own scripts in every application. Its keyboard hook swallows the physical press and re-sends the key to the game as a synthetic press-and-release pair. Menus react to the press event and work; the driving frame polls `ctx.input.is_pressed(Key::Up)` and never sees the key down, so JAWS players had to pass every driving key through with JAWS Key+3. NVDA leaves unbound keys physical, which is why nobody saw it.

**Measured** on Norm's JAWS machine with `tools/key_probe.py` (the Python probe; the SDL path sees the same events): every arrow arrives as DOWN then UP 0 ms later in the same frame; the first repeat pair lands at the Windows repeat delay (512 ms); the rest come every ~250 ms (242–272) — JAWS's script latency, not the 33 ms Windows repeat rate.

**Fix.** `HeldKeys` moves from `app/context.rs` into its own module, `app/held_keys.rs`, and grows a pulse layer. `App::frame` clocks it (`begin_frame(dt)`) before dispatching the frame's events. Every press starts a pulse: a fresh press gets the OS repeat delay plus grace (read from Windows via `SystemParametersInfoW`, defaults elsewhere); a repeat gets the spacing the repeats are actually arriving at, learned from the synthetic pairs themselves (second repeat on, largest of the last eight) — until one is learned, repeats get the fresh pulse, so the first hold of a session cannot stutter. A release in the same frame as the press that began the pair is synthetic and keeps the pulse; a release in a later frame is the finger and ends it. `is_pressed` = physically down OR pulse alive, so the physical path is byte-for-byte what it was. Pulses clear on every state-stack change (`push_shared_with`, `take_top`) and on window focus regained.

Two guards specific to the Rust side:
- `sdl_shell::translate_events` passes SDL's own auto-repeat through as further `KeyDown`s of a key that is already down (pygame filtered those). Only a press from the released state can begin a synthetic pair, so a finger lifting in the same frame as one of those repeats is a real release — covered by `sdl_auto_repeat_of_a_held_key_never_makes_a_pair`.
- The layer is inert until `begin_frame` has clocked a frame. The playtest harness, the breaker, and the driving tests feed `ctx.input.press/release` directly without a frame loop, and every one of them keeps today's plain semantics — covered by `without_a_frame_clock_the_pulse_layer_is_inert` and `test_a_tap_fed_straight_in_keeps_its_plain_meaning`.

`windows-sys` gains the `Win32_UI_WindowsAndMessaging` feature for `SystemParametersInfoW` (no lockfile change).

## What players or maintainers will notice

JAWS players drive with the arrows like everyone else — no pass-through key. Nothing changes for NVDA, SAPI, or no-screen-reader players. Two honest limits, stated in the changelog: JAWS only re-sends a held key about four times a second and never says how long it was held, so letting go takes effect about a third of a second late, a quick tap of a pedal reads as a short press of about half a second, and the double-tap-and-hold pedal latch cannot be caught through JAWS (roadmap follow-up: an event-counted gesture).

## Tests and checks run

- `cargo test --workspace` — 45 unit tests pass; the `it` bucket 2,123 passed, 86 ignored, 1 failed: `app_smoke::smoke_checks_find_every_baked_runtime_file`, because this checkout holds LFS pointers for `sounds.pak`/`music.pak` (the repo has exceeded its LFS budget, so they cannot be fetched -- see the note below). `ff-core`'s own lib tests do not compile on a clean checkout either: `crates/ff-core/src/cab_filter/fixtures/*.wav` are `include_bytes!`-ed but not committed.
- `cargo clippy -p freight-fate --all-targets` — no warnings from the new code (the two it prints are pre-existing: `ff-core` `chunks_exact_to_as_chunks`, `context.rs:365` `drain_collect`); `cargo fmt` clean.
- New unit tests in `app::held_keys` (12): the physical path unchanged; inert without a frame clock; a lone pair holds until the first repeat would come; the measured JAWS train, replayed from the log, is one continuous hold from the first pair with no learned spacing and lapses within a spacing plus grace, and a second key's train starts with the spacing known; a fast train lapses quickly once learned; a finger's rhythm never teaches the spacing; SDL auto-repeat of a held key never makes a pair; a pair after a frame hitch is not a hold; a double tap gets a fresh pulse; per-key isolation; clearing pulses keeps the learning while `clear` drops everything; Windows setting decode.
- New `tests/it/app_held_keys.rs` (2): JAWS-cadence Up pairs through the real `update_frame`, clocked as `App::frame` clocks it, take the throttle to full with no dip below 0.9 and drop it to 0 within a second of the pairs stopping; a tap fed straight in without a clock still reads as a tap.
- Manual: the probe run under JAWS on Norm's machine (numbers above). The Rust binary itself has not been driven under JAWS yet — the LFS budget on this repo is exhausted, so a fresh checkout cannot fetch the packs.

## Accessibility impact

An accessibility fix: restores keyboard driving for JAWS users. No spoken text changed.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`, written in plain player language and matching the style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this PR includes `[skip changelog]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4QKamivXQeSqULeVbueHv
