### PR TITLE
ci: select explicit macOS package verification

### DIFF
--- a/.github/workflows/build-career-1.9.yml
+++ b/.github/workflows/build-career-1.9.yml
@@ -168,7 +168,7 @@ jobs:
         run: cargo test -p ff-core -p freight-fate
 
       - name: Build the macOS release
-        run: uv run python tools/build_release.py --rust --smoke --tag "${{ needs.prepare.outputs.tag }}"
+        run: uv run python tools/build_release.py --rust --macos-non-launch-verify --tag "${{ needs.prepare.outputs.tag }}"
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## What changed and why

The Career 1.9 Apple Silicon job now selects the release tool's explicit non-launch verification mode. Repeated GitHub-hosted launches timed out before Rust logging even after native dependency audits and deep strict signing passed, so this keeps the Mac gate structural and names that boundary honestly.

This is a one-line activation change on main. The implementation and regression coverage are already on feat/career-1.9 at de174e80. Stable build and CI workflows are unchanged.

## What players or maintainers will notice

The Career Mac package must still pass full Rust tests, staged payload checks, native-library closure, deep strict signing, archive verification, Apple Silicon naming, and all-or-nothing release fan-in. Windows retains its real packaged process smoke. The hosted Mac job no longer claims runtime smoke coverage.

## Tests and checks run

- Passed the complete Python suite on the Career implementation branch.
- Passed 85 focused packaging and workflow tests.
- Passed full Ruff lint, touched-file Ruff format, byte compilation, and diff checks.
- Passed the repository release-note pre-push gate on both branches.
- Independent code and accessibility reviews found no remaining issue.

## Accessibility impact

No gameplay, spoken text, keyboard behavior, or stable workflow changes. Mac runtime, VoiceOver, keyboard, and audio remain explicitly unproven until the fresh tester archive is exercised in a real Apple Silicon user session; the non-launch gate is package-integrity evidence only.

## Changelog

- [ ] I added a player-facing bullet under ## Unreleased in CHANGELOG.md.
- [x] This change is not player-facing, and every commit message in this PR includes [skip changelog].