### PR TITLE
Resume speeding callouts after a missed-exit turnaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
   never move the trip. The turnaround now puts you back on the approach so
   you can take the destination exit.
 
+- **Speeding is enforced again after a missed-exit turnaround.** Missing the
+  yard used to leave the cab silent on speed until you actually took the
+  destination exit, even after dispatch put you back on the highway
+  approach. Once you are on that approach again, a speeding strike calls
+  out the posted limit as usual. If dispatch cannot find a turnaround, the
+  cab still stays quiet on that dead-end rather than stacking facility-gate
+  strikes.
+
 - **Driving keys now work with JAWS without the pass-through key.** JAWS
   hands the game each arrow key as an instant tap rather than a held key,
   so holding Up, Down, Left, or Right to accelerate, brake, or steer did

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -1212,7 +1212,10 @@ class DrivingEventMixin:
             return
         # Every miss must reposition the trip. The old say-once guard
         # swallowed a second miss and left the truck stuck at zero miles.
-        self._missed_destination_exit_said = True
+        # Leave _missed_destination_exit_said false: that flag is the
+        # unrecoverable say-once, and it also suppresses speeding. After a
+        # successful rewind the truck is back on the highway approach, so
+        # posted-limit strikes must resume. A second miss rewinds again.
         self.trip.game_minutes += 20.0
         self.trip.position_mi = recover_pos
         self._destination_exit_announced_key = None

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -918,7 +918,7 @@ class DrivingUpdateMixin:
         if self._ramp_mi is not None:
             return  # the ramp is off the highway and unpatrolled
         if self._missed_destination_exit_said and not self._destination_exit_taken:
-            return  # recovery state: guide the player back to the missed exit
+            return  # unrecoverable miss: still at the gate, don't stack 15-mph strikes
         if self._pull_over is not None:
             return  # already being pulled over; don't pile on strikes
         limit, _ = self.trip.speed_limit_at(self.trip.position_mi)

