### PR TITLE
Fix exit slowdown timing and ramp assist override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -755,6 +755,19 @@
   privately; they just stay off your profile.
 
 ### Fixed
+
+- **Exit assistance now uses the road it promises and gives the pedals back.**
+  At faster trip pacing, most of the mile and a half where exit assistance
+  was supposedly slowing could pass before the clock gave its brakes real
+  time to work, leaving the useful braking until the half-mile call or even
+  after the ramp. That whole approach now runs in real time, including a
+  destination exit that full lane keeping takes without a signal. At a red
+  light or stop sign beyond the ramp, route-transition assistance also ends
+  a completed brake application instead of trapping the truck near fifteen
+  miles per hour hundreds of feet from the bar, and a deliberate press of
+  the accelerator takes the pedals back; release it and the assistance can
+  still brake again when the stop genuinely requires it.
+
 - **Nearly half the exits in the game now end at the control that is really
   there.** What waits at the bottom of an off-ramp -- a traffic light, a stop
   sign, or nothing at all -- was decided by a roll of the dice at every exit

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3522,7 +3522,12 @@ for 1.8" framing predates the release split):
       putting the trip on the real clock for the shed window the way a
       controlled ramp and a severe curve already do, so signalling nine miles
       out no longer starts the shed the moment the signal goes on, at any
-      pacing. Battery scenario: `ramp_speed_control_handback`.
+      pacing. Follow-up control fixes make the whole active exit-assistance
+      window real time, including signal-free destination exits under full
+      lane keeping. At ramp-end controls, a completed brake snub now releases
+      without returning to the old air-draining brake chatter, and a live
+      accelerator press owns the pedals until the driver lets it go. Battery
+      scenario: `ramp_speed_control_handback`.
 - [x] **Enforcement beyond the speeding stop.** Weigh-station blow-pasts
       and severe visible damage draw roadside stops; running from lights
       escalates through warnings to a felony stop with spike strips and

--- a/src/freight_fate/sim/trip.py
+++ b/src/freight_fate/sim/trip.py
@@ -1156,7 +1156,16 @@ class Trip(TripRoadEventMixin, TripTrafficMixin, EnforcementPostMixin):
         speed = self.truck.speed_mph
         if speed <= RAMP_MAX_MPH:
             return False  # already slow enough for the gore: nothing to shed
-        window = approach_shed_mi(speed, RAMP_MAX_MPH) * EXIT_APPROACH_DECOMPRESS_SLACK
+        # Exit speed assistance starts at this distance in the driving layer.
+        # Keep that entire pedal-working window on the real clock: previously
+        # the assist applied its brake at 1.5 miles, while pacing stayed
+        # compressed until the smaller physics-only shed window. Most of the
+        # approach therefore vanished in a handful of frames and useful
+        # slowing did not begin until the half-mile callout.
+        window = max(
+            EXIT_SPEED_ASSIST_START_MI,
+            approach_shed_mi(speed, RAMP_MAX_MPH) * EXIT_APPROACH_DECOMPRESS_SLACK,
+        )
         return ahead <= window
 
     @staticmethod

--- a/src/freight_fate/sim/trip_models.py
+++ b/src/freight_fate/sim/trip_models.py
@@ -284,6 +284,7 @@ FACILITY_ACCESS_TAIL_MI = 2.0
 # layer, because both the zone builder and the driving state need the same
 # number: ``states/driving_core`` imports it as ``RAMP_MAX_MPH``.
 RAMP_MAX_MPH = 45.0
+EXIT_SPEED_ASSIST_START_MI = 1.5
 # The destination approach never caps below the speed the ramp needs. It used
 # to be a flat 35 over the last three miles, which put a step change on the
 # road a mile or two before the exit and dragged the truck down to a crawl

--- a/src/freight_fate/states/driving_core.py
+++ b/src/freight_fate/states/driving_core.py
@@ -81,6 +81,7 @@ from ..sim.trip_models import (
     APPROACH_DECEL_MPS2,
     APPROACH_REACTION_S,
     DESTINATION_LOCAL_APPROACH_MI,
+    EXIT_SPEED_ASSIST_START_MI,
     METERS_PER_MILE,
 )
 from ..sim.trip_models import RAMP_MAX_MPH as TRIP_RAMP_MAX_MPH
