### PR TITLE
fix(ci): pin Career 1.9 compiler for stable cache reuse

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
+      - ".cargo/**"
       - ".github/workflows/rust.yml"
   # A manual run is the FULL suite: no `--cfg ci_quick`, sweeps included.
   workflow_dispatch:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,6 @@
 [toolchain]
-channel = "stable"
+# Keep CI, snapshots and local builds on the same compiler. A moving stable
+# channel invalidates compiler caches when the runner image updates.
+# Bump deliberately after validating the new compiler on Career 1.9.
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What changed and why

Pin rust-toolchain.toml to Rust 1.98.0, the compiler used by the latest passing Career 1.9 CI run (34185701869). The file previously said stable despite workflows describing it as pinned. Runner updates could therefore change compilers and invalidate both Cargo and sccache entries without a repository change. Add .cargo/** to the Rust PR path filter so linker, flags and cache-affecting configuration changes receive validation.

PortKey Drop's wxWidgets cache workaround does not apply here: Windows SDL2 is prebuilt, BASS is already cached and verified, Clippy and tests have separate dependency caches with cache-on-failure enabled, and tests already use sccache. The baseline restored both Cargo caches successfully; Clippy took 55.59s and test compilation 4m12s. This change stabilizes reuse, not a claim of another 91% speedup or faster same-source test linking.

## What players or maintainers will notice

Compiler upgrades become explicit, reviewable changes shared by CI, snapshot builds and developers. Existing test coverage and Rust-only gameplay remain unchanged. Compiler bumps will still deliberately invalidate caches.

Snapshot cache-on-failure inputs were inspected but not changed: the snapshot YAML must match its main-branch copy or scheduled runs fail the stale-workflow guard. This Career-only PR does not introduce that mismatch.

## Tests and checks run

- Parsed rust-toolchain.toml and verified the exact pin.
- actionlint 1.7.7 passed on rust.yml.
- git diff --check passed.
- Windows Rust CI will validate the pinned compiler; no local gameplay change requires another runtime test suite.

## Accessibility impact

None; build configuration only.

## Changelog

- [x] This change is not player-facing, and every commit message in this PR includes [skip changelog].