### PR TITLE
fix(driving): restore exit braking time and ramp pedal override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1261,6 +1261,15 @@
 
 ### Fixed
 
+- **Exit assistance slows early enough and gives the pedals back.** The
+  full mile-and-a-half slowdown approach now runs in real time at faster
+  trip pacing. Ramp-end assistance releases a completed brake application
+  instead of making the truck crawl toward a distant stop, and holding the
+  accelerator overrides it until you let go. Thanks to Tower
+  (@TowerAlphaTheta15) for the report and original fix in
+  [PR #185](https://github.com/Orinks/Freight-Fate/pull/185), adapted here for
+  the Rust Career 1.9 game.
+
 - **Heavy traffic follows local road conditions.** Clear stretches between
   busy sections stay clear, and a narrow bottleneck no longer holds the
   surrounding wider road at the same slow speed. Rush-hour traffic still

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7682,7 +7682,13 @@ for 1.8" framing predates the release split):
       putting the trip on the real clock for the shed window the way a
       controlled ramp and a severe curve already do, so signalling nine miles
       out no longer starts the shed the moment the signal goes on, at any
-      pacing. Battery scenario: `ramp_speed_control_handback`.
+      pacing. The Rust follow-up to TowerAlphaTheta15's #185 keeps the whole
+      1.5-mile exit-assistance window in real time, releases completed
+      terminal brake snubs with separate engage/release thresholds, and
+      honors the frame's accelerator override until release. Existing
+      automatic lane-keeping exit assistance and data-driven ramp speeds
+      remain in place. Rust regressions cover the clock, brake release,
+      and the live input path. Battery scenario: `ramp_speed_control_handback`.
 - [x] **Enforcement beyond the speeding stop.** Weigh-station blow-pasts
       and severe visible damage draw roadside stops; running from lights
       escalates through warnings to a felony stop with spike strips and

--- a/crates/ff-core/src/sim/trip/placement.rs
+++ b/crates/ff-core/src/sim/trip/placement.rs
@@ -687,7 +687,10 @@ impl Trip {
         if speed <= ramp_mph {
             return false; // already slow enough for the gore: nothing to shed
         }
-        let window = approach_shed_mi(speed, ramp_mph) * EXIT_APPROACH_DECOMPRESS_SLACK;
+        // Keep the whole assist window on the real clock, while retaining
+        // a longer physics-based shed for the exit's own advisory speed.
+        let window = EXIT_SPEED_ASSIST_START_MI
+            .max(approach_shed_mi(speed, ramp_mph) * EXIT_APPROACH_DECOMPRESS_SLACK);
         ahead <= window
     }
 

--- a/crates/ff-core/src/sim/trip_models.rs
+++ b/crates/ff-core/src/sim/trip_models.rs
@@ -266,6 +266,8 @@ pub const FACILITY_ACCESS_TAIL_MI: f64 = 2.0;
 /// The speed at or below which an off-ramp can actually be taken, and so the
 /// floor for anything the arrival zones cap.
 pub const RAMP_MAX_MPH: f64 = 45.0;
+/// The exit assist needs real braking time throughout this approach.
+pub const EXIT_SPEED_ASSIST_START_MI: f64 = 1.5;
 /// The destination approach never caps below the speed the ramp needs.
 pub const DESTINATION_APPROACH_LIMIT_MPH: f64 = RAMP_MAX_MPH;
 /// ASSUMED, and it cannot be otherwise: no vehicle code reaches inside a

--- a/crates/freight-fate/src/playtest/break_scenarios/enforcement.rs
+++ b/crates/freight-fate/src/playtest/break_scenarios/enforcement.rs
@@ -147,7 +147,16 @@ pub fn scale_pull_over_stands_down_exit() -> Outcome {
     rig.drive.exit_stop = Some(truckstop);
     rig.drive.exit_signal_on = true;
     rig.drive.cruise_exit_mph = Some(40.0);
-    rig.step(60, DT, Some(&|rig: &Rig| rig.drive.pull_over.is_some()));
+    // The armed exit puts this approach on the real clock. A tenth of a
+    // mile at 54 mph takes nearly seven seconds, so sixty frames (two
+    // seconds) cannot establish that the truck actually crossed the scale.
+    rig.step(
+        600,
+        DT,
+        Some(&|rig: &Rig| {
+            rig.drive.pull_over.is_some() || rig.drive.trip.position_mi > SCALE_MI + 0.2
+        }),
+    );
     if rig.drive.pull_over.is_none() {
         findings.push("an unarmed 54 mph scale crossing was never charged".to_string());
     }

--- a/crates/freight-fate/src/states/driving_core/constants.rs
+++ b/crates/freight-fate/src/states/driving_core/constants.rs
@@ -189,6 +189,8 @@ pub const RAMP_TERMINAL_GRACE_MI: f64 = 0.02; // rolling this far past the bar c
                                               // to brake application against the nominal full-service figure, and holds the
                                               // stop once the truck is within the hold window short of the bar.
 pub const RAMP_ASSIST_DECEL_START_MPS2: f64 = 0.6;
+// End a completed snub below the engagement threshold to avoid brake chatter.
+pub const RAMP_ASSIST_DECEL_RELEASE_MPS2: f64 = 0.35;
 // The destination approach: how hard the assist is willing to shed to ARRIVE
 // stopped, and the brake it uses. Gentler than the ramp figure -- an approach
 // is a street chain with a gate at the end, and the point is that the stop is

--- a/crates/freight-fate/src/states/driving_events/exits.rs
+++ b/crates/freight-fate/src/states/driving_events/exits.rs
@@ -635,7 +635,7 @@ impl DrivingState {
             return;
         }
         let ahead = stop.at_mi - self.trip.position_mi;
-        if !(ahead > 0.0 && ahead <= 1.5) {
+        if !(ahead > 0.0 && ahead <= ff_core::sim::trip_models::EXIT_SPEED_ASSIST_START_MI) {
             return;
         }
         if self.trip.truck.speed_mph() <= self.gore_acceptance_mph(Some(stop)) {

--- a/crates/freight-fate/src/states/driving_events/ramp_crossing.rs
+++ b/crates/freight-fate/src/states/driving_events/ramp_crossing.rs
@@ -23,6 +23,15 @@ impl DrivingState {
     /// driver's move unless facility stopping assistance is on, in which case
     /// that assist takes it (`terminal_release_text`).
     pub fn update_ramp_terminal_assist(&mut self, ctx: &mut GameContext) {
+        self.update_ramp_terminal_assist_with_input(ctx, false);
+    }
+
+    /// A live accelerator press overrides this assist, including its red-light hold.
+    pub fn update_ramp_terminal_assist_with_input(
+        &mut self,
+        ctx: &mut GameContext,
+        accelerating: bool,
+    ) {
         if !ctx.settings.route_transition_assist {
             return;
         }
@@ -37,6 +46,12 @@ impl DrivingState {
             "signal" | "stop" | "yield" | "roundabout"
         ) || !self.ramp_light_announced
         {
+            return;
+        }
+        if accelerating {
+            // Clear only this assist's held application. The input layer owns
+            // the pedals; never erase a driver's brake or another assist's.
+            self.ramp_assist_brake = 0.0;
             return;
         }
         if self.ramp_waiting_at_light {
@@ -164,6 +179,10 @@ impl DrivingState {
         let gap_m = 0.5f64.max(gap_mi * 1609.344);
         let v_mps = 0.0f64.max(self.trip.truck.velocity_mps);
         let needed = (v_mps * v_mps) / (2.0 * gap_m);
+        if needed < RAMP_ASSIST_DECEL_RELEASE_MPS2 && gap_m > 30.0 {
+            self.ramp_assist_brake = 0.0;
+            return;
+        }
         let idle = self.ramp_assist_brake <= 0.0;
         if idle && needed < RAMP_ASSIST_DECEL_START_MPS2 && gap_m > 30.0 {
             return;

--- a/crates/freight-fate/src/states/driving_events/update_exit.rs
+++ b/crates/freight-fate/src/states/driving_events/update_exit.rs
@@ -13,6 +13,17 @@ use crate::states::driving_stops::assist_servo_brake;
 impl DrivingState {
     /// Advance an armed exit or an active ramp; opens the stop menu.
     pub fn update_exit(&mut self, ctx: &mut GameContext, moved_mi: f64, dt: f64) {
+        self.update_exit_with_input(ctx, moved_mi, dt, false);
+    }
+
+    /// Advance exits with the frame's keyboard/controller accelerator intent.
+    pub fn update_exit_with_input(
+        &mut self,
+        ctx: &mut GameContext,
+        moved_mi: f64,
+        dt: f64,
+        accelerating: bool,
+    ) {
         // Real time from the gore to the terminal: while the ramp ends in
         // a live light or sign, the clock must not compress the seconds
         // the driver needs to brake for it.
@@ -79,20 +90,26 @@ impl DrivingState {
         };
         self.trip.exit_approach_mi = ahead_to_exit.filter(|ahead| *ahead > 0.0);
         if self.ramp_mi.is_some() {
-            self.update_active_ramp(ctx, moved_mi, dt);
+            self.update_active_ramp(ctx, moved_mi, dt, accelerating);
             return;
         }
         self.update_armed_exit(ctx);
     }
 
     /// The `_ramp_mi is not None` half of `_update_exit`.
-    fn update_active_ramp(&mut self, ctx: &mut GameContext, moved_mi: f64, dt: f64) {
+    fn update_active_ramp(
+        &mut self,
+        ctx: &mut GameContext,
+        moved_mi: f64,
+        dt: f64,
+        accelerating: bool,
+    ) {
         let ramp_mi = self.ramp_mi.expect("checked by the caller") - moved_mi;
         self.ramp_mi = Some(ramp_mi);
         if !self.ramp_light_announced && ramp_mi <= RAMP_CONTROL_ANNOUNCE_MI {
             self.announce_ramp_terminal(ctx);
         }
-        self.update_ramp_terminal_assist(ctx);
+        self.update_ramp_terminal_assist_with_input(ctx, accelerating);
         if self.update_selected_stop_assist(ctx) {
             return;
         }

--- a/crates/freight-fate/src/states/driving_updates/frame.rs
+++ b/crates/freight-fate/src/states/driving_updates/frame.rs
@@ -517,7 +517,7 @@ impl DrivingState {
         self.check_gate_approach_warning(ctx, dt);
         self.update_turn_commitment(ctx, dt);
         let moved_mi = self.trip.last_moved_mi;
-        self.update_exit(ctx, moved_mi, dt);
+        self.update_exit_with_input(ctx, moved_mi, dt, hand_accelerating);
         self.update_departure_ramp(ctx, moved_mi);
         // Immediately after the exit watch, which is what turns a signaled
         // scale exit into a ramp. Only now can a scale crossing be told apart

--- a/crates/freight-fate/tests/it/main.rs
+++ b/crates/freight-fate/tests/it/main.rs
@@ -151,3 +151,5 @@ mod transcript_tutorial_verbosity;
 mod transcript_wrong_way;
 mod updater;
 mod windows_subsystem;
+
+mod states_ramp_assist_control;

--- a/crates/freight-fate/tests/it/states_ramp_assist_control.rs
+++ b/crates/freight-fate/tests/it/states_ramp_assist_control.rs
@@ -1,0 +1,168 @@
+//! Rust regressions for TowerAlphaTheta15's ramp-assist report (#185).
+
+use ff_core::data::world::get_world;
+use ff_core::models::jobs::make_reposition_job;
+use ff_core::models::profile::Profile;
+use ff_core::sim::trip_models::RoadStop;
+use ff_core::sim::weather::WeatherKind;
+use freight_fate::app::testing::TestApp;
+use freight_fate::states::driving::DrivingState;
+use freight_fate::states::driving_core::*;
+
+fn a_real_drive(app: &mut TestApp) -> DrivingState {
+    let world = get_world();
+    let mut profile = Profile::named_in("Ramps", "Denver");
+    profile.tutorial_done = true;
+    app.ctx.profile = Some(profile);
+    let job = make_reposition_job(world, "Denver", "Cheyenne", false, None)
+        .expect("Denver to Cheyenne is a supported reposition");
+    let route = world
+        .shortest_route("Denver", "Cheyenne", None, false)
+        .expect("the world routes")
+        .expect("Denver to Cheyenne has a route");
+    let mut drive = DrivingState::new(
+        &mut app.ctx,
+        job,
+        route,
+        Some(0),
+        DRIVE_PHASE_DELIVERY,
+        Some(12.0),
+    );
+    // The bubble is its own suite's business; an empty road keeps these
+    // deterministic (`driving_feature_helpers.quiet_trip`). The weather is
+    // the other half of that helper: the trip seed is unseeded, so a drive
+    // that does not pin the sky draws a real condition and an ice day caps
+    // the safe speed under whatever the test is measuring.
+    drive.trip.set_npc_vehicles(Vec::new());
+    drive.trip.weather.current = WeatherKind::Clear;
+    drive
+}
+
+fn mph_to_mps(mph: f64) -> f64 {
+    mph / 2.2369362920544
+}
+
+/// `_FakeStop`: a bare route point at a milepost.
+fn a_stop(at_mi: f64) -> RoadStop {
+    RoadStop::new("Test Plaza", at_mi, "travel_center")
+}
+
+/// `_on_ramp`: the truck mid-ramp at the terminal bar with a known light.
+fn on_ramp(drive: &mut DrivingState, control: &str, red: bool, mph: f64) {
+    drive.trip.truck.start_engine();
+    drive.trip.truck.velocity_mps = mph_to_mps(mph);
+    drive.ramp_mi = Some(RAMP_ACCESS_MI); // right at the terminal bar
+    drive.ramp_control = control.to_string();
+    drive.ramp_light_offset_s = if red { 0.0 } else { RAMP_LIGHT_RED_S }; // phase start
+    drive.ramp_light_timer = 0.0;
+    drive.ramp_light_announced = true;
+    drive.ramp_light_last_phase = if red { "red" } else { "green" }.to_string();
+    drive.ramp_terminal_done = false;
+    drive.ramp_waiting_at_light = false;
+    drive.ramp_stop = Some(a_stop(drive.trip.position_mi + 0.5));
+}
+
+#[test]
+fn ramp_assist_releases_a_completed_snub() {
+    let mut app = TestApp::new();
+    let mut d = a_real_drive(&mut app);
+    app.ctx.settings.route_transition_assist = true;
+    on_ramp(&mut d, "stop", false, 15.0);
+    d.ramp_mi = Some(RAMP_ACCESS_MI + 1000.0 / 5280.0);
+    d.ramp_assist_brake = 0.25;
+    d.trip.truck.brake = 0.0;
+    d.trip.truck.throttle = 0.5;
+    d.update_ramp_terminal_assist(&mut app.ctx);
+    assert_eq!(d.ramp_assist_brake, 0.0);
+    assert_eq!(d.trip.truck.brake, 0.0);
+    assert_eq!(d.trip.truck.throttle, 0.5);
+}
+
+#[test]
+fn ramp_assist_accelerator_wins_through_the_frame_loop() {
+    use freight_fate::states::base::{Key, Mods};
+    let mut app = TestApp::new();
+    let mut d = a_real_drive(&mut app);
+    app.ctx.settings.route_transition_assist = true;
+    app.ctx.settings.destination_approach_assist = false;
+    // A straight, empty highway keeps unrelated curve/traffic assists from
+    // owning the pedals while this test exercises the terminal override.
+    crate::transcript_cruise_support::bench_road(&mut d, 65.0, 0.0, 1.0);
+    on_ramp(&mut d, "stop", false, 35.0);
+    d.ramp_mi = Some(RAMP_ACCESS_MI + 0.08);
+    d.ramp_assist_brake = 0.25;
+    d.trip.truck.brake = 0.0;
+    d.trip.truck.throttle = 0.5;
+    d.trip.truck.set_air_ready(false);
+    d.trip.truck.transmission.gear = 10;
+    d.departure_checked = true;
+    app.ctx.input.press(Key::Up, Mods::NONE);
+    d.update_frame(&mut app.ctx, 1.0 / 60.0);
+    assert_eq!(d.ramp_assist_brake, 0.0);
+    assert!(d.trip.truck.throttle > 0.0);
+    app.ctx.input.release(Key::Up, Mods::NONE);
+    d.update_frame(&mut app.ctx, 1.0 / 60.0);
+    assert!(d.ramp_assist_brake > 0.0);
+}
+
+#[test]
+fn ramp_assist_release_has_hysteresis_and_keeps_the_close_stop() {
+    let mut app = TestApp::new();
+    let mut d = a_real_drive(&mut app);
+    app.ctx.settings.route_transition_assist = true;
+    on_ramp(&mut d, "stop", false, 15.0);
+    let gap_m = 100.0;
+    d.ramp_mi = Some(RAMP_ACCESS_MI + gap_m / 1609.344);
+    // Start a snub, keep it through the dead band, finish it, then stay
+    // released through that same band until braking is needed again.
+    for (demand, braking) in [
+        (0.7_f64, true),
+        (0.45, true),
+        (0.3, false),
+        (0.45, false),
+        (0.7, true),
+    ] {
+        d.trip.truck.velocity_mps = (2.0 * gap_m * demand).sqrt();
+        d.trip.truck.brake = 0.0;
+        d.update_ramp_terminal_assist(&mut app.ctx);
+        assert_eq!(d.ramp_assist_brake > 0.0, braking, "demand {demand}");
+    }
+    // A low demand must not release the final approach to the stop line.
+    d.ramp_mi = Some(RAMP_ACCESS_MI + 20.0 / 1609.344);
+    d.trip.truck.velocity_mps = mph_to_mps(5.0);
+    d.ramp_assist_brake = 0.0;
+    d.update_ramp_terminal_assist(&mut app.ctx);
+    assert!(d.ramp_assist_brake > 0.0);
+}
+
+#[test]
+fn ramp_assist_release_does_not_erase_a_manual_brake() {
+    let mut app = TestApp::new();
+    let mut d = a_real_drive(&mut app);
+    on_ramp(&mut d, "stop", false, 15.0);
+    d.ramp_mi = Some(RAMP_ACCESS_MI + 1000.0 / 5280.0);
+    d.ramp_assist_brake = 0.25;
+    d.trip.truck.brake = 0.7;
+    d.update_ramp_terminal_assist(&mut app.ctx);
+    assert_eq!(d.ramp_assist_brake, 0.0);
+    assert_eq!(d.trip.truck.brake, 0.7);
+}
+
+#[test]
+fn ramp_assist_full_lane_destination_already_works_without_a_signal() {
+    let mut app = TestApp::new();
+    let mut d = a_real_drive(&mut app);
+    app.ctx.settings.apply_driving_assistance_preset("all");
+    let stop = RoadStop::new(
+        "Destination",
+        d.trip.position_mi + 1.0,
+        "delivery_destination",
+    );
+    d.exit_stop = Some(stop.clone());
+    d.exit_signal_on = false;
+    d.trip.truck.velocity_mps = mph_to_mps(90.0);
+    d.trip.truck.brake = 0.0;
+    assert!(d.exit_intent_ready(&app.ctx, &stop));
+    d.update_exit_preparation(&mut app.ctx, 1.0 / 60.0);
+    assert!(d.trip.truck.brake >= 0.35);
+}

--- a/crates/freight-fate/tests/it/transcript_cruise_resume_ramp.rs
+++ b/crates/freight-fate/tests/it/transcript_cruise_resume_ramp.rs
@@ -690,3 +690,18 @@ fn test_set_at_current_speed_cruise_is_unchanged() {
     assert!((harness.read_drive(|d| d.truck().speed_mph()) - 60.0).abs() < 5.0);
     assert!(!harness.read_drive(|d| d.truck().over_revving()));
 }
+
+#[test]
+fn ramp_assist_full_approach_window_uses_real_time() {
+    for scale in [1.0, 4.0, 20.0, 40.0] {
+        let (mut harness, stop) = armed_exit_at(4.5, scale, "off");
+        harness.with_drive(move |d, ctx| {
+            d.trip.position_mi = stop.at_mi - 1.49;
+            d.update_exit(ctx, 0.0, 0.0);
+        });
+        assert!(
+            approx(harness.read_drive(|d| d.trip.effective_time_scale()), 1.0),
+            "pacing {scale}"
+        );
+    }
+}


### PR DESCRIPTION
## What changed and why

Rust adaptation of TowerAlphaTheta15's changes in #185 for Career 1.9. The original targets the Python-based Career 2.0 branch, so changing its base alone would not implement these behaviors in the Rust runtime. Thanks to Tower for the original fixes.

- Preserve real-time travel through the full 1.5-mile armed-exit approach, while retaining longer physics-based slowdown windows and data-driven ramp advisories.
- Release terminal-assist braking when acceleration is pressed, and resume assistance after release.
- Release completed braking snubs with hysteresis while preserving close-stop behavior and manual braking.
- Retain the destination full-lane assistance already implemented on 1.9.
- Add six regression tests. Update the scale-bypass stress scenario to wait for the actual checkpoint crossing within a bounded 20-second window; its enforcement assertions are unchanged.

## What players will notice

More time to slow for exits, smoother terminal braking, and accelerator control during ramp assistance.

## Validation

- Linux core suite: 2,229 passed.
- Linux game integration suite: 2,445 passed.
- Linux game unit suite: 79 passed.
- Six focused regressions passed, including actual frame-loop accelerator press/release.
- Adversarial battery after the timing correction: 46 clean, 0 odd, 0 errors.
- Formatting and staged diff checks passed.
- Clippy passed for all targets with warnings denied.
- Windows CI passed: tests, Clippy, formatting, changelog, and security checks.

The combined local Cargo test invocation encountered intermittent Linux linker errors. The core Cargo run and successfully linked game test binaries from the same gameplay source passed separately. The subsequent harness-only timing correction passed its focused scenario and the entire adversarial battery.

## Accessibility

No interface or key-binding changes. Verified through headless Rust tests; manual Windows/NVDA playtesting was not performed.

## Documentation

- [x] CHANGELOG.md updated, with credit and link to Tower's original PR.
- [x] ROADMAP.md updated.

Original #185 remains open pending verification of this replacement.