@@ -294,6 +295,10 @@ RAMP_TERMINAL_GRACE_MI = 0.02  # rolling this far past the bar commits the viola
 # to brake application against the nominal full-service figure, and holds the
 # stop once the truck is within the hold window short of the bar.
 RAMP_ASSIST_DECEL_START_MPS2 = 0.6
+# Once a held application has taken demand this far below the engagement
+# point, finish that snub and coast. Separate thresholds prevent the rapid
+# release/reapply cycle that used to empty the air tanks.
+RAMP_ASSIST_DECEL_RELEASE_MPS2 = 0.35
 RAMP_ASSIST_FULL_DECEL_MPS2 = 3.0
 RAMP_ASSIST_HOLD_MI = 60.0 / 5280.0
 # How far the demand has to fall below the pedal the assist is already holding

--- a/src/freight_fate/states/driving_events.py
+++ b/src/freight_fate/states/driving_events.py
@@ -1316,6 +1316,7 @@ class DrivingEventMixin:
             return
         if self._exit_signal_on:
             self._update_exit_countdown(stop)
+        if self._exit_intent_ready(stop):
             self._update_exit_speed_assist(stop)
         if self.ctx.settings.lane_is_automated():
             return
@@ -1410,7 +1411,7 @@ class DrivingEventMixin:
         if not self.ctx.settings.exit_speed_assist:
             return
         ahead = stop.at_mi - self.trip.position_mi
-        if not 0 < ahead <= 1.5:
+        if not 0 < ahead <= EXIT_SPEED_ASSIST_START_MI:
             return
         if self._cruise_mph is not None or self._keeper_mph is not None:
             # The assist takes the pedals for the ramp; the session is not its
@@ -2313,7 +2314,7 @@ class DrivingEventMixin:
                 category=SpeechCategory.NAVIGATION,
             )
 
