### PR TITLE
ci: bound Career snapshot release notes

### DIFF
--- a/.github/workflows/build-career-1.9.yml
+++ b/.github/workflows/build-career-1.9.yml
@@ -169,6 +169,7 @@ jobs:
             python3 tools/release_notes.py nightly --first-snapshot --output notes.md
           fi
           test -s notes.md
+          python3 tools/release_notes.py check-size --input notes.md --max-characters 120000
           test -s assets/checksums.txt
 
       - name: Create prerelease


### PR DESCRIPTION
## What changed and why

Adds the reviewed 120,000 serialized-character release-note guard to the active Career 1.9 snapshot workflow. This prevents GitHub release creation from receiving oversized notes while keeping the release-note implementation and tests on `feat/career-1.9`.

This PR changes only `.github/workflows/build-career-1.9.yml`. It does not merge Career source, tools, tests, or gameplay into `main`, dispatch a workflow, or create a release.

## What players or maintainers will notice

Career snapshot publication now stops before release creation if generated notes exceed GitHub's safe serialized size. The workflow still targets `feat/career-1.9`.

## Tests and checks run

- Passed the full Python suite on exact Career revision `d18cfc899281e2e116f7bdf387ef42d7139c2d74`.
- Parsed the updated workflow with PyYAML.
- Passed focused assertions for the exact 120,000-character guard, immutable commit pinning, Career branch target, and release target.
- Verified exactly one workflow path changed.
- Verified stable `build.yml` and `retry-failed-nightly.yml` remain byte-identical to `origin/main`.
- Passed `git diff --check` and the repository pre-push release-note gate.

## Accessibility impact

This changes CI automation only. It adds no gameplay, spoken text, keyboard interaction, or player interface, so no deeper accessibility testing applies.

## Changelog

- [ ] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`, written in plain player language and matching the style of the existing entries.
- [x] This change is not player-facing, and every commit message in this PR includes `[skip changelog]`.