--- a/tests/test_driving_features.py
+++ b/tests/test_driving_features.py
@@ -1735,9 +1735,12 @@ def test_missed_destination_recovery_does_not_keep_issuing_gate_speed_strikes(mo
         assert "missed the destination exit" in events[-1].lower()
         assert "back up" not in events[-1].lower()
 
-        driving.update(SPEEDING_HOLD_S + 1.0)
+        assert driving.trip.position_mi < driving.trip.total_miles - 0.05
+        driving._update_speeding(SPEEDING_HOLD_S + 1.0)
 
-        assert driving.speeding_strikes == 0
+        # Successful rewind is back on the highway, not the facility gate.
+        # Gate-zone strike spam was the stuck-miss bug; highway speeding
+        # after recover is asserted on the Hattiesburg path.
         assert not any("End of facility gate zone" in event for event in events)
     finally:
         app.shutdown()

--- a/tests/test_missed_destination_exit.py
+++ b/tests/test_missed_destination_exit.py
@@ -117,3 +117,85 @@ def test_unrecoverable_miss_fails_honestly(monkeypatch):
         assert "ahead again" not in events[-1].lower()
     finally:
         app.shutdown()
+
+
+def test_hattiesburg_recover_resumes_speeding_callout(monkeypatch):
+    """After a clean US-49 miss-and-recover, 89 mph on the 65 limit speaks."""
+    from freight_fate.app import App
+    from freight_fate.models.jobs import CARGO_CATALOG, Job
+    from freight_fate.models.profile import Profile
+    from freight_fate.states.driving import SPEEDING_HOLD_S, DrivingState
+
+    app = App()
+    events = []
+    monkeypatch.setattr(app.ctx, "say_event", speech_stub(events))
+    monkeypatch.setattr(app.ctx.audio, "play", lambda *a, **k: None)
+    try:
+        app.ctx.profile = Profile(name="Hattiesburg Speed", current_city="gulfport_ms_us")
+        route = app.ctx.world.supported_route("gulfport_ms_us", "hattiesburg_ms_us")
+        assert route is not None
+        job = Job(
+            CARGO_CATALOG["general"],
+            12.0,
+            "gulfport_ms_us",
+            "company yard",
+            "hattiesburg_ms_us",
+            route.miles,
+            1000.0,
+            12.0,
+            destination_location="Hattiesburg freight market",
+        )
+        driving = DrivingState(app.ctx, job, route, phase="delivery")
+        quiet_trip(driving)
+        release_air_brakes(driving)
+
+        _miss_destination_exit(driving)
+
+        assert not driving.trip.finished
+        assert not driving._missed_destination_exit_said
+        assert not driving._destination_exit_taken
+        limit, reason = driving.trip.speed_limit_at(driving.trip.position_mi)
+        assert reason is None
+        assert limit == 65.0
+        assert driving.trip.active_patrol_at(driving.trip.position_mi) is None
+
+        driving.truck.velocity_mps = 89.0 / 2.23694
+        driving._update_speeding(SPEEDING_HOLD_S + 1.0)
+
+        assert driving.speeding_strikes == 1
+        assert driving._pull_over is None
+        assert "speeding strike" in events[-1].lower()
+        assert "65 miles per hour" in events[-1].lower()
+    finally:
+        app.shutdown()
+
+
+def test_unrecoverable_miss_does_not_issue_gate_speed_strikes(monkeypatch):
+    from freight_fate.app import App
+    from freight_fate.states.driving import SPEEDING_HOLD_S, DrivingState
+
+    app = App()
+    events = []
+    monkeypatch.setattr(app.ctx, "say_event", speech_stub(events))
+    monkeypatch.setattr(app.ctx.audio, "play", lambda *a, **k: None)
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        monkeypatch.setattr(driving, "_destination_exit_details", lambda *a, **k: None)
+        monkeypatch.setattr(driving, "_synthetic_destination_exit_mi", lambda: 0.0)
+
+        missed_from = driving.trip.total_miles
+        _miss_destination_exit(driving)
+
+        assert isinstance(app.state, DrivingState)
+        assert driving.trip.position_mi == missed_from
+        assert driving._missed_destination_exit_said
+        driving.truck.velocity_mps = 89.0 / 2.23694
+        driving._update_speeding(SPEEDING_HOLD_S + 1.0)
+
+        assert driving.speeding_strikes == 0
+        assert driving._pull_over is None
+        assert not any("speeding strike" in event.lower() for event in events)
+    finally:
+        app.shutdown()
+


### PR DESCRIPTION
## What changed and why

The speeding half of #169. After #174 rewinds a missed destination exit, `_handle_missed_destination_exit` still set `_missed_destination_exit_said`, and `_update_speeding` treats that flag as "do not enforce speed." A clean miss-and-recover on Gulfport → Hattiesburg therefore stayed silent at 89 mph on a 65 mph OSM US-49 approach.

The flag is now only the unrecoverable say-once. A successful rewind leaves it false so posted-limit strikes resume on the highway. If dispatch cannot place a turnaround, the cab still stays quiet at the facility gate instead of stacking 15 mph strikes.

Hattiesburg US-49 / US-98 approaches do have a 65 mph OSM limit (I-59 from Meridian is 70). These short corridors seed zero patrols (`n = int(miles/120)`), so 89 mph is a spoken speeding strike, not a pull-over. No invented interchange geometry or cops.

## What players or maintainers will notice

If you miss the yard and dispatch puts you back on the approach, speeding is live again. Hold 89 on that 65 limit and the cab calls a speeding strike. If there is no safe turnaround, the dead-end stays quiet rather than spamming facility-gate strikes.

## Tests and checks run

- `uv run pytest tests/test_missed_destination_exit.py tests/test_driving_features.py::test_missed_destination_exit_reroutes_every_time tests/test_driving_features.py::test_missed_destination_recovery_does_not_keep_issuing_gate_speed_strikes -q` (7 passed)
- `uv run ruff check` on the touched driving and test files
- `python -m compileall` on the touched Python files

## Accessibility impact

The new callout is the existing speeding-strike line with the posted limit. Nothing new to learn. Unrecoverable dead-ends still do not stack gate-zone strike speech.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in
      `CHANGELOG.md`, written in plain player language and matching the
      style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this
      PR includes `[skip changelog]`.