### PR TITLE
1.9: Fix contradictory terrain readout and headless Windows rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,6 +651,10 @@
   officer's ten-hour or thirty-minute order parked you and reset the clock
   but was never remembered afterwards, so the scale house never looked harder
   at a driver who had been shut down before.
+- **Headless Windows runs avoid unnecessary graphics-driver startup.** Dummy windows use software rendering, preventing a native graphics-driver crash seen in restricted test environments.
+
+- **G announces an upcoming grade directly.** When a gentler hill or short steep stretch is ahead, the terrain report names it without first saying there is nothing steep ahead.
+
 - **Running the light or the sign at a ramp end is a gamble now, and it can
   cost you a ticket.** Before, blowing the red or the stop sign always clipped
   cross traffic and never drew a citation. Now the crossroad decides: some

--- a/crates/freight-fate/src/app/sdl_shell.rs
+++ b/crates/freight-fate/src/app/sdl_shell.rs
@@ -94,7 +94,16 @@ impl SdlShell {
             .position_centered()
             .build()
             .map_err(|e| e.to_string())?;
-        let canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
+        // A dummy window has no GPU surface. Automatic renderer selection can
+        // still enter native graphics drivers before falling back to software;
+        // AMD's driver fail-fasts there in restricted Windows environments.
+        let canvas = window.into_canvas();
+        let canvas = if video.current_video_driver() == "dummy" {
+            canvas.software()
+        } else {
+            canvas
+        };
+        let canvas = canvas.build().map_err(|e| e.to_string())?;
         // The dummy driver (every headless run: CI, the agent server under
         // FREIGHT_FATE_NO_SPEECH, the playtest benches) has no native window,
         // and the sdl2 crate PANICS rather than erring when asked for one --

--- a/crates/freight-fate/src/states/driving_controls/info.rs
+++ b/crates/freight-fate/src/states/driving_controls/info.rs
@@ -481,48 +481,41 @@ impl DrivingState {
         let scanned = 0.0f64.max(GRADE_WARN_SCAN_MI.min(self.trip.total_miles() - position));
         // "Nothing steep ahead" in the same breath as a six percent grade
         // under the wheels reads as the game contradicting itself.
-        let mut nothing = if here.abs() >= GRADE_WARN_PCT {
+        let nothing = if here.abs() >= GRADE_WARN_PCT {
             "Nothing else steep".to_string()
         } else {
             "Nothing steep".to_string()
         };
-        let (clause, sustained) = self.mild_grade_clause(ctx, here);
-        // A short punchy pull can be over the steep number and still fall
-        // under the run filter this scan uses. Saying "nothing steep" and then
-        // naming a 3.7 percent grade in the same sentence is the same
-        // contradiction in miniature, so the lead says what the scan means.
-        if !clause.is_empty() && !sustained {
-            nothing.push_str(" for long");
+        let upcoming = self.mild_grade_text(ctx, here);
+        if !upcoming.is_empty() {
+            return upcoming;
         }
         format!(
-            "{nothing} in the next {}{clause}.",
+            "{nothing} in the next {}.",
             self.trip.distance_text(scanned)
         )
     }
 
-    /// `_mild_grade_clause(here_pct)`: the grade the preview is planning for,
-    /// when none is steep enough to call out, and whether it is under the
-    /// steep number.
+    /// The grade the preview is planning for,
+    /// announced directly when none passes the sustained
+    /// steep scan.
     ///
     /// Automatic speed control banks momentum for a two percent pull and says
     /// so; with nothing steep in fifteen miles, G had nothing to say back and
     /// the two answers looked like a bug (tester report, 2026-08-15). Read off
     /// the preview's own scan so both describe the same hill.
-    pub fn mild_grade_clause(&self, ctx: &GameContext, here_pct: f64) -> (String, bool) {
+    pub fn mild_grade_text(&self, ctx: &GameContext, here_pct: f64) -> String {
         let Some((grade, ahead_mi)) = self.preview_grade_ahead() else {
-            return (String::new(), true);
+            return String::new();
         };
         // A grade already under the wheels is the first sentence's job.
         if here_pct.abs() >= PCC_GRADE_MIN * 100.0 && (grade > 0.0) == (here_pct > 0.0) {
-            return (String::new(), true);
+            return String::new();
         }
         let pct = grade.abs() * 100.0;
         let direction = if grade > 0.0 { "upgrade" } else { "downgrade" };
         let where_text = ctx.settings.short_distance_text(ahead_mi);
-        (
-            format!(", but a {pct:.1} percent {direction} starts in {where_text}"),
-            pct < GRADE_WARN_PCT,
-        )
+        format!("Next, a {pct:.1} percent {direction} starts in {where_text}.")
     }
 
     /// `_speak_upcoming(within_mi=15.0)`: U -- the road ahead that no other

--- a/crates/freight-fate/tests/it/sdl_shell.rs
+++ b/crates/freight-fate/tests/it/sdl_shell.rs
@@ -11,6 +11,8 @@ use freight_fate::app::sdl_shell::SdlShell;
 fn the_shell_boots_on_the_dummy_video_driver() {
     std::env::set_var("SDL_VIDEODRIVER", "dummy");
     std::env::set_var("SDL_AUDIODRIVER", "dummy");
-    let shell = SdlShell::new("Freight Fate headless").expect("the dummy driver hosts a window");
+    let mut shell =
+        SdlShell::new("Freight Fate headless").expect("the dummy driver hosts a window");
     assert_eq!(shell.video.current_video_driver(), "dummy");
+    shell.render(&[]);
 }

--- a/crates/freight-fate/tests/it/transcript_driving_cruise_weather_grades.rs
+++ b/crates/freight-fate/tests/it/transcript_driving_cruise_weather_grades.rs
@@ -629,3 +629,30 @@ fn test_the_status_readout_names_the_grade_cap_and_leaves_the_set_speed_alone() 
         65.0
     ));
 }
+
+#[test]
+fn test_g_announces_upcoming_grade_without_nothing_steep() {
+    for grade in [0.015, -0.015, 0.037, -0.037] {
+        let mut harness = cruising("G Upcoming Grade", 62.0, 200.0, &[(0.0, BENCH_MILES, 0.0)]);
+        hill_road(&mut harness, 1.0, grade, 0.5);
+        harness.with_drive(|d, _| d.truck_mut().grade = -0.014);
+        harness.clear_speech();
+        harness.with_drive(|d, ctx| d.speak_grade(ctx));
+        let direction = if grade > 0.0 { "upgrade" } else { "downgrade" };
+        assert!(said_any(&harness, direction), "{:?}", spoken(&harness));
+        assert!(said_any(&harness, "Grade 1.4 percent downhill"));
+        assert!(!said_any(&harness, "Nothing"), "{:?}", spoken(&harness));
+    }
+}
+
+#[test]
+fn test_g_keeps_clear_road_report_when_no_grade_is_ahead() {
+    let mut harness = cruising("G Clear Road", 62.0, 200.0, &[(0.0, BENCH_MILES, 0.0)]);
+    harness.clear_speech();
+    harness.with_drive(|d, ctx| d.speak_grade(ctx));
+    assert!(
+        said_any(&harness, "Nothing steep in the next"),
+        "{:?}",
+        spoken(&harness)
+    );
+}


### PR DESCRIPTION
## What changed and why

The G terrain readout could say "Nothing steep in the next two miles, but a 1.5 percent upgrade starts in one mile." When the preview finds an upcoming grade, announce it directly and reserve the clear-road response for when no upcoming grade is reported.

Dummy-video windows now explicitly select software rendering. Automatic renderer selection entered AMD graphics-driver code and terminated an isolated Windows headless test with 0xc0000409 / FAST_FAIL_INVALID_ARG in a restricted environment. Selecting software rendering avoids that unnecessary hardware path.

## What players or maintainers will notice

The reported example becomes: "Grade 1.4 percent downhill. Speed in hand. Next, a 1.5 percent upgrade starts in one mile."

Headless dummy-window runs avoid the reproduced graphics-driver failure. Ordinary window rendering retains its existing selection behavior.

## Tests and checks run

- Released change: formatting, locked Clippy with warnings denied, full ff-core/freight-fate tests (4,862 passed), and adversarial battery (46 clean).
- Fork release workflow: Windows, macOS Apple Silicon, Linux x64/ARM64 builds and tests, plus all Linux package smoke checks passed: https://github.com/trssharp/Freight-Fate/actions/runs/34730229250
- PR branch rebased onto current Career 1.9: formatting and focused grade/SDL regression checks.
- Regression coverage includes mild climbs/descents, short steep grades, a clear road, and dummy-window rendering.

## Accessibility impact

Removes misleading spoken reassurance before an upcoming grade. Spoken output is checked with the transcript harness; no manual listening claim is made.

## Changelog

- [x] Added player-facing bullets under `Unreleased` in `CHANGELOG.md`.
- [ ] This change is not player-facing.

This PR contains only the five fix/test/changelog files; no fork workflow changes.