-    def _update_ramp_terminal_assist(self) -> None:
+    def _update_ramp_terminal_assist(self, *, accelerating: bool = False) -> None:
         """Route-transition assistance works the pedals for the terminal.
 
         Stopping a rig blind inside the bar's grace window while the light
@@ -2330,6 +2331,15 @@ class DrivingEventMixin:
         if self._ramp_mi is None or self._ramp_terminal_done:
             return
         if self._ramp_control not in ("signal", "stop") or not self._ramp_light_announced:
+            return
+        if accelerating:
+            # A live accelerator press is the driver taking the pedals. Drop
+            # the assist's stored application as well as standing aside this
+            # frame, otherwise it returns on the next tick and fights the
+            # same held input. Once the driver releases, the higher engage
+            # threshold below may take over again if the bar truly requires
+            # it.
+            self._ramp_assist_brake = 0.0
             return
         if self._ramp_waiting_at_light:
             # Holding for green: the assist keeps the brakes on.
@@ -2389,6 +2399,13 @@ class DrivingEventMixin:
         gap_m = max(0.5, gap_mi * 1609.344)
         v_mps = max(0.0, self.truck.velocity_mps)
         needed = (v_mps * v_mps) / (2.0 * gap_m)
+        if needed < RAMP_ASSIST_DECEL_RELEASE_MPS2 and gap_m > 30.0:
+            # The current snub has done its work. Keeping the minimum pedal
+            # down here trapped trucks near 15 mph with a thousand feet still
+            # to run and made throttle ineffective. Coast until demand rises
+            # through the separate engagement threshold again.
+            self._ramp_assist_brake = 0.0
+            return
         idle = self._ramp_assist_brake <= 0.0
         if idle and needed < RAMP_ASSIST_DECEL_START_MPS2 and gap_m > 30.0:
             return
@@ -2510,7 +2527,9 @@ class DrivingEventMixin:
             return
         self._ramp_terminal_done = True
 
-    def _update_exit(self, moved_mi: float, dt: float = 0.0) -> None:
+    def _update_exit(
+        self, moved_mi: float, dt: float = 0.0, *, accelerating: bool = False
+    ) -> None:
         """Advance an armed exit or an active ramp; opens the stop menu."""
         # Real time from the gore to the terminal: while the ramp ends in
         # a live light or sign, the clock must not compress the seconds
@@ -2536,7 +2555,7 @@ class DrivingEventMixin:
             self._ramp_mi -= moved_mi
             if not self._ramp_light_announced and self._ramp_mi <= RAMP_CONTROL_ANNOUNCE_MI:
                 self._announce_ramp_terminal()
-            self._update_ramp_terminal_assist()
+            self._update_ramp_terminal_assist(accelerating=accelerating)
             if self._update_selected_stop_assist():
                 return
             if not self._ramp_terminal_done and self._ramp_mi <= RAMP_ACCESS_MI:

--- a/src/freight_fate/states/driving_updates.py
+++ b/src/freight_fate/states/driving_updates.py
@@ -509,7 +509,7 @@ class DrivingUpdateMixin:
         self._check_destination_exit()
         self._check_gate_approach_warning(dt)
         self._update_turn_commitment(dt)
-        self._update_exit(self.trip.last_moved_mi, dt)
+        self._update_exit(self.trip.last_moved_mi, dt, accelerating=hand_accelerating)
         # Immediately after the exit watch, which is what turns a signaled
         # scale exit into a ramp. Only now can a scale crossing be told apart
         # from a check-in.

--- a/tests/test_cruise_resume_ramp.py
+++ b/tests/test_cruise_resume_ramp.py
@@ -334,6 +334,27 @@ def test_the_ramp_cap_glides_down_as_the_exit_closes(monkeypatch):
         app.shutdown()
 
 
+@pytest.mark.parametrize("time_scale", [1.0, 4.0, 20.0, 40.0])
+def test_exit_speed_assist_window_runs_on_the_real_clock(monkeypatch, time_scale):
+    """The assist's entire 1.5-mile pedal window must buy real seconds.
+
+    Previously only the smaller physics shed window decompressed pacing, so
+    most of the advertised assist window disappeared at 20x or 40x and useful
+    braking appeared to begin around the half-mile callout.
+    """
+    from freight_fate.app import App
+
+    app = App()
+    try:
+        driving, stop = _armed_exit_at(app, monkeypatch, ahead_mi=4.5, time_scale=time_scale)
+        driving.trip.position_mi = stop.at_mi - 1.49
+        driving._update_exit(0.0)
+
+        assert driving.trip.effective_time_scale == pytest.approx(1.0)
+    finally:
+        app.shutdown()
+
+
 def _cap_at(driving, stop, ahead_mi: float) -> float:
     """The exit cap with the truck ``ahead_mi`` short of the gore."""
     driving.trip.position_mi = stop.at_mi - ahead_mi

--- a/tests/test_driving_exits.py
+++ b/tests/test_driving_exits.py
@@ -725,6 +725,37 @@ def test_exit_speed_assist_slows_with_full_lane_keeping(monkeypatch):
         app.shutdown()
 
 
+def test_exit_speed_assist_slows_an_automatically_taken_destination_exit(monkeypatch):
+    """Full lane keeping takes the destination exit without an X signal.
+
+    That is valid exit intent, so it must receive the same speed assistance
+    as a manually signalled exit rather than arriving at the gore at highway
+    speed whenever cruise is off.
+    """
+    from freight_fate.app import App
+
+    app = App()
+    app.ctx.settings.apply_driving_assistance_preset("all")
+    monkeypatch.setattr(app.ctx, "say_event", speech_stub())
+    try:
+        driving = start_drive(app)
+        quiet_trip(driving)
+        destination = driving._destination_exit_stop()
+        driving.trip.position_mi = destination.at_mi - 1.0
+        driving.truck.velocity_mps = 29.0  # ~65 mph
+
+        driving._check_destination_exit()
+        assert driving._exit_stop is not None
+        assert not driving._exit_signal_on
+
+        driving._update_exit_preparation(HeldKeys(), 1 / 60)
+
+        assert driving._exit_intent_ready(driving._exit_stop)
+        assert driving.truck.brake >= 0.35
+    finally:
+        app.shutdown()
+
+
 @pytest.mark.smoke
 def test_exit_lane_stays_set_after_keyboard_release():
     from freight_fate.app import App

--- a/tests/test_ramp_terminals.py
+++ b/tests/test_ramp_terminals.py
@@ -234,6 +234,62 @@ def test_transition_assist_brakes_for_the_red():
         app.shutdown()
 
 
+def test_transition_assist_finishes_a_snub_instead_of_crawling_to_the_bar():
+    """A completed snub must not pin a slow truck hundreds of feet out.
+
+    The anti-fanning servo deliberately holds one application, but its floor
+    used to survive even after demand collapsed. At 15 mph with 1,000 feet to
+    go it kept forcing throttle to zero all the way down the approach.
+    """
+    from freight_fate.app import App
+
+    app = App()
+    try:
+        d = _driving(app)
+        app.ctx.settings.route_transition_assist = True
+        _on_ramp(d, "stop", red=False, mph=15.0)
+        d._ramp_mi = RAMP_ACCESS_MI + 1000.0 / 5280.0
+        d._ramp_assist_brake = 0.25
+        d.truck.brake = 0.25
+        d.truck.throttle = 0.5
+
+        d._update_ramp_terminal_assist()
+
+        assert d._ramp_assist_brake == 0.0
+        assert d.truck.throttle == 0.5
+    finally:
+        app.shutdown()
+
+
+def test_accelerator_takes_authority_then_terminal_assist_can_reengage():
+    """A held accelerator wins now; releasing it does not disable safety."""
+    from freight_fate.app import App
+
+    app = App()
+    try:
+        d = _driving(app)
+        app.ctx.settings.route_transition_assist = True
+        _on_ramp(d, "signal", red=True, mph=35.0)
+        d._ramp_mi = RAMP_ACCESS_MI + 0.08
+        d._ramp_assist_brake = 0.25
+        d.truck.brake = 0.0
+        d.truck.throttle = 0.5
+
+        d._update_ramp_terminal_assist(accelerating=True)
+
+        assert d._ramp_assist_brake == 0.0
+        assert d.truck.brake == 0.0
+        assert d.truck.throttle == 0.5
+
+        d._update_ramp_terminal_assist(accelerating=False)
+
+        assert d._ramp_assist_brake > 0.0
+        assert d.truck.brake > 0.0
+        assert d.truck.throttle == 0.0
+    finally:
+        app.shutdown()
+
+
 def test_transition_assist_holds_the_stop_at_the_bar():
     from freight_fate.app import App
     from freight_fate.states.driving import RAMP_ASSIST_HOLD_MI


### PR DESCRIPTION
## What changed and why

Exit speed assistance now gets the full 1.5-mile approach window in real time instead of waiting for the shorter dynamic decompression window. The assist also runs for a valid destination-exit intent under full lane keeping, rather than depending on the manual signal-only path.

Route-transition braking at ramp terminals now uses hysteresis: once the required deceleration falls below the release threshold, it ends the current brake snub and coasts until braking is genuinely needed again. A deliberate accelerator press immediately yields the pedals to the driver and clears the stored assist application.

The ramp speed itself remains data-driven. This does not impose one universal ramp speed or change individual ramp advisories.

## What players or maintainers will notice

- Exit assistance begins slowing early enough to reach the ramp at its advised speed instead of beginning after the useful approach has passed.
- The same speed-assist behavior is available with full lane keeping.
- Route-transition assistance no longer traps the truck near 15 mph with roughly 1,000 feet still available before a stop bar.
- Holding the accelerator overrides terminal assistance; releasing it still allows the assist to re-engage if the stop genuinely requires braking.
- Existing automatic-speed-control handoff remains intact: it is paused for the ramp and resumes after a non-destination stop bar is honored and the truck is moving again.

## Tests and checks run

- `uv run pytest tests/test_ramp_terminals.py tests/test_driving_exits.py tests/test_cruise_resume_ramp.py`
- `uv run pytest` — 4,105 passed, 12 skipped, 5 xfailed
- `uv run ruff check src tests tools`
- `uv run python -m compileall src tests tools`
- `uv run pytest tests/test_release_notes.py` — 18 passed
- `git diff --check`
- Windows portable build completed through `tools/build_release.py`, including its frozen-build smoke boot
- Manual keyboard playtest with a temporary career confirmed the exit slowdown timing and terminal override fixes

Regression coverage pins the 1.5-mile decompression window, full-lane exit intent, terminal brake release, live accelerator override, and cruise handoff behavior.

## Accessibility impact

This is an accessibility fix for an audio-first driving path. Blind players can rely on the spoken exit sequence and assistance timing without discovering visually that braking began too late. The accelerator remains a direct keyboard/controller override, and the existing spoken assist announcements are unchanged. The manual playtest used the normal keyboard-driven flow; no new visual-only information or required control was introduced.

## Changelog

- [x] I added a player-facing bullet under `## Unreleased` in `CHANGELOG.md`, written in plain player language and matching the style of the existing entries.
- [ ] This change is not player-facing, and every commit message in this PR includes `[skip changelog]`.

`ROADMAP.md` also records the shipped behavior and regression coverage.