### PR TITLE
ci: activate Career 1.9 snapshots

### DIFF
--- a/.github/workflows/build-career-1.9.yml
+++ b/.github/workflows/build-career-1.9.yml
@@ -1,0 +1,188 @@
+name: Career 1.9 snapshot
+
+on:
+  schedule:
+    - cron: "37 2 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Skip release creation"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: career-19-snapshot
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+  CAREER_BRANCH: "feat/career-1.9"
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+      tag: ${{ steps.check.outputs.tag }}
+      commit_sha: ${{ steps.check.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CAREER_BRANCH }}
+          fetch-depth: 0
+
+      - name: Check snapshot conditions
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "tag=1.9-tester-$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_TAG=$(git tag --list "1.9-tester-*" --sort=-version:refname | head -1)
+          if [ -z "$LAST_TAG" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh release view "$LAST_TAG" --json body -q .body > previous-notes.md || true
+          : > latest-stable-notes.md
+          LATEST_STABLE_TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases" \
+            --jq '[.[] | select(.draft == false and .prerelease == false)][0].tag_name // ""')
+          if [ -n "$LATEST_STABLE_TAG" ]; then
+            gh release view "$LATEST_STABLE_TAG" --json body -q .body > latest-stable-notes.md || true
+          fi
+          python3 tools/release_notes.py should-build-nightly \
+            --previous-tag "$LAST_TAG" \
+            --exclude-notes previous-notes.md \
+            --latest-stable-tag "$LATEST_STABLE_TAG" \
+            --exclude-stable-notes latest-stable-notes.md \
+            >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build (Windows)
+    needs: prepare
+    if: needs.prepare.outputs.should_build == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      FREIGHT_FATE_NO_SPEECH: "1"
+      SDL_VIDEODRIVER: dummy
+      SDL_AUDIODRIVER: dummy
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: "1"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+          fetch-depth: 0
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install the pinned Rust toolchain
+        run: rustup show
+
+      - name: Check Rust formatting
+        run: cargo fmt --all --check
+
+      - name: Fetch BASS
+        # Audio tests skip when the proprietary BASS runtime is absent. Fetch
+        # and verify it before Clippy or Cargo tests so a clean runner cannot
+        # report green without exercising the audio backend.
+        run: |
+          uv run python tools/fetch_bass.py
+          uv run python tools/fetch_bass.py --check
+
+      - name: Lint Rust targets
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+      - name: Test Rust workspace
+        run: cargo test -p ff-core -p freight-fate
+
+      - name: Build the portable release
+        run: ./build-release.ps1 --tag "${{ needs.prepare.outputs.tag }}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Windows
+          path: dist/FreightFate-*-windows-portable.zip
+          if-no-files-found: error
+
+  release:
+    name: Release
+    needs: [prepare, build]
+    if: always() && needs.prepare.outputs.should_build == 'true' && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: Windows
+          path: assets
+
+      - name: Verify the Windows archive
+        shell: bash
+        run: |
+          shopt -s nullglob
+          archives=(assets/FreightFate-*-windows-portable.zip)
+          if [ "${#archives[@]}" -ne 1 ]; then
+            echo "Expected exactly one Windows portable archive; found ${#archives[@]}." >&2
+            exit 1
+          fi
+
+      - name: Prepare and verify release notes and checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$COMMIT_SHA"
+          (cd assets && sha256sum FreightFate-*-windows-portable.zip > checksums.txt)
+          (cd assets && sha256sum -c checksums.txt)
+
+          LAST_TAG=$(git tag --list "1.9-tester-*" --sort=-version:refname | grep -v "^$TAG$" | head -1)
+          if [ -n "$LAST_TAG" ]; then
+            gh release view "$LAST_TAG" --json body -q .body > previous-notes.md || true
+            python3 tools/release_notes.py nightly \
+              --previous-tag "$LAST_TAG" \
+              --exclude-notes previous-notes.md \
+              --output notes.md
+          else
+            python3 tools/release_notes.py nightly --first-snapshot --output notes.md
+          fi
+          test -s notes.md
+          test -s assets/checksums.txt
+
+      - name: Create prerelease
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" -y --cleanup-tag
+          elif git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            git push origin ":refs/tags/$TAG"
+          fi
+          gh release create "$TAG" assets/* --notes-file notes.md \
+            --title "Freight Fate 1.9 tester snapshot $(date -u +%Y-%m-%d)" \
+            --prerelease --target "$COMMIT_SHA"

--- a/.github/workflows/retry-failed-nightly.yml
+++ b/.github/workflows/retry-failed-nightly.yml
@@ -2,7 +2,7 @@ name: Retry failed nightly
 
 on:
   workflow_run:
-    workflows: [Build]
+    workflows: [Build, Career 1.9 snapshot]
     types: [completed]
 
 permissions:
@@ -29,21 +29,48 @@ jobs:
       - name: Dispatch one recovery build if still needed
         env:
           GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
-          TAG="nightly-$(date -u +%Y%m%d)"
+          if [ "$WORKFLOW_NAME" = "Career 1.9 snapshot" ]; then
+            TAG="1.9-tester-$(date -u +%Y%m%d)"
+            TARGET_BRANCH="feat/career-1.9"
+          elif [ "$WORKFLOW_NAME" = "Build" ]; then
+            TAG="nightly-$(date -u +%Y%m%d)"
+            TARGET_BRANCH="dev"
+          else
+            echo "Unsupported workflow: $WORKFLOW_NAME" >&2
+            exit 1
+          fi
 
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "$TAG already exists; the nightly recovered while waiting."
+            if [ "$WORKFLOW_NAME" = "Career 1.9 snapshot" ]; then
+              echo "$TAG already exists; the Career 1.9 snapshot recovered while waiting."
+            else
+              echo "$TAG already exists; the nightly recovered while waiting."
+            fi
             exit 0
           fi
 
-          ACTIVE=$(gh run list --repo "$GITHUB_REPOSITORY" \
-            --workflow Build --branch dev --limit 20 \
-            --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
-          if [ "$ACTIVE" -gt 0 ]; then
-            echo "A dev Build is already queued or running; not dispatching a duplicate."
-            exit 0
-          fi
+          if [ "$WORKFLOW_NAME" = "Career 1.9 snapshot" ]; then
+            ACTIVE=$(gh run list --repo "$GITHUB_REPOSITORY" \
+              --workflow "Career 1.9 snapshot" --branch "$TARGET_BRANCH" --limit 20 \
+              --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
+            if [ "$ACTIVE" -gt 0 ]; then
+              echo "A Career 1.9 snapshot is already queued or running; not dispatching a duplicate."
+              exit 0
+            fi
 
-          echo "Scheduled nightly is still missing after 45 minutes; dispatching one retry."
-          gh workflow run Build --repo "$GITHUB_REPOSITORY" --ref dev -f dry_run=false
+            echo "Scheduled Career 1.9 snapshot is still missing after 45 minutes; dispatching one retry."
+            gh workflow run "Career 1.9 snapshot" --repo "$GITHUB_REPOSITORY" --ref "feat/career-1.9" -f dry_run=false
+          else
+            ACTIVE=$(gh run list --repo "$GITHUB_REPOSITORY" \
+              --workflow Build --branch dev --limit 20 \
+              --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
+            if [ "$ACTIVE" -gt 0 ]; then
+              echo "A dev Build is already queued or running; not dispatching a duplicate."
+              exit 0
+            fi
+
+            echo "Scheduled nightly is still missing after 45 minutes; dispatching one retry."
+            gh workflow run Build --repo "$GITHUB_REPOSITORY" --ref dev -f dry_run=false
+          fi


### PR DESCRIPTION
## What changed and why

Activates the dedicated Career 1.9 snapshot workflow on the repository default branch so GitHub can schedule and manually dispatch builds from `feat/career-1.9`. Extends the existing one-retry workflow to recognize failed scheduled Career snapshots while preserving the stable `Build` recovery path.

This PR contains workflow definitions only. It does not merge Career gameplay into `main`, dispatch a workflow, or create a release.

## What players or maintainers will notice

Maintainers can see `Career 1.9 snapshot` as a separate scheduled/manual workflow. Stable `Build` behavior remains unchanged and continues to target `dev`; Career snapshots target `feat/career-1.9`.

## Tests and checks run

- Passed the full Python suite on the exact published Career revision.
- Parsed both activation YAML files with PyYAML.
- Passed focused workflow contract assertions for immutable commit pinning, branch targets, release targeting, and stable retry preservation.
- Verified exactly two workflow paths changed and `.github/workflows/build.yml` is byte-identical to `origin/main`.
- Passed `git diff --check` and the repository pre-push release-note gate.

## Accessibility impact

This changes CI automation only. It adds no gameplay, spoken text, keyboard interaction, or player interface, so no deeper accessibility testing applies.

## Changelog

- [ ] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`, written in plain player language and matching the style of the existing entries.
- [x] This change is not player-facing, and every commit message in this PR includes `[skip changelog]